### PR TITLE
Add iterable helpers + refactors

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -20,8 +20,8 @@ import scala.reflect.ClassTag
  * @tparam TQuad Type of quad statements in the RDF library.
  */
 trait ConverterFactory[
-  TEncoder <: ProtoEncoder[TNode, TTriple, TQuad, ?],
-  TDecConv <: ProtoDecoderConverter[TNode, TDatatype, TTriple, TQuad],
+  +TEncoder <: ProtoEncoder[TNode, TTriple, TQuad, ?],
+  +TDecConv <: ProtoDecoderConverter[TNode, TDatatype, TTriple, TQuad],
   TNode, TDatatype : ClassTag, TTriple, TQuad
 ]:
   protected def decoderConverter: TDecConv

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/IterableAdapter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/IterableAdapter.scala
@@ -1,0 +1,55 @@
+package eu.ostrzyciel.jelly.core
+
+import scala.collection.immutable
+
+object IterableAdapter:
+  /**
+   * Helper class for creating an "immutable" iterable from an iterator closure.
+   *
+   * Note that if the iterator closure refers to a mutable state that changes,
+   * the resulting iterable's behavior is undefined.
+   *
+   * @param it iterator closure
+   * @tparam T type of elements
+   */
+  final class IterableFromIterator[T](val it: () => Iterator[T]) extends immutable.Iterable[T]:
+    override def iterator: Iterator[T] = it()
+
+/**
+ * Generic trait for making converters from graph- and dataset-like structures to
+ * [[scala.collection.immutable.Iterable]] of triples and quads.
+ *
+ * These converters can be used to feed the streaming encoders in the stream module.
+ *
+ * Warning: the converters assume that the underlying structures are static!
+ * If they change during iteration, the results are undefined.
+ * 
+ * @tparam TNode node type
+ * @tparam TTriple triple type
+ * @tparam TQuad quad type
+ * @tparam TGraph graph type
+ * @tparam TDataset dataset type
+ */
+trait IterableAdapter[+TNode, +TTriple, +TQuad, -TGraph, -TDataset]:
+  extension (graph: TGraph)
+
+    /**
+     * Converts the graph to an iterable of triples.
+     * @return iterable of triples
+     */
+    def asTriples: immutable.Iterable[TTriple]
+
+  extension (dataset: TDataset)
+
+    /**
+     * Converts the dataset to an iterable of quads.
+     * @return iterable of quads
+     */
+    def asQuads: immutable.Iterable[TQuad]
+
+    /**
+     * Converts the dataset to an iterable of (node, Iterable[Triple]) pairs.
+     * This is useful for GRAPHS Jelly streams.
+     * @return iterable of (node, Iterable[Triple]) pairs
+     */
+    def asGraphs: immutable.Iterable[(TNode, immutable.Iterable[TTriple])]

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -9,7 +9,7 @@ import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, RdfStreamRow}
  * 
  * @tparam TOut Type of the output of the decoder.
  */
-trait ProtoDecoder[TOut]:
+trait ProtoDecoder[+TOut]:
   def getStreamOpt: Option[RdfStreamOptions]
   
   def ingestRow(row: RdfStreamRow): Option[TOut]

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderConverter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderConverter.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
  * @tparam TTriple type of triple statements (not quoted triples) in the library
  * @tparam TQuad type of quad statements in the library
  */
-trait ProtoDecoderConverter[TNode, TDatatype : ClassTag, TTriple, TQuad]:
+trait ProtoDecoderConverter[TNode, TDatatype : ClassTag, +TTriple, +TQuad]:
   def makeSimpleLiteral(lex: String): TNode
   def makeLangLiteral(lex: String, lang: String): TNode
   def makeDtLiteral(lex: String, dt: TDatatype): TNode

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
  *
  * See the base (extendable) trait: [[ProtoDecoder]].
  */
-sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, TTriple, TQuad, TOut]
+sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +TQuad, +TOut]
 (converter: ProtoDecoderConverter[TNode, TDatatype, TTriple, TQuad])
   extends ProtoDecoder[TOut]:
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -19,7 +19,7 @@ object ProtoEncoder:
  * Take care to ensure the correctness of the transmitted data, or use the specialized wrappers from the stream package.
  * @param options options for this stream
  */
