### PR TITLE
Add support for proto versioning

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -13,3 +13,12 @@ trait ProtoDecoder[+TOut]:
   def getStreamOpt: Option[RdfStreamOptions]
   
   def ingestRow(row: RdfStreamRow): Option[TOut]
+
+  /**
+   * Checks if the version of the stream is supported.
+   * Throws an exception if not.
+   * @param options Options of the stream.
+   */
+  protected final def checkVersion(options: RdfStreamOptions): Unit =
+    if options.version > Constants.protoVersion then
+      throw new RdfProtoDeserializationError(s"Unsupported proto version: ${options.version}")

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
@@ -136,6 +136,7 @@ sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +T
         throw new RdfProtoDeserializationError("Row kind is not set.")
 
   protected def handleOptions(opts: RdfStreamOptions): Unit =
+    checkVersion(opts)
     setStreamOpt(opts)
 
   protected def handleTriple(triple: RdfTriple): Option[TOut] =
@@ -281,6 +282,7 @@ object ProtoDecoderImpl:
           inner.get.ingestRow(row)
 
     private def handleOptions(opts: RdfStreamOptions): Unit =
+      checkVersion(opts)
       if inner.isDefined then
         throw new RdfProtoDeserializationError("Stream options are already set." +
           "The type of the stream cannot be inferred.")

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -238,7 +238,10 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   private def emitOptions(): Unit =
     emittedOptions = true
     extraRowsBuffer.append(
-      RdfStreamRow(RdfStreamRow.Row.Options(options))
+      RdfStreamRow(RdfStreamRow.Row.Options(
+        // Override whatever the user set in the options.
+        options.withVersion(Constants.protoVersion)
+      ))
     )
 
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/package.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/package.scala
@@ -16,3 +16,5 @@ package object core:
     val jellyName = "Jelly"
     val jellyFileExtension = "jelly"
     val jellyContentType = "application/x-jelly-rdf"
+    val protoVersion = 1
+    val protoSemanticVersion = "1.0.0"

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -11,7 +11,11 @@ object ProtoTestCases:
   val GRAPH_REPEAT: RdfGraph = RdfGraph(RdfGraph.Graph.Repeat(RdfRepeat()))
 
   def wrapEncoded(rows: Seq[RowValue]): Seq[RdfStreamRow.Row] = rows map {
-    case v: RdfStreamOptions => RdfStreamRow.Row.Options(v)
+    case v: RdfStreamOptions => v.version match
+      // If the version is not set, set it to the current version
+      case 0 => RdfStreamRow.Row.Options(v.withVersion(Constants.protoVersion))
+      // Otherwise assume we are checking version compatibility
+      case _ => RdfStreamRow.Row.Options(v)
     case v: RdfDatatypeEntry => RdfStreamRow.Row.Datatype(v)
     case v: RdfPrefixEntry => RdfStreamRow.Row.Prefix(v)
     case v: RdfNameEntry => RdfStreamRow.Row.Name(v)


### PR DESCRIPTION
Add support for the `version` field in stream options. In the encoder set it to 1. In the decoder, require the version be less or equal to 1.