### PR TITLE
Add IO convenience functions for Jelly/Pekko streams

### DIFF
--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
@@ -1,7 +1,8 @@
-package eu.ostrzyciel.jelly.integration_tests.native_io
+package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.core.JellyOptions
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -9,9 +10,10 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, FileInputStream}
 
 /**
- * Tests for library-native ser/des (Jena RIOT and RDF4J Rio).
+ * Tests for IO ser/des (Jena RIOT, RDF4J Rio, and semi-reactive IO over Pekko Streams).
  */
-class NativeSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures:
+class IoSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  implicit val as: ActorSystem = ActorSystem("test")
 
   val casesTriples: Seq[(String, File)] = Seq[String](
     "weather.nt", "p2_ontology.nt", "nt-syntax-subm-01.nt", "rdf-star.nt", "rdf-star-blanks.nt"
@@ -37,6 +39,12 @@ class NativeSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures:
   runTest(JenaSerDes, Rdf4jSerDes)
   runTest(Rdf4jSerDes, JenaSerDes)
   runTest(Rdf4jSerDes, Rdf4jSerDes)
+
+  runTest(ReactiveSerDes(), ReactiveSerDes())
+  runTest(ReactiveSerDes(), JenaSerDes)
+  runTest(ReactiveSerDes(), Rdf4jSerDes)
+  runTest(JenaSerDes, ReactiveSerDes())
+  runTest(Rdf4jSerDes, ReactiveSerDes())
 
   private def runTest[TMSer : Measure, TDSer : Measure, TMDes : Measure, TDDes : Measure](
     ser: NativeSerDes[TMSer, TDSer],

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
@@ -1,4 +1,4 @@
-package eu.ostrzyciel.jelly.integration_tests.native_io
+package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.jena.riot.{JellyFormatVariant, JellyLanguage}
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
@@ -1,4 +1,4 @@
-package eu.ostrzyciel.jelly.integration_tests.native_io
+package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
 

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
@@ -1,4 +1,4 @@
-package eu.ostrzyciel.jelly.integration_tests.native_io
+package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.rdf4j.rio
 import eu.ostrzyciel.jelly.convert.rdf4j.rio.JellyWriterSettings
@@ -10,7 +10,7 @@ import org.eclipse.rdf4j.rio.{RDFFormat, Rio}
 import java.io.{InputStream, OutputStream}
 import scala.jdk.CollectionConverters.*
 
-implicit val rdf4jMeasure: Measure[Seq[Statement]] = (seq: Seq[Statement]) => seq.size
+implicit def seqMeasure[T]: Measure[Seq[T]] = (seq: Seq[T]) => seq.size
 
 object Rdf4jSerDes extends NativeSerDes[Seq[Statement], Seq[Statement]]:
   val name = "RDF4J"

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/ReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/ReactiveSerDes.scala
@@ -1,0 +1,43 @@
+package eu.ostrzyciel.jelly.integration_tests.io
+
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.stream.{DecoderFlow, EncoderFlow, JellyIo}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.*
+import org.eclipse.rdf4j.model.Statement
+
+import java.io.{InputStream, OutputStream}
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+
+class ReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Seq[Statement], Seq[Statement]]:
+  implicit val rdf4jConverter: Rdf4jConverterFactory.type = Rdf4jConverterFactory
+
+  override def name: String = "Reactive (RDF4J)"
+
+  override def readTriplesW3C(is: InputStream): Seq[Statement] = Rdf4jSerDes.readTriplesW3C(is)
+
+  override def readQuadsW3C(is: InputStream): Seq[Statement] = Rdf4jSerDes.readQuadsW3C(is)
+
+  private def read(is: InputStream): Seq[Statement] =
+    val f = JellyIo.fromIoStream(is)
+      .via(DecoderFlow.anyToFlat)
+      .runWith(Sink.seq)
+    Await.result(f, 10.seconds)
+
+  override def readTriplesJelly(is: InputStream): Seq[Statement] = read(is)
+
+  override def readQuadsJelly(is: InputStream): Seq[Statement] = read(is)
+
+  override def writeTriplesJelly(os: OutputStream, model: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
+    val f = Source.fromIterator(() => model.iterator)
+      .via(EncoderFlow.fromFlatTriples(EncoderFlow.Options(frameSize * 10), opt))
+      .runWith(JellyIo.toIoStream(os))
+    Await.ready(f, 10.seconds)
+
+  override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
+    val f = Source.fromIterator(() => dataset.iterator)
+      .via(EncoderFlow.fromFlatQuads(EncoderFlow.Options(frameSize * 10), opt))
+      .runWith(JellyIo.toIoStream(os))
+    Await.ready(f, 10.seconds)

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/JellyIo.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/JellyIo.scala
@@ -1,0 +1,53 @@
+package eu.ostrzyciel.jelly.stream
+
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
+import org.apache.pekko.{Done, NotUsed}
+import org.apache.pekko.stream.scaladsl.*
+
+import java.io.OutputStream
+import scala.concurrent.Future
+
+/**
+ * Convenience methods for working with Jelly over IO streams.
+ */
+object JellyIo:
+  /**
+   * Convert a stream of Jelly frames into a stream of NON-DELIMITED bytes.
+   *
+   * If you use this method, you must ensure that the stream is delimited somewhere else.
+   * @return Pekko Flow
+   */
+  def toBytes: Flow[RdfStreamFrame, Array[Byte], NotUsed] =
+    Flow[RdfStreamFrame].map(_.toByteArray)
+
+  /**
+   * Convert a stream of NON-DELIMITED bytes into a stream of Jelly frames.
+   *
+   * If you use this method, you must ensure that the stream is delimited somewhere else.
+   * @return Pekko Flow
+   */
+  def fromBytes: Flow[Array[Byte], RdfStreamFrame, NotUsed] =
+    Flow[Array[Byte]].map(RdfStreamFrame.parseFrom)
+
+  /**
+   * Write a stream of Jelly frames to an output stream. The frames will be delimited.
+   *
+   * You can safely use this method to write to a file or socket.
+   * @param os Java IO output stream
+   * @return Pekko Sink
+   */
+  def toIoStream(os: OutputStream): Sink[RdfStreamFrame, Future[Done]] =
+    Sink.foreach((f: RdfStreamFrame) => f.writeDelimitedTo(os))
+
+  /**
+   * Read a stream of Jelly frames from an input stream. The frames are assumed be delimited.
+   *
+   * You can safely use this method to read from a file or socket.
+   * @param is Java IO input stream
+   * @return Pekko Source
+   */
+  def fromIoStream(is: java.io.InputStream): Source[RdfStreamFrame, NotUsed] =
+    Source.fromIterator(() =>
+        Iterator.continually(RdfStreamFrame.parseDelimitedFrom(is))
+          .takeWhile(_.isDefined)
+      ).mapConcat(identity)

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/JellyIoSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/JellyIoSpec.scala
@@ -1,0 +1,71 @@
+package eu.ostrzyciel.jelly.stream
+
+import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamType
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+class JellyIoSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import ProtoTestCases.*
+
+  val cases = Seq(
+    ("triples, frame size 1", Triples1.encodedFull(
+      JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+      1,
+    )),
+    ("triples, frame size 20", Triples1.encodedFull(
+      JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+      20,
+    )),
+    ("triples (norepeat), frame size 5", Triples2NoRepeat.encodedFull(
+      JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_TRIPLES),
+      5
+    )),
+    ("quads, frame size 6", Quads1.encodedFull(
+      JellyOptions.smallGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_QUADS),
+      6,
+    )),
+    ("graphs, frame size 3", Graphs1.encodedFull(
+      JellyOptions.bigGeneralized.withStreamType(RdfStreamType.RDF_STREAM_TYPE_GRAPHS),
+      3,
+    ))
+  )
+
+  "toBytes and fromBytes" should {
+    for (name, testCase) <- cases do
+      s"work for $name" in {
+        val decoded = Source.fromIterator(() => testCase.iterator)
+          .via(JellyIo.toBytes)
+          .via(JellyIo.fromBytes)
+          .runWith(Sink.seq)
+          .futureValue
+
+        decoded shouldEqual testCase
+      }
+  }
+
+  "toIoStream and fromIoStream" should {
+    for (name, testCase) <- cases do
+      s"work for $name" in {
+        val os = ByteArrayOutputStream()
+        Source.fromIterator(() => testCase.iterator)
+          .runWith(JellyIo.toIoStream(os))
+          .futureValue
+
+        val bytes = os.toByteArray
+        bytes.length should be > 0
+
+        val is = ByteArrayInputStream(bytes)
+        val decoded = JellyIo.fromIoStream(is)
+          .runWith(Sink.seq)
+          .futureValue
+
+        decoded shouldEqual testCase
+      }
+  }


### PR DESCRIPTION
plus tests, both in the stream module and in the integration tests (cross-checking with Jena RIOT and RDF4J Rio)