### PR TITLE
Compile releases under Java 11 to broaden bincompat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '11'
           cache: 'sbt'
 
       - run: sbt ci-release


### PR DESCRIPTION
Using Java 11 vs 21 should have no performance impact on the generated code... it should mostly behave the same.