### PR TITLE
Add a factory for constructing STaX types from IRIs

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/LogicalStreamTypeExtensions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/LogicalStreamTypeExtensions.scala
@@ -90,3 +90,25 @@ private trait LogicalStreamTypeExtensions:
 private object LogicalStreamTypeExtensions extends LogicalStreamTypeExtensions
 
 export LogicalStreamTypeExtensions.*
+
+object LogicalStreamTypeFactory:
+
+  /**
+   * Creates a logical stream type from an RDF-STaX stream type individual IRI.
+   *
+   * @param iri the IRI of the RDF-STaX stream type individual
+   * @return the logical stream type, or None if the IRI is not a valid RDF-STaX stream type individual
+   */
+  def fromOntologyIri(iri: String): Option[LogicalStreamType] =
+    if !iri.startsWith(staxPrefix) then
+      return None
+
+    iri.substring(staxPrefix.length) match
+      case "flatTripleStream" => Some(LogicalStreamType.FLAT_TRIPLES)
+      case "flatQuadStream" => Some(LogicalStreamType.FLAT_QUADS)
+      case "graphStream" => Some(LogicalStreamType.GRAPHS)
+      case "subjectGraphStream" => Some(LogicalStreamType.SUBJECT_GRAPHS)
+      case "datasetStream" => Some(LogicalStreamType.DATASETS)
+      case "namedGraphStream" => Some(LogicalStreamType.NAMED_GRAPHS)
+      case "timestampedNamedGraphStream" => Some(LogicalStreamType.TIMESTAMPED_NAMED_GRAPHS)
+      case _ => None

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/LogicalStreamTypeExtensionsSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/LogicalStreamTypeExtensionsSpec.scala
@@ -54,6 +54,12 @@ class LogicalStreamTypeExtensionsSpec extends AnyWordSpec, Matchers:
         t.get should startWith ("https://w3id.org/stax/ontology#")
       }
 
+      s"return a type that can be parsed by LogicalStreamTypeFactory for $streamType" in {
+        val t = streamType.getRdfStaxType
+        val newType = LogicalStreamTypeFactory.fromOntologyIri(t.get)
+        newType should be (Some(streamType))
+      }
+
     "not return RDF STaX type for UNSPECIFIED" in {
       LogicalStreamType.UNSPECIFIED.getRdfStaxType should be (None)
     }
@@ -86,4 +92,14 @@ class LogicalStreamTypeExtensionsSpec extends AnyWordSpec, Matchers:
         error.getMessage should include ("Unsupported logical stream type")
         error.getMessage should include ("UNSPECIFIED")
       }
+  }
+
+  "LogicalStreamTypeFactory.fromOntologyIri" should {
+    "return None for a non-STaX IRI" in {
+      LogicalStreamTypeFactory.fromOntologyIri("https://example.org/stream") should be (None)
+    }
+
+    "return None for an invalid STaX IRI" in {
+      LogicalStreamTypeFactory.fromOntologyIri("https://w3id.org/stax/ontology#doesNotExist") should be (None)
+    }
   }


### PR DESCRIPTION
This would be useful for example in RiverBench's CI worker, which needs to annotate its Jelly streams, while already knowing what is the IRI of the RDF-STaX type.