### PR TITLE
Enable HTTP/2 in application.conf

### DIFF
--- a/grpc/src/main/resources/application.conf
+++ b/grpc/src/main/resources/application.conf
@@ -1,0 +1,2 @@
+# Enable HTTP/2 support in Pekko server so that gRPC works
+pekko.http.server.preview.enable-http2 = on


### PR DESCRIPTION
Without this, the Pekko HTTP server uses HTTP/1.1, which completely disables gRPC. Apparently you need to enable this yourself...