### PR TITLE
Move default typesafe config to reference.conf

### DIFF
--- a/grpc/src/main/resources/reference.conf
+++ b/grpc/src/main/resources/reference.conf
@@ -1,0 +1,2 @@
+# Enable HTTP/2 support in Pekko server so that gRPC works
+pekko.http.server.preview.enable-http2 = on


### PR DESCRIPTION
This is where the default config should be for libraries...