### PR TITLE
Add streaming tests, refactors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val stream = (project in file("stream"))
     ),
     commonSettings,
   )
-  .dependsOn(core)
+  .dependsOn(core % "compile->compile;test->test")
 
 lazy val integrationTests = (project in file("integration-tests"))
   .settings(

--- a/core/src/main/scala/pl/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/pl/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -8,6 +8,10 @@ import scala.reflect.ClassTag
 /**
  * "Main" trait to be implemented by RDF conversion modules (e.g., for Jena and RDF4J).
  * Exposes factory methods for building protobuf encoders and decoders.
+ *
+ * This should typically be implemented as an object. You should also provide a package-scoped implicit for your
+ * implementation so that users can easily make use of the connector in the stream package.
+ *
  * @tparam TEncoder Implementation of [[ProtoEncoder]] for a given RDF library.
  * @tparam TDecConv Implementation of [[ProtoDecoderConverter]] for a given RDF library.
  * @tparam TNode Type of RDF nodes in the RDF library

--- a/core/src/main/scala/pl/ostrzyciel/jelly/core/NameEncoder.scala
+++ b/core/src/main/scala/pl/ostrzyciel/jelly/core/NameEncoder.scala
@@ -11,9 +11,8 @@ import scala.jdk.CollectionConverters.*
  * Maintains internal lookups for prefixes, names, and datatypes. Uses the LRU strategy for eviction.
  *
  * @param opt Jelly options
- * @param rowsBuffer buffer to which the new lookup entries should be appended
  */
-private[core] final class NameEncoder(opt: RdfStreamOptions, rowsBuffer: ListBuffer[RdfStreamRow]):
+private[core] final class NameEncoder(opt: RdfStreamOptions):
   private val nameLookup = new EncoderLookup(opt.maxNameTableSize)
   private val prefixLookup = new EncoderLookup(opt.maxPrefixTableSize)
   private val dtLookup = new EncoderLookup(opt.maxDatatypeTableSize)
@@ -38,9 +37,10 @@ private[core] final class NameEncoder(opt: RdfStreamOptions, rowsBuffer: ListBuf
    * Encodes an IRI to a protobuf representation.
    * Also adds the necessary prefix and name lookup entries to the buffer.
    * @param iri IRI to be encoded
+   * @param rowsBuffer buffer to which the new lookup entries should be appended
    * @return protobuf representation of the IRI
    */
-  def encodeIri(iri: String): RdfIri =
+  def encodeIri(iri: String, rowsBuffer: ListBuffer[RdfStreamRow]): RdfIri =
     def plainIriEncode: RdfIri =
       nameLookup.addEntry(iri) match
         case EncoderValue(id, false) =>
@@ -80,9 +80,10 @@ private[core] final class NameEncoder(opt: RdfStreamOptions, rowsBuffer: ListBuf
    * Encodes a datatype IRI to a protobuf representation.
    * Also adds the necessary datatype lookup entries to the buffer.
    * @param dt datatype IRI
+   * @param rowsBuffer buffer to which the new lookup entries should be appended
    * @return datatype representation for a literal
    */
-  def encodeDatatype(dt: String): RdfLiteral.LiteralKind.Datatype =
+  def encodeDatatype(dt: String, rowsBuffer: ListBuffer[RdfStreamRow]): RdfLiteral.LiteralKind.Datatype =
     val dtVal = dtLookup.addEntry(dt)
     if dtVal.newEntry then
       dtTable.update(

--- a/core/src/main/scala/pl/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/pl/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -110,7 +110,7 @@ abstract class ProtoEncoder[TNode >: Null <: AnyRef, TTriple, TQuad, TQuoted](va
   // *** 3. THE PROTECTED INTERFACE ***
   // **********************************
   protected final inline def makeIriNode(iri: String): RdfTerm =
-    val iriEnc = iriEncoder.encodeIri(iri)
+    val iriEnc = iriEncoder.encodeIri(iri, extraRowsBuffer)
     RdfTerm(RdfTerm.Term.Iri(iriEnc))
 
   protected final inline def makeBlankNode(label: String): RdfTerm =
@@ -128,7 +128,7 @@ abstract class ProtoEncoder[TNode >: Null <: AnyRef, TTriple, TQuad, TQuoted](va
 
   protected final inline def makeDtLiteral(lex: String, dt: String): RdfTerm =
     RdfTerm(RdfTerm.Term.Literal(
-      RdfLiteral(lex, iriEncoder.encodeDatatype(dt))
+      RdfLiteral(lex, iriEncoder.encodeDatatype(dt, extraRowsBuffer))
     ))
 
   protected final inline def makeTripleNode(triple: TQuoted): RdfTerm =
@@ -137,8 +137,8 @@ abstract class ProtoEncoder[TNode >: Null <: AnyRef, TTriple, TQuad, TQuoted](va
 
   // *** 3. PRIVATE FIELDS AND METHODS ***
   // *************************************
-  private val extraRowsBuffer = new ListBuffer[RdfStreamRow]()
-  private val iriEncoder = new NameEncoder(options, extraRowsBuffer)
+  private var extraRowsBuffer = new ListBuffer[RdfStreamRow]()
+  private val iriEncoder = new NameEncoder(options)
   private var emittedCompressionOptions = false
 
   private val lastSubject: LastNodeHolder[TNode] = new LastNodeHolder()
@@ -202,7 +202,7 @@ abstract class ProtoEncoder[TNode >: Null <: AnyRef, TTriple, TQuad, TQuoted](va
     )
 
   private def handleHeader(): Unit =
-    extraRowsBuffer.clear()
+    extraRowsBuffer = new ListBuffer[RdfStreamRow]()
     if !emittedCompressionOptions then
       emittedCompressionOptions = true
       extraRowsBuffer.append(

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -2,25 +2,13 @@ package pl.ostrzyciel.jelly.core
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.helpers.MockConverterFactory
 import pl.ostrzyciel.jelly.core.helpers.Mrl.*
 import pl.ostrzyciel.jelly.core.proto.*
 
 class ProtoDecoderSpec extends AnyWordSpec, Matchers:
   import ProtoDecoderImpl.*
   import ProtoTestCases.*
-
-  // Mock implementation of ProtoDecoder
-  class MockProtoDecoderConverter extends ProtoDecoderConverter[Node, Datatype, Triple, Quad]:
-    def makeSimpleLiteral(lex: String) = SimpleLiteral(lex)
-    def makeLangLiteral(lex: String, lang: String) = LangLiteral(lex, lang)
-    def makeDtLiteral(lex: String, dt: Datatype) = DtLiteral(lex, dt)
-    def makeDatatype(dt: String) = Datatype(dt)
-    def makeBlankNode(label: String) = BlankNode(label)
-    def makeIriNode(iri: String) = Iri(iri)
-    def makeTripleNode(s: Node, p: Node, o: Node) = TripleNode(Triple(s, p, o))
-    def makeDefaultGraphNode() = null
-    def makeTriple(s: Node, p: Node, o: Node) = Triple(s, p, o)
-    def makeQuad(s: Node, p: Node, o: Node, g: Node) = Quad(s, p, o, g)
 
   // Helper method
   def assertDecoded(observed: Seq[Statement], expected: Seq[Statement]): Unit =
@@ -33,7 +21,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
   // Test body
   "a TriplesDecoder" should {
     "decode triple statements" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val decoded = Triples1
         .encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES))
         .flatMap(row => decoder.ingestRow(RdfStreamRow(row)))
@@ -41,7 +29,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "decode triple statements (norepeat)" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val decoded = Triples2NoRepeat
         .encoded(JellyOptions.smallGeneralized
           .withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES)
@@ -52,7 +40,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a quad in a TRIPLES stream" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         RdfQuad(
@@ -73,7 +61,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     // The code is the same in quads, triples, or graphs decoders, so this is fine.
     // Code coverage checks out.
     "ignore duplicate stream options" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         JellyOptions.smallGeneralized
@@ -88,7 +76,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on RdfRepeat without preceding value" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         RdfTriple(TERM_REPEAT, TERM_REPEAT, TERM_REPEAT),
@@ -101,7 +89,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on RdfRepeat in a quoted triple" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         RdfTriple(
@@ -120,7 +108,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on unset row kind" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val error = intercept[RdfProtoDeserializationError] {
         decoder.ingestRow(RdfStreamRow(RdfStreamRow.Row.Empty))
       }
@@ -128,7 +116,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on unset term kind" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         RdfTriple(
@@ -145,7 +133,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on unset literal kind" in {
-      val decoder = new TriplesDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.triplesDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
         RdfTriple(
@@ -164,7 +152,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
 
   "a QuadsDecoder" should {
     "decode quad statements" in {
-      val decoder = new QuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.quadsDecoder
       val decoded = Quads1
         .encoded(
           JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS)
@@ -174,7 +162,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "decode quad statements (norepeat)" in {
-      val decoder = new QuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.quadsDecoder
       val decoded = Quads2NoRepeat
         .encoded(
           JellyOptions.smallGeneralized
@@ -186,7 +174,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a triple in a QUADS stream" in {
-      val decoder = new QuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.quadsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
         RdfTriple(
@@ -203,7 +191,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a graph start in a QUADS stream" in {
-      val decoder = new QuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.quadsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
         RdfGraphStart(RdfGraph(RdfGraph.Graph.DefaultGraph(RdfDefaultGraph()))),
@@ -216,7 +204,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a graph end in a QUADS stream" in {
-      val decoder = new QuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.quadsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
         RdfGraphEnd(),
@@ -231,7 +219,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
 
   "a GraphsDecoder" should {
     "decode graphs" in {
-      val decoder = new GraphsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsDecoder
       val decoded = Graphs1
         .encoded(
           JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS)
@@ -251,7 +239,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a quad in a GRAPHS stream" in {
-      val decoder = new GraphsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
         RdfQuad(
@@ -269,7 +257,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a graph end before a graph start" in {
-      val decoder = new GraphsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
         RdfTriple(
@@ -289,7 +277,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
 
     // The following cases are for the [[ProtoDecoder]] base class – but tested on the child.
     "throw exception on graph term repeat in graph name" in {
-      val decoder = new GraphsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
         RdfGraphStart(RdfGraph(RdfGraph.Graph.Repeat(RdfRepeat()))),
@@ -302,7 +290,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on unset graph term type" in {
-      val decoder = new GraphsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
         RdfGraphStart(),
@@ -317,7 +305,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
 
   "a GraphsAsQuadsDecoder" should {
     "decode graphs as quads" in {
-      val decoder = new GraphsAsQuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsAsQuadsDecoder
       val decoded = Graphs1
         .encoded(
           JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS)
@@ -327,7 +315,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     }
 
     "throw exception on a triple before a graph start" in {
-      val decoder = new GraphsAsQuadsDecoder(new MockProtoDecoderConverter())
+      val decoder = MockConverterFactory.graphsAsQuadsDecoder
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
         RdfTriple(
@@ -345,10 +333,10 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
   }
 
   val streamTypeCases = Seq(
-    (new TriplesDecoder(new MockProtoDecoderConverter()), "Triples", RdfStreamType.RDF_STREAM_TYPE_QUADS),
-    (new QuadsDecoder(new MockProtoDecoderConverter()), "Quads", RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
-    (new GraphsDecoder(new MockProtoDecoderConverter()), "Graphs", RdfStreamType.RDF_STREAM_TYPE_QUADS),
-    (new GraphsAsQuadsDecoder(new MockProtoDecoderConverter()), "GraphsAsQuads", RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+    (MockConverterFactory.triplesDecoder, "Triples", RdfStreamType.RDF_STREAM_TYPE_QUADS),
+    (MockConverterFactory.quadsDecoder, "Quads", RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+    (MockConverterFactory.graphsDecoder, "Graphs", RdfStreamType.RDF_STREAM_TYPE_QUADS),
+    (MockConverterFactory.graphsAsQuadsDecoder, "GraphsAsQuads", RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
   )
 
   for (decoder, decName, streamType) <- streamTypeCases do

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -2,6 +2,7 @@ package pl.ostrzyciel.jelly.core
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.helpers.Assertions.*
 import pl.ostrzyciel.jelly.core.helpers.MockConverterFactory
 import pl.ostrzyciel.jelly.core.helpers.Mrl.*
 import pl.ostrzyciel.jelly.core.proto.*
@@ -9,14 +10,6 @@ import pl.ostrzyciel.jelly.core.proto.*
 class ProtoDecoderSpec extends AnyWordSpec, Matchers:
   import ProtoDecoderImpl.*
   import ProtoTestCases.*
-
-  // Helper method
-  def assertDecoded(observed: Seq[Statement], expected: Seq[Statement]): Unit =
-    for ix <- 0 until observed.size.max(expected.size) do
-      val obsRow = observed.applyOrElse(ix, null)
-      withClue(s"Row $ix:") {
-        obsRow should be (expected.applyOrElse(ix, null))
-      }
 
   // Test body
   "a TriplesDecoder" should {

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoEncoderSpec.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoEncoderSpec.scala
@@ -2,6 +2,8 @@ package pl.ostrzyciel.jelly.core
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.helpers.Assertions.*
+import pl.ostrzyciel.jelly.core.helpers.MockProtoEncoder
 import pl.ostrzyciel.jelly.core.helpers.Mrl.*
 import pl.ostrzyciel.jelly.core.proto.*
 
@@ -9,39 +11,6 @@ import scala.collection.immutable.{AbstractSeq, LinearSeq}
 
 class ProtoEncoderSpec extends AnyWordSpec, Matchers:
   import ProtoTestCases.*
-
-  // Mock implementation of ProtoEncoder
-  class MockProtoEncoder(override val options: RdfStreamOptions)
-    extends ProtoEncoder[Node, Triple, Quad, Triple](options):
-
-    protected inline def getTstS(triple: Triple) = triple.s
-    protected inline def getTstP(triple: Triple) = triple.p
-    protected inline def getTstO(triple: Triple) = triple.o
-
-    protected inline def getQstS(quad: Quad) = quad.s
-    protected inline def getQstP(quad: Quad) = quad.p
-    protected inline def getQstO(quad: Quad) = quad.o
-    protected inline def getQstG(quad: Quad) = quad.g
-
-    protected inline def getQuotedS(triple: Triple) = triple.s
-    protected inline def getQuotedP(triple: Triple) = triple.p
-    protected inline def getQuotedO(triple: Triple) = triple.o
-
-    protected def nodeToProto(node: Node): RdfTerm = node match
-      case Iri(iri) => makeIriNode(iri)
-      case SimpleLiteral(lex) => makeSimpleLiteral(lex)
-      case LangLiteral(lex, lang) => makeLangLiteral(lex, lang)
-      case DtLiteral(lex, dt) => makeDtLiteral(lex, dt.dt)
-      case TripleNode(t) => makeTripleNode(t)
-      case BlankNode(label) => makeBlankNode(label)
-
-  // Helper method
-  def assertEncoded(observed: Seq[RdfStreamRow], expected: Seq[RdfStreamRow.Row]): Unit =
-    for ix <- 0 until observed.size.max(expected.size) do
-      val obsRow = observed.applyOrElse(ix, null)
-      withClue(s"Row $ix:") {
-        obsRow.row should be (expected.applyOrElse(ix, null))
-      }
 
   // Test body
   "a ProtoEncoder" should {

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -27,6 +27,12 @@ object ProtoTestCases:
   trait TestCase[TStatement]:
     def mrl: Seq[TStatement]
     def encoded(opt: RdfStreamOptions): Seq[RdfStreamRow.Row]
+    def encodedFull(opt: RdfStreamOptions, groupByN: Int) =
+      encoded(opt)
+        .map(row => RdfStreamRow(row))
+        .grouped(groupByN)
+        .map(rows => RdfStreamFrame(rows))
+        .toSeq
 
   object Triples1 extends TestCase[Triple]:
     val mrl = Seq(

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/Assertions.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/Assertions.scala
@@ -2,6 +2,7 @@ package pl.ostrzyciel.jelly.core.helpers
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.helpers.Mrl.Statement
 import pl.ostrzyciel.jelly.core.proto.RdfStreamRow
 
 object Assertions extends AnyWordSpec, Matchers:
@@ -10,4 +11,11 @@ object Assertions extends AnyWordSpec, Matchers:
       val obsRow = observed.applyOrElse(ix, null)
       withClue(s"Row $ix:") {
         obsRow.row should be (expected.applyOrElse(ix, null))
+      }
+
+  def assertDecoded(observed: Seq[Statement], expected: Seq[Statement]): Unit =
+    for ix <- 0 until observed.size.max(expected.size) do
+      val obsRow = observed.applyOrElse(ix, null)
+      withClue(s"Row $ix:") {
+        obsRow should be (expected.applyOrElse(ix, null))
       }

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/Assertions.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/Assertions.scala
@@ -1,0 +1,13 @@
+package pl.ostrzyciel.jelly.core.helpers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.proto.RdfStreamRow
+
+object Assertions extends AnyWordSpec, Matchers:
+  def assertEncoded(observed: Seq[RdfStreamRow], expected: Seq[RdfStreamRow.Row]): Unit =
+    for ix <- 0 until observed.size.max(expected.size) do
+      val obsRow = observed.applyOrElse(ix, null)
+      withClue(s"Row $ix:") {
+        obsRow.row should be (expected.applyOrElse(ix, null))
+      }

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockConverterFactory.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockConverterFactory.scala
@@ -1,0 +1,12 @@
+package pl.ostrzyciel.jelly.core.helpers
+
+import pl.ostrzyciel.jelly.core.ConverterFactory
+import pl.ostrzyciel.jelly.core.helpers.Mrl.*
+import pl.ostrzyciel.jelly.core.proto.RdfStreamOptions
+
+object MockConverterFactory extends ConverterFactory
+  [MockProtoEncoder, MockProtoDecoderConverter, Node, Datatype, Triple, Quad]:
+
+  override protected def decoderConverter = new MockProtoDecoderConverter()
+
+  override def encoder(options: RdfStreamOptions) = new MockProtoEncoder(options)

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockProtoDecoderConverter.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockProtoDecoderConverter.scala
@@ -1,0 +1,19 @@
+package pl.ostrzyciel.jelly.core.helpers
+
+import pl.ostrzyciel.jelly.core.ProtoDecoderConverter
+import pl.ostrzyciel.jelly.core.helpers.Mrl.*
+
+/**
+ * Mock implementation of [[ProtoDecoder]].
+ */
+class MockProtoDecoderConverter extends ProtoDecoderConverter[Node, Datatype, Triple, Quad]:
+  def makeSimpleLiteral(lex: String) = SimpleLiteral(lex)
+  def makeLangLiteral(lex: String, lang: String) = LangLiteral(lex, lang)
+  def makeDtLiteral(lex: String, dt: Datatype) = DtLiteral(lex, dt)
+  def makeDatatype(dt: String) = Datatype(dt)
+  def makeBlankNode(label: String) = BlankNode(label)
+  def makeIriNode(iri: String) = Iri(iri)
+  def makeTripleNode(s: Node, p: Node, o: Node) = TripleNode(Triple(s, p, o))
+  def makeDefaultGraphNode() = null
+  def makeTriple(s: Node, p: Node, o: Node) = Triple(s, p, o)
+  def makeQuad(s: Node, p: Node, o: Node, g: Node) = Quad(s, p, o, g)

--- a/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
+++ b/core/src/test/scala/pl/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
@@ -1,0 +1,33 @@
+package pl.ostrzyciel.jelly.core.helpers
+
+import pl.ostrzyciel.jelly.core.ProtoEncoder
+import pl.ostrzyciel.jelly.core.helpers.Mrl.*
+import pl.ostrzyciel.jelly.core.proto.*
+
+/**
+ * Mock implementation of ProtoEncoder
+ * @param options options for this stream
+ */
+class MockProtoEncoder(override val options: RdfStreamOptions)
+  extends ProtoEncoder[Node, Triple, Quad, Triple](options):
+
+  protected inline def getTstS(triple: Triple) = triple.s
+  protected inline def getTstP(triple: Triple) = triple.p
+  protected inline def getTstO(triple: Triple) = triple.o
+
+  protected inline def getQstS(quad: Quad) = quad.s
+  protected inline def getQstP(quad: Quad) = quad.p
+  protected inline def getQstO(quad: Quad) = quad.o
+  protected inline def getQstG(quad: Quad) = quad.g
+
+  protected inline def getQuotedS(triple: Triple) = triple.s
+  protected inline def getQuotedP(triple: Triple) = triple.p
+  protected inline def getQuotedO(triple: Triple) = triple.o
+
+  protected def nodeToProto(node: Node): RdfTerm = node match
+    case Iri(iri) => makeIriNode(iri)
+    case SimpleLiteral(lex) => makeSimpleLiteral(lex)
+    case LangLiteral(lex, lang) => makeLangLiteral(lex, lang)
+    case DtLiteral(lex, dt) => makeDtLiteral(lex, dt.dt)
+    case TripleNode(t) => makeTripleNode(t)
+    case BlankNode(label) => makeBlankNode(label)

--- a/jena/src/main/scala/pl/ostrzyciel/jelly/convert/jena/package.scala
+++ b/jena/src/main/scala/pl/ostrzyciel/jelly/convert/jena/package.scala
@@ -1,0 +1,4 @@
+package pl.ostrzyciel.jelly.convert
+
+package object jena:
+  implicit val jenaConverterFactory: JenaConverterFactory.type = JenaConverterFactory

--- a/rdf4j/src/main/scala/pl/ostrzyciel/jelly/convert/rdf4j/package.scala
+++ b/rdf4j/src/main/scala/pl/ostrzyciel/jelly/convert/rdf4j/package.scala
@@ -1,0 +1,4 @@
+package pl.ostrzyciel.jelly.convert
+
+package object rdf4j:
+  implicit val rdf4jConverterFactory: Rdf4jConverterFactory.type = Rdf4jConverterFactory

--- a/stream/src/test/scala/pl/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
+++ b/stream/src/test/scala/pl/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
@@ -1,5 +1,155 @@
 package pl.ostrzyciel.jelly.stream
 
-class DecoderFlowSpec {
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
+import pl.ostrzyciel.jelly.core.helpers.Assertions.*
+import pl.ostrzyciel.jelly.core.helpers.MockConverterFactory
+import pl.ostrzyciel.jelly.core.proto.*
 
-}
+import scala.collection.mutable.ArrayBuffer
+
+class DecoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  import pl.ostrzyciel.jelly.core.helpers.Mrl.*
+  import ProtoTestCases.*
+  implicit val converterFactory: MockConverterFactory.type = MockConverterFactory
+  implicit val actorSystem: ActorSystem = ActorSystem()
+
+  "triplesToFlat" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode triples, frame size: $n" in {
+        val encoded = Triples1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+          n,
+        )
+        val decoded: Seq[Triple] = Source(encoded)
+          .via(DecoderFlow.triplesToFlat)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded, Triples1.mrl)
+      }
+
+    "decode triples (norepeat)" in {
+      val encoded = Triples2NoRepeat.encodedFull(
+        JellyOptions.smallGeneralized
+          .withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES)
+          .withUseRepeat(false),
+        100,
+      )
+      val decoded: Seq[Triple] = Source(encoded)
+        .via(DecoderFlow.triplesToFlat)
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertDecoded(decoded, Triples2NoRepeat.mrl)
+    }
+  }
+
+  "triplesToGrouped" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode triples as groups, frame size: $n" in {
+        val encoded = Triples1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+          n,
+        )
+        val decoded: Seq[Seq[Triple]] = Source(encoded)
+          .via(DecoderFlow.triplesToGrouped)
+          .map(_.iterator.toSeq)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded.flatten, Triples1.mrl)
+        decoded.size should be (encoded.size)
+      }
+  }
+
+  "quadsToFlat" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode quads, frame size: $n" in {
+        val encoded = Quads1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
+          n,
+        )
+        val decoded: Seq[Quad] = Source(encoded)
+          .via(DecoderFlow.quadsToFlat)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded, Quads1.mrl)
+      }
+  }
+
+  "quadsToGrouped" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode quads as groups, frame size: $n" in {
+        val encoded = Quads1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
+          n,
+        )
+        val decoded: Seq[Seq[Quad]] = Source(encoded)
+          .via(DecoderFlow.quadsToGrouped)
+          .map(_.iterator.toSeq)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded.flatten, Quads1.mrl)
+        decoded.size should be (encoded.size)
+      }
+  }
+
+  "graphsAsQuadsToFlat" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode graphs as quads, frame size: $n" in {
+        val encoded = Graphs1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
+          n,
+        )
+        val decoded: Seq[Quad] = Source(encoded)
+          .via(DecoderFlow.graphsAsQuadsToFlat)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded, Graphs1.mrlQuads)
+      }
+  }
+
+  "graphsAsQuadsToGrouped" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode graphs as quads (grouped), frame size: $n" in {
+        val encoded = Graphs1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
+          n,
+        )
+        val decoded: Seq[Seq[Quad]] = Source(encoded)
+          .via(DecoderFlow.graphsAsQuadsToGrouped)
+          .map(_.iterator.toSeq)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded.flatten, Graphs1.mrlQuads)
+        decoded.size should be (encoded.size)
+      }
+  }
+
+  "graphsToFlat" should {
+    for n <- Seq(1, 2, 100) do
+      s"decode graphs, frame size: $n" in {
+        val encoded = Graphs1.encodedFull(
+          JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
+          n,
+        )
+        val decoded: Seq[(Node, Iterable[Triple])] = Source(encoded)
+          .via(DecoderFlow.graphsToFlat)
+          .toMat(Sink.seq)(Keep.right)
+          .run().futureValue
+
+        assertDecoded(decoded.flatMap(_._2), Graphs1.mrl.flatMap(_._2))
+        decoded.size should be (2) // 2 graphs in the input
+        decoded.head._2.size should be (2)
+        decoded(1)._2.size should be (1)
+      }
+  }

--- a/stream/src/test/scala/pl/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
+++ b/stream/src/test/scala/pl/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
@@ -1,0 +1,5 @@
+package pl.ostrzyciel.jelly.stream
+
+class DecoderFlowSpec {
+
+}

--- a/stream/src/test/scala/pl/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
+++ b/stream/src/test/scala/pl/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import pl.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
 import pl.ostrzyciel.jelly.core.helpers.Assertions.*
 import pl.ostrzyciel.jelly.core.helpers.MockConverterFactory
-import pl.ostrzyciel.jelly.core.proto.{RdfStreamFrame, RdfStreamOptions, RdfStreamType}
+import pl.ostrzyciel.jelly.core.proto.*
 
 class EncoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
   import ProtoTestCases.*

--- a/stream/src/test/scala/pl/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
+++ b/stream/src/test/scala/pl/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
@@ -1,0 +1,124 @@
+package pl.ostrzyciel.jelly.stream
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import pl.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
+import pl.ostrzyciel.jelly.core.helpers.Assertions.*
+import pl.ostrzyciel.jelly.core.helpers.MockConverterFactory
+import pl.ostrzyciel.jelly.core.proto.{RdfStreamFrame, RdfStreamOptions, RdfStreamType}
+
+class EncoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  import ProtoTestCases.*
+  implicit val converterFactory: MockConverterFactory.type = MockConverterFactory
+  implicit val actorSystem: ActorSystem = ActorSystem()
+
+  "fromFlatTriples" should {
+    "encode triples" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Triples1.mrl)
+        .via(EncoderFlow.fromFlatTriples(EncoderFlow.Options(), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Triples1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES))
+      )
+      encoded.size should be (1)
+    }
+
+    "encode triples with max message size" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Triples1.mrl)
+        .via(EncoderFlow.fromFlatTriples(EncoderFlow.Options(80), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Triples1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES))
+      )
+      encoded.size should be (3)
+    }
+
+    "encode triples (norepeat)" in {
+      val jOptions = JellyOptions.smallGeneralized.withUseRepeat(false)
+      val encoded: Seq[RdfStreamFrame] = Source(Triples2NoRepeat.mrl)
+        .via(EncoderFlow.fromFlatTriples(EncoderFlow.Options(), jOptions))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Triples2NoRepeat.encoded(jOptions.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES))
+      )
+      encoded.size should be (1)
+    }
+  }
+
+  "fromGroupedTriples" should {
+    "encode grouped triples" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Triples1.mrl)
+        .grouped(2)
+        .via(EncoderFlow.fromGroupedTriples(EncoderFlow.Options(), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Triples1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES))
+      )
+      encoded.size should be (2)
+      encoded.head.rows.count(_.row.isTriple) should be (2)
+      encoded(1).rows.count(_.row.isTriple) should be (2)
+    }
+  }
+
+  "fromFlatQuads" should {
+    "encode quads" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Quads1.mrl)
+        .via(EncoderFlow.fromFlatQuads(EncoderFlow.Options(), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Quads1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS))
+      )
+      encoded.size should be (1)
+    }
+  }
+
+  "fromGroupedQuads" should {
+    "encode grouped quads" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Quads1.mrl)
+        .grouped(2)
+        .via(EncoderFlow.fromGroupedQuads(EncoderFlow.Options(), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Quads1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS))
+      )
+      encoded.size should be (2)
+      encoded.head.rows.count(_.row.isQuad) should be (2)
+      encoded(1).rows.count(_.row.isQuad) should be (2)
+    }
+  }
+
+  "fromGraphs" should {
+    "encode graphs" in {
+      val encoded: Seq[RdfStreamFrame] = Source(Graphs1.mrl)
+        .via(EncoderFlow.fromGraphs(EncoderFlow.Options(), JellyOptions.smallGeneralized))
+        .toMat(Sink.seq)(Keep.right)
+        .run().futureValue
+
+      assertEncoded(
+        encoded.flatMap(_.rows),
+        Graphs1.encoded(JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS))
+      )
+      encoded.size should be (2)
+    }
+  }


### PR DESCRIPTION
Added tests for EncoderFlow and DecoderFlow. Spotted some bugs and messy code on the way – so that's fixed as well in this PR.

Test coverage for the `stream` module is pretty much 100%.