### PR TITLE
Change Akka to Pekko; bump Scala to 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "3.2.1"
+ThisBuild / scalaVersion := "3.3.0"
 ThisBuild / organization := "eu.ostrzyciel.jelly"
 ThisBuild / homepage := Some(url("https://github.com/Jelly-RDF/jelly-jvm"))
 ThisBuild / licenses := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
@@ -17,8 +17,7 @@ ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeProfileName := "eu.ostrzyciel"
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
-// !!! 2.6.x is the last release with the Apache license. Do not upgrade to Akka 2.7.x
-lazy val akkaV = "2.6.20"
+lazy val pekkoV = "1.0.1"
 lazy val jenaV = "4.6.1"
 lazy val rdf4jV = "4.2.2"
 lazy val scalapbV = "0.11.12"
@@ -75,28 +74,25 @@ lazy val stream = (project in file("stream"))
   .settings(
     name := "jelly-stream",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor-typed" % akkaV,
-      "com.typesafe.akka" %% "akka-stream-typed" % akkaV,
-    ).map(_.cross(CrossVersion.for3Use2_13)),
+      "org.apache.pekko" %% "pekko-actor-typed" % pekkoV,
+      "org.apache.pekko" %% "pekko-stream-typed" % pekkoV,
+    ),
     commonSettings,
   )
   .dependsOn(core % "compile->compile;test->test")
 
 lazy val grpc = (project in file("grpc"))
-  .enablePlugins(AkkaGrpcPlugin)
+  .enablePlugins(PekkoGrpcPlugin)
   .settings(
     name := "jelly-grpc",
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+      "org.apache.pekko" %% "pekko-actor-typed" % pekkoV,
+      "org.apache.pekko" %% "pekko-discovery" % pekkoV,
+      "org.apache.pekko" %% "pekko-stream-typed" % pekkoV,
+      "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoV % Test,
+      "org.apache.pekko" %% "pekko-grpc-runtime" % "1.0.0",
     ),
-    libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor-typed" % akkaV,
-      "com.typesafe.akka" %% "akka-discovery" % akkaV,
-      "com.typesafe.akka" %% "akka-stream-typed" % akkaV,
-      "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaV % Test,
-      // 2.1.x is the last release with the Apache license
-      "com.lightbend.akka.grpc" %% "akka-grpc-runtime" % "2.1.6",
-    ).map(_.cross(CrossVersion.for3Use2_13)),
     // Add the shared proto sources
     Compile / PB.protoSources ++= Seq(
       (core / baseDirectory).value / "src" / "main" / "protobuf_shared",

--- a/build.sbt
+++ b/build.sbt
@@ -19,12 +19,12 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 lazy val pekkoV = "1.0.1"
 lazy val jenaV = "4.6.1"
-lazy val rdf4jV = "4.2.2"
-lazy val scalapbV = "0.11.12"
+lazy val rdf4jV = "4.3.0"
+lazy val scalapbV = "0.11.13"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.2.14" % Test,
+    "org.scalatest" %% "scalatest" % "3.2.15" % Test,
   ),
   excludeDependencies ++= Seq(
     "com.thesamet.scalapb" % "scalapb-runtime_2.13",

--- a/grpc/src/main/scala/eu/ostrzyciel/jelly/grpc/RdfStreamServer.scala
+++ b/grpc/src/main/scala/eu/ostrzyciel/jelly/grpc/RdfStreamServer.scala
@@ -1,10 +1,10 @@
 package eu.ostrzyciel.jelly.grpc
 
-import akka.Done
-import akka.actor.typed.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import org.apache.pekko.Done
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.Http.ServerBinding
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.LazyLogging
 import eu.ostrzyciel.jelly.core.proto.v1.*

--- a/grpc/src/test/scala/eu/ostrzyciel/jelly/grpc/GrpcSpec.scala
+++ b/grpc/src/test/scala/eu/ostrzyciel/jelly/grpc/GrpcSpec.scala
@@ -1,11 +1,11 @@
 package eu.ostrzyciel.jelly.grpc
 
-import akka.NotUsed
-import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.Behaviors
-import akka.grpc.GrpcClientSettings
-import akka.stream.scaladsl.*
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.grpc.GrpcClientSettings
+import org.apache.pekko.stream.scaladsl.*
 import com.typesafe.config.ConfigFactory
 import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
 import eu.ostrzyciel.jelly.core.proto.v1.*

--- a/grpc/src/test/scala/eu/ostrzyciel/jelly/grpc/GrpcSpec.scala
+++ b/grpc/src/test/scala/eu/ostrzyciel/jelly/grpc/GrpcSpec.scala
@@ -24,18 +24,18 @@ class GrpcSpec extends AnyWordSpec, Matchers, ScalaFutures, BeforeAndAfterAll:
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 50.millis)
   val conf = ConfigFactory.parseString(
     """
-      |akka.http.server.preview.enable-http2 = on
-      |akka.grpc.client.jelly-no-gzip.host = 127.0.0.1
-      |akka.grpc.client.jelly-no-gzip.port = 8080
-      |akka.grpc.client.jelly-no-gzip.enable-gzip = false
-      |akka.grpc.client.jelly-no-gzip.use-tls = false
-      |akka.grpc.client.jelly-no-gzip.backend = netty
+      |pekko.http.server.preview.enable-http2 = on
+      |pekko.grpc.client.jelly-no-gzip.host = 127.0.0.1
+      |pekko.grpc.client.jelly-no-gzip.port = 8080
+      |pekko.grpc.client.jelly-no-gzip.enable-gzip = false
+      |pekko.grpc.client.jelly-no-gzip.use-tls = false
+      |pekko.grpc.client.jelly-no-gzip.backend = netty
       |
-      |akka.grpc.client.jelly-gzip.host = 127.0.0.1
-      |akka.grpc.client.jelly-gzip.port = 8081
-      |akka.grpc.client.jelly-gzip.enable-gzip = true
-      |akka.grpc.client.jelly-gzip.use-tls = false
-      |akka.grpc.client.jelly-gzip.backend = netty
+      |pekko.grpc.client.jelly-gzip.host = 127.0.0.1
+      |pekko.grpc.client.jelly-gzip.port = 8081
+      |pekko.grpc.client.jelly-gzip.enable-gzip = true
+      |pekko.grpc.client.jelly-gzip.use-tls = false
+      |pekko.grpc.client.jelly-gzip.backend = netty
       |""".stripMargin)
     .withFallback(ConfigFactory.defaultApplication())
 
