### PR TITLE
Rework stream frame size limits

### DIFF
--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/TestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/TestStream.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.integration_tests
 
 import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
-import eu.ostrzyciel.jelly.stream.EncoderFlow
+import eu.ostrzyciel.jelly.stream.*
 import org.apache.pekko.stream.scaladsl.*
 import org.apache.pekko.{Done, NotUsed}
 
@@ -9,13 +9,13 @@ import java.io.{InputStream, OutputStream}
 import scala.concurrent.{ExecutionContext, Future}
 
 trait TestStream:
-  def tripleSource(is: InputStream, streamOpt: EncoderFlow.Options, jellyOpt: RdfStreamOptions):
+  def tripleSource(is: InputStream, limiter: SizeLimiter, jellyOpt: RdfStreamOptions):
   Source[RdfStreamFrame, NotUsed]
 
-  def quadSource(is: InputStream, streamOpt: EncoderFlow.Options, jellyOpt: RdfStreamOptions):
+  def quadSource(is: InputStream, limiter: SizeLimiter, jellyOpt: RdfStreamOptions):
   Source[RdfStreamFrame, NotUsed]
 
-  def graphSource(is: InputStream, streamOpt: EncoderFlow.Options, jellyOpt: RdfStreamOptions):
+  def graphSource(is: InputStream, limiter: SizeLimiter, jellyOpt: RdfStreamOptions):
   Source[RdfStreamFrame, NotUsed]
 
   def tripleSink(os: OutputStream)(implicit ec: ExecutionContext): Sink[RdfStreamFrame, Future[Done]]

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
@@ -2,7 +2,7 @@ package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
-import eu.ostrzyciel.jelly.stream.{DecoderFlow, EncoderFlow, JellyIo}
+import eu.ostrzyciel.jelly.stream.*
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.*
 import org.eclipse.rdf4j.model.Statement
@@ -32,12 +32,12 @@ class Rdf4jReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Seq[S
 
   override def writeTriplesJelly(os: OutputStream, model: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
     val f = Source.fromIterator(() => model.iterator)
-      .via(EncoderFlow.fromFlatTriples(EncoderFlow.Options(frameSize * 10), opt))
+      .via(EncoderFlow.fromFlatTriples(StreamRowCountLimiter(frameSize), opt))
       .runWith(JellyIo.toIoStream(os))
     Await.ready(f, 10.seconds)
 
   override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
     val f = Source.fromIterator(() => dataset.iterator)
-      .via(EncoderFlow.fromFlatQuads(EncoderFlow.Options(frameSize * 10), opt))
+      .via(EncoderFlow.fromFlatQuads(StreamRowCountLimiter(frameSize), opt))
       .runWith(JellyIo.toIoStream(os))
     Await.ready(f, 10.seconds)

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/SizeLimiter.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/SizeLimiter.scala
@@ -1,0 +1,40 @@
+package eu.ostrzyciel.jelly.stream
+
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Flow
+
+/**
+ * Policy for limiting the size of stream frames in the Jelly stream producer.
+ *
+ * Note that the limiter is only a **limit**. When streaming grouped triples,
+ * grouped quads, or graphs, the size of the stream frame may be smaller than
+ * the limit, as the stream frame is always created after the group is complete.
+ *
+ * See also: [[EncoderFlow]], [[EncoderSource]]
+ */
+trait SizeLimiter:
+  /**
+   * Flow that limits the size of stream frames.
+   *
+   * The flow should group the incoming rows into Seqs that will be later used to
+   * create stream frames.
+   * @return Apache Pekko Flow
+   */
+  def flow: Flow[RdfStreamRow, Seq[RdfStreamRow], NotUsed]
+
+/**
+ * Stream frame size limiter that maintains a maximum byte size of stream frames.
+ * @param maxSize maximum byte size of stream frames
+ */
+final class ByteSizeLimiter(maxSize: Long) extends SizeLimiter:
+  override def flow: Flow[RdfStreamRow, Seq[RdfStreamRow], NotUsed] =
+    Flow[RdfStreamRow].groupedWeighted(maxSize)(row => row.serializedSize)
+
+/**
+ * Stream frame size limiter that maintains a maximum number of rows in stream frames.
+ * @param maxRows maximum number of rows in stream frames
+ */
+final class StreamRowCountLimiter(maxRows: Int) extends SizeLimiter:
+  override def flow: Flow[RdfStreamRow, Seq[RdfStreamRow], NotUsed] =
+    Flow[RdfStreamRow].grouped(maxRows)


### PR DESCRIPTION
The previous system required the user to use a byte size limit on the stream frames, which did not make sense in all cases (e.g., some grouped streaming use cases).

This commit introduces the SizeLimiter trait that can be used to define the policy for splitting frames when they get too big. The policy can be disabled entirely in grouped streaming formulations, but is mandatory in flat streaming.