### PR TITLE
Update Apache Pekko to 1.0.2

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+    { groupId = "com.thesamet.scalapb" }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,12 @@ ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeProfileName := "eu.ostrzyciel"
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
-lazy val pekkoV = "1.0.1"
+lazy val pekkoV = "1.0.2"
 lazy val jenaV = "4.10.0"
 lazy val rdf4jV = "4.3.0"
+// Must be synchronized to the version used by Pekko gRPC
+// See: https://mvnrepository.com/artifact/org.apache.pekko/pekko-grpc-runtime_3
+// When updating also change the version in plugins.sbt
 lazy val scalapbV = "0.11.13"
 
 lazy val commonSettings = Seq(
@@ -89,7 +92,7 @@ lazy val grpc = (project in file("grpc"))
       "org.apache.pekko" %% "pekko-discovery" % pekkoV,
       "org.apache.pekko" %% "pekko-stream-typed" % pekkoV,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoV % Test,
-      "org.apache.pekko" %% "pekko-grpc-runtime" % "1.0.0",
+      "org.apache.pekko" %% "pekko-grpc-runtime" % pekkoV,
     ),
     // Add the shared proto sources
     Compile / PB.protoSources ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,6 @@ addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addDependencyTreePlugin
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.12"
+lazy val scalapbV = "0.11.13"
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % scalapbV


### PR DESCRIPTION
Also add a rule for Scala Steward to ignore scalapb – updating it automatically would be a bit complex, so better leave it to humans.