@@ -92,7 +92,7 @@ class GrpcSpec extends AnyWordSpec, Matchers, ScalaFutures, BeforeAndAfterAll:
   ).map((name, confKey) => {
     val service = new TestService(data)
     val bound = new RdfStreamServer(
-      RdfStreamServer.Options.fromConfig(conf.getConfig(s"akka.grpc.client.$confKey")),
+      RdfStreamServer.Options.fromConfig(conf.getConfig(s"pekko.grpc.client.$confKey")),
       service
     )(serverSystem).run().futureValue
     (name, confKey, service, bound)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
@@ -1,8 +1,8 @@
 package eu.ostrzyciel.jelly.integration_tests
 
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.*
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
 import eu.ostrzyciel.jelly.core.*
 import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
 import eu.ostrzyciel.jelly.stream.*

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/JenaTestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/JenaTestStream.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.integration_tests
 
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.apache.pekko.{Done, NotUsed}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
 import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
 import eu.ostrzyciel.jelly.stream.{DecoderFlow, EncoderFlow}
 import org.apache.jena.graph.{Graph, Node, Triple}

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/Rdf4jTestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/Rdf4jTestStream.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.integration_tests
 
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.*
+import org.apache.pekko.{Done, NotUsed}
+import org.apache.pekko.stream.scaladsl.*
 import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
 import eu.ostrzyciel.jelly.stream.{DecoderFlow, EncoderFlow}
 import org.eclipse.rdf4j.model.Model

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/TestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/TestStream.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.integration_tests
 
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.*
+import org.apache.pekko.{Done, NotUsed}
+import org.apache.pekko.stream.scaladsl.*
 import eu.ostrzyciel.jelly.stream.EncoderFlow
 import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.1.6")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addDependencyTreePlugin
 

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
-import akka.NotUsed
-import akka.stream.scaladsl.Flow
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Flow
 import eu.ostrzyciel.jelly.core.{ConverterFactory, ProtoDecoder}
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
 

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/EncoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/EncoderFlow.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
-import akka.NotUsed
-import akka.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
 import com.typesafe.config.Config
 import eu.ostrzyciel.jelly.core.ConverterFactory
 import eu.ostrzyciel.jelly.core.proto.v1.*

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/DecoderFlowSpec.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.*
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
 import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
 import eu.ostrzyciel.jelly.core.helpers.Assertions.*
 import eu.ostrzyciel.jelly.core.helpers.MockConverterFactory

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.*
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
 import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
 import eu.ostrzyciel.jelly.core.helpers.Assertions.*
 import eu.ostrzyciel.jelly.core.helpers.MockConverterFactory


### PR DESCRIPTION
Pekko has a 1.0.0 release now, so we can safely use it. Akka's OSS version will not really be updated, so that's the way to go. Pekko for Scala 3 requires (I think) Scala 3.3.0, so I've updated it as well.

aand some minor bumps to other dependencies (patches only)

Everything seems to work fine.