-abstract class ProtoEncoder[TNode, TTriple, TQuad, TQuoted](val options: RdfStreamOptions):
+abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfStreamOptions):
   import ProtoEncoder.*
 
   // *** 1. THE PUBLIC INTERFACE ***

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
@@ -41,11 +41,16 @@ class IoSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures:
   runTest(Rdf4jSerDes, JenaSerDes)
   runTest(Rdf4jSerDes, Rdf4jSerDes)
 
-  runTest(ReactiveSerDes(), ReactiveSerDes())
-  runTest(ReactiveSerDes(), JenaSerDes)
-  runTest(ReactiveSerDes(), Rdf4jSerDes)
-  runTest(JenaSerDes, ReactiveSerDes())
-  runTest(Rdf4jSerDes, ReactiveSerDes())
+  runTest(Rdf4jReactiveSerDes(), Rdf4jReactiveSerDes())
+  runTest(Rdf4jReactiveSerDes(), JenaSerDes)
+  runTest(Rdf4jReactiveSerDes(), Rdf4jSerDes)
+  runTest(JenaSerDes, Rdf4jReactiveSerDes())
+  runTest(Rdf4jSerDes, Rdf4jReactiveSerDes())
+
+  // the Jena reactive implementation only has a serializer
+  runTest(JenaReactiveSerDes(), Rdf4jReactiveSerDes())
+  runTest(JenaReactiveSerDes(), Rdf4jSerDes)
+  runTest(JenaReactiveSerDes(), JenaSerDes)
 
   private def runTest[TMSer : Measure, TDSer : Measure, TMDes : Measure, TDDes : Measure](
     ser: NativeSerDes[TMSer, TDSer],

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaReactiveSerDes.scala
@@ -1,0 +1,36 @@
+package eu.ostrzyciel.jelly.integration_tests.io
+
+import eu.ostrzyciel.jelly.convert.jena.*
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.stream.{EncoderFlow, EncoderSource, JellyIo}
+import org.apache.jena.query.Dataset
+import org.apache.jena.rdf.model.Model
+import org.apache.pekko.stream.Materializer
+
+import java.io.{InputStream, OutputStream}
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+
+class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model, Dataset]:
+
+  val name = "Reactive writes (Apache Jena)"
+
+  override def readTriplesW3C(is: InputStream) = JenaSerDes.readTriplesW3C(is)
+
+  def readQuadsW3C(is: InputStream): Dataset = JenaSerDes.readQuadsW3C(is)
+
+  def readQuadsJelly(is: InputStream): Dataset = JenaSerDes.readQuadsJelly(is)
+
+  def readTriplesJelly(is: InputStream): Model = JenaSerDes.readTriplesJelly(is)
+
+  def writeQuadsJelly
+  (os: OutputStream, dataset: Dataset, opt: RdfStreamOptions, frameSize: Int): Unit =
+    val f = EncoderSource.fromDatasetAsQuads(dataset, EncoderFlow.Options(), opt)(jenaIterableAdapter, jenaConverterFactory)
+      .runWith(JellyIo.toIoStream(os))
+    Await.ready(f, 10.seconds)
+
+  def writeTriplesJelly
+  (os: OutputStream, model: Model, opt: RdfStreamOptions, frameSize: Int): Unit =
+    val f = EncoderSource.fromGraph(model, EncoderFlow.Options(), opt)(jenaIterableAdapter, jenaConverterFactory)
+      .runWith(JellyIo.toIoStream(os))
+    Await.ready(f, 10.seconds)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
@@ -11,7 +11,7 @@ import java.io.{InputStream, OutputStream}
 import scala.concurrent.Await
 import scala.concurrent.duration.*
 
-class ReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Seq[Statement], Seq[Statement]]:
+class Rdf4jReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Seq[Statement], Seq[Statement]]:
   implicit val rdf4jConverter: Rdf4jConverterFactory.type = Rdf4jConverterFactory
 
   override def name: String = "Reactive (RDF4J)"

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaIterableAdapter.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaIterableAdapter.scala
@@ -1,0 +1,42 @@
+package eu.ostrzyciel.jelly.convert.jena
+
+import eu.ostrzyciel.jelly.core.IterableAdapter
+import eu.ostrzyciel.jelly.core.IterableAdapter.IterableFromIterator
+import org.apache.jena.graph.{Graph, Node, Triple}
+import org.apache.jena.query.Dataset
+import org.apache.jena.rdf.model.Model
+import org.apache.jena.sparql.core.{DatasetGraph, Quad}
+
+import scala.collection.immutable
+import scala.jdk.CollectionConverters.*
+
+object JenaIterableAdapter extends IterableAdapter[Node, Triple, Quad, Graph | Model, DatasetGraph | Dataset]:
+
+  private inline def graphAsTriples(graph: Graph): immutable.Iterable[Triple] =
+    IterableFromIterator[Triple](() => graph.find().asScala)
+
+  extension (graph: Graph | Model)
+    def asTriples: immutable.Iterable[Triple] = graph match
+      case g: Graph => graphAsTriples(g)
+      case m: Model => graphAsTriples(m.getGraph)
+
+  private inline def datasetAsQuads(dataset: DatasetGraph): immutable.Iterable[Quad] =
+    IterableFromIterator[Quad](() => dataset.find().asScala)
+
+  private inline def datasetAsGraphs(dataset: DatasetGraph): immutable.Iterable[(Node, immutable.Iterable[Triple])] =
+    IterableFromIterator[(Node, immutable.Iterable[Triple])](() => {
+      val default = dataset.getDefaultGraph
+      (if default.isEmpty then Iterator.empty else Iterator(Quad.defaultGraphIRI -> graphAsTriples(default))) ++
+        dataset.listGraphNodes().asScala.map { graphNode =>
+          (graphNode, graphAsTriples(dataset.getGraph(graphNode)))
+        }
+    })
+
+  extension (dataset: DatasetGraph | Dataset)
+    def asQuads: immutable.Iterable[Quad] = dataset match
+      case dg: DatasetGraph => datasetAsQuads(dg)
+      case d: Dataset => datasetAsQuads(d.asDatasetGraph)
+
+    def asGraphs: immutable.Iterable[(Node, immutable.Iterable[Triple])] = dataset match
+      case dg: DatasetGraph => datasetAsGraphs(dg)
+      case d: Dataset => datasetAsGraphs(d.asDatasetGraph)

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/package.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/package.scala
@@ -1,4 +1,5 @@
 package eu.ostrzyciel.jelly.convert
 
 package object jena:
+  implicit val jenaIterableAdapter: JenaIterableAdapter.type = JenaIterableAdapter
   implicit val jenaConverterFactory: JenaConverterFactory.type = JenaConverterFactory

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaIterableAdapterSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaIterableAdapterSpec.scala
@@ -1,0 +1,78 @@
+package eu.ostrzyciel.jelly.convert.jena
+
+import org.apache.jena.graph.{NodeFactory, Triple}
+import org.apache.jena.query.DatasetFactory
+import org.apache.jena.rdf.model.impl.ModelCom
+import org.apache.jena.sparql.core.Quad
+import org.apache.jena.sparql.graph.GraphFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JenaIterableAdapterSpec extends AnyWordSpec, Matchers:
+  import JenaIterableAdapter.*
+
+  val triples = Set(
+    Triple(
+      NodeFactory.createURI("http://example.com/subject"),
+      NodeFactory.createURI("http://example.com/predicate"),
+      NodeFactory.createURI("http://example.com/object_1")
+    ),
+    Triple(
+      NodeFactory.createURI("http://example.com/subject"),
+      NodeFactory.createURI("http://example.com/predicate"),
+      NodeFactory.createURI("http://example.com/object_2")
+    ),
+    Triple(
+      NodeFactory.createURI("http://example.com/subject"),
+      NodeFactory.createURI("http://example.com/predicate_2"),
+      NodeFactory.createURI("http://example.com/object_2")
+    )
+  )
+
+  val graph = GraphFactory.createGraphMem()
+  triples.foreach(graph.add)
+  val model = ModelCom(graph)
+
+  val dataset = DatasetFactory.create()
+  dataset.setDefaultModel(model)
+  dataset.addNamedModel("http://example.com/named", model)
+  dataset.addNamedModel("http://example.com/named_2", model)
+  val datasetGraph = dataset.asDatasetGraph()
+
+  "JenaIterableAdapter" should {
+    "convert a Graph to triples" in {
+      graph.asTriples should contain theSameElementsAs triples
+    }
+
+    "convert a Model to triples" in {
+      model.asTriples should contain theSameElementsAs triples
+    }
+
+    "convert a DatasetGraph to quads" in {
+      val seq = datasetGraph.asQuads.toSeq
+      seq.size should be (triples.size * 3)
+      seq.map(_.getGraph).count(Quad.isDefaultGraph) should be (triples.size)
+    }
+
+    "convert a Dataset to quads" in {
+      val seq = dataset.asQuads.toSeq
+      seq.size should be (triples.size * 3)
+      seq.map(_.getGraph).count(Quad.isDefaultGraph) should be (triples.size)
+    }
+
+    "convert a DatasetGraph to graphs" in {
+      val seq = datasetGraph.asGraphs.toSeq
+      seq.size should be (3)
+      seq.head._1 should be (Quad.defaultGraphIRI)
+      for g <- seq.map(_._2) do
+        g should contain theSameElementsAs triples
+    }
+
+    "convert a Dataset to graphs" in {
+      val seq = dataset.asGraphs.toSeq
+      seq.size should be (3)
+      seq.head._1 should be (Quad.defaultGraphIRI)
+      for g <- seq.map(_._2) do
+        g should contain theSameElementsAs triples
+    }
+  }

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jIterableAdapter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jIterableAdapter.scala
@@ -1,0 +1,28 @@
+package eu.ostrzyciel.jelly.convert.rdf4j
+
+import eu.ostrzyciel.jelly.core.IterableAdapter
+import eu.ostrzyciel.jelly.core.IterableAdapter.IterableFromIterator
+import org.eclipse.rdf4j.model.{Model, Statement, Value}
+
+import scala.collection.immutable
+import scala.jdk.CollectionConverters.*
+
+object Rdf4jIterableAdapter extends IterableAdapter[Value, Statement, Statement, Model, Model]:
+  extension (model: Model)
+    def asTriples: immutable.Iterable[Statement] =
+      IterableFromIterator[Statement](() => model.iterator().asScala)
+
+    def asQuads: immutable.Iterable[Statement] =
+      IterableFromIterator[Statement](() => model.iterator().asScala)
+
+    def asGraphs: immutable.Iterable[(Value, immutable.Iterable[Statement])] =
+      IterableFromIterator[(Value, immutable.Iterable[Statement])](() => {
+        model.contexts().iterator().asScala.map(context => {
+          (
+            context,
+            IterableFromIterator[Statement](
+              () => model.getStatements(null, null, null, context).iterator().asScala
+            )
+          )
+        })
+      })

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/package.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/package.scala
@@ -1,4 +1,5 @@
 package eu.ostrzyciel.jelly.convert
 
 package object rdf4j:
+  implicit val rdf4jIterableAdapter: Rdf4jIterableAdapter.type = Rdf4jIterableAdapter
   implicit val rdf4jConverterFactory: Rdf4jConverterFactory.type = Rdf4jConverterFactory

--- a/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jIterableAdapterSpec.scala
+++ b/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jIterableAdapterSpec.scala
@@ -1,0 +1,63 @@
+package eu.ostrzyciel.jelly.convert.rdf4j
+
+import org.eclipse.rdf4j.model.impl.DynamicModelFactory
+import org.eclipse.rdf4j.model.util.Statements.*
+import org.eclipse.rdf4j.model.util.Values.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters.*
+
+class Rdf4jIterableAdapterSpec extends AnyWordSpec, Matchers:
+  import Rdf4jIterableAdapter.*
+
+  val triples = Seq(
+    statement(
+      iri("http://example.com/subject"),
+      iri("http://example.com/predicate"),
+      iri("http://example.com/object"),
+      null
+    ),
+    statement(
+      iri("http://example.com/subject"),
+      iri("http://example.com/predicate"),
+      iri("http://example.com/object2"),
+      null
+    ),
+    statement(
+      iri("http://example.com/subject2"),
+      iri("http://example.com/predicate"),
+      iri("http://example.com/object"),
+      null
+    ),
+  )
+
+  val graphs = Seq(null, "http://example.com/named", "http://example.com/named_2")
+    .map(s => if s == null then null else iri(s))
+  val quads = graphs
+    .flatMap(g => triples.map(t => statement(t.getSubject, t.getPredicate, t.getObject, g)))
+
+  val model = DynamicModelFactory().createEmptyModel()
+  model.addAll(triples.asJava)
+
+  val ds = DynamicModelFactory().createEmptyModel()
+  ds.addAll(quads.asJava)
+
+  "Rdf4jIterableAdapter" should {
+    "convert a Model to triples" in {
+      model.asTriples should contain theSameElementsAs triples
+    }
+
+    "convert a Model to quads" in {
+      val seq = ds.asQuads.toSeq
+      seq.size should be (triples.size * 3)
+      seq should contain theSameElementsAs quads
+    }
+
+    "convert a Model to graphs" in {
+      val seq = ds.asGraphs.toSeq
+      seq.size should be (3)
+      seq.map(_._1) should contain theSameElementsAs graphs
+      seq.flatMap(_._2) should contain theSameElementsAs quads
+    }
+  }

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/EncoderSource.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/EncoderSource.scala
@@ -1,0 +1,68 @@
+package eu.ostrzyciel.jelly.stream
+
+import eu.ostrzyciel.jelly.core.{ConverterFactory, IterableAdapter}
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.*
+
+object EncoderSource:
+  import EncoderFlow.*
+
+  /**
+   * A source of RDF stream frames from an RDF graph implementation.
+   * RDF stream type: TRIPLES.
+   *
+   * @param graph the RDF graph to be streamed
+   * @param opt streaming options
+   * @param streamOpt Jelly serialization options
+   * @param adapter graph -> triples adapter (see implementations of [[IterableAdapter]])
+   * @param factory implementation of [[ConverterFactory]] (e.g., JenaConverterFactory)
+   * @tparam TGraph type of the RDF graph
+   * @tparam TTriple type of the RDF triple
+   * @return Pekko Streams source of RDF stream frames
+   */
+  def fromGraph[TGraph, TTriple](graph: TGraph, opt: Options, streamOpt: RdfStreamOptions)
+    (implicit adapter: IterableAdapter[?, TTriple, ?, TGraph, ?], factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
+  Source[RdfStreamFrame, NotUsed] =
+    Source(adapter.asTriples(graph))
+      .via(fromFlatTriples(opt, streamOpt))
+
+  /**
+   * A source of RDF stream frames from an RDF dataset implementation (quads format).
+   * RDF stream type: QUADS.
+   *
+   * @param dataset the RDF dataset to be streamed
+   * @param opt streaming options
+   * @param streamOpt Jelly serialization options
+   * @param adapter dataset -> quads adapter (see implementations of [[IterableAdapter]])
+   * @param factory implementation of [[ConverterFactory]] (e.g., JenaConverterFactory)
+   * @tparam TDataset type of the RDF dataset
+   * @tparam TQuad type of the RDF quad
+   * @return Pekko Streams source of RDF stream frames
+   */
+  def fromDatasetAsQuads[TDataset, TQuad](dataset: TDataset, opt: Options, streamOpt: RdfStreamOptions)
+    (implicit adapter: IterableAdapter[?, ?, TQuad, ?, TDataset], factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
+  Source[RdfStreamFrame, NotUsed] =
+    Source(adapter.asQuads(dataset))
+      .via(fromFlatQuads(opt, streamOpt))
+
+  /**
+   * A source of RDF stream frames from an RDF dataset implementation (graphs format).
+   * RDF stream type: GRAPHS.
+   *
+   * @param dataset the RDF dataset to be streamed
+   * @param opt streaming options
+   * @param streamOpt Jelly serialization options
+   * @param adapter dataset -> graphs adapter (see implementations of [[IterableAdapter]])
+   * @param factory implementation of [[ConverterFactory]] (e.g., JenaConverterFactory)
+   * @tparam TDataset type of the RDF dataset
+   * @tparam TNode type of the RDF node
+   * @tparam TTriple type of the RDF triple
+   * @return
+   */
+  def fromDatasetAsGraphs[TDataset, TNode, TTriple](dataset: TDataset, opt: Options, streamOpt: RdfStreamOptions)
+    (implicit adapter: IterableAdapter[TNode, TTriple, ?, ?, TDataset],
+      factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
+  Source[RdfStreamFrame, NotUsed] =
+    Source(adapter.asGraphs(dataset))
+      .via(fromGraphs(opt, streamOpt))


### PR DESCRIPTION
Closes: #27 

- `core` Added an abstract trait for model/dataset to iterables conversion
- `jena` and `rdf4j` added implementations for the iterable adapter
- `stream` added stream sources from models/datasets using the new adapters
- `core` refactored the existing traits to include more sensible type variance
- more tests