### PR TITLE
Experiment: default IDs in LUT references

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/EncoderLookup.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/EncoderLookup.scala
@@ -2,10 +2,6 @@ package eu.ostrzyciel.jelly.core
 
 import java.util
 
-private[core] object EncoderValue:
-  // Empty default value to slightly reduce heap pressure
-  val Empty = EncoderValue(0, 0, false)
-
 private[core] final case class EncoderValue(getId: Int, setId: Int, newEntry: Boolean)
 
 private[core] final class EncoderLookup(maxEntries: Int)

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/NameEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/NameEncoder.scala
@@ -4,6 +4,9 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
 
 import scala.collection.mutable.ListBuffer
 
+private[core] object NameEncoder:
+  private val repeatDatatype = RdfLiteral.LiteralKind.Datatype(0)
+
 /**
  * IRI and datatype encoder.
  * Maintains internal lookups for prefixes, names, and datatypes. Uses the LRU strategy for eviction.
@@ -11,17 +14,23 @@ import scala.collection.mutable.ListBuffer
  * @param opt Jelly options
  */
 private[core] final class NameEncoder(opt: RdfStreamOptions):
+  import NameEncoder.*
+
   private val nameLookup = new EncoderLookup(opt.maxNameTableSize)
   private val prefixLookup = new EncoderLookup(opt.maxPrefixTableSize)
   private val dtLookup = new EncoderLookup(opt.maxDatatypeTableSize)
   private val dtTable = new DecoderLookup[RdfLiteral.LiteralKind.Datatype](opt.maxDatatypeTableSize)
+
+  private val lastDatatype = LastNodeHolder[RdfLiteral.LiteralKind.Datatype]()
+  private var lastIriPrefixId: Int = -1000
+  private var lastIriNameId: Int = 0
 
   /**
    * Try to extract the prefix out of the IRI.
    *
    * Somewhat based on [[org.apache.jena.riot.system.PrefixMapStd.getPossibleKey]]
    * @param iri IRI
-   * @return prefix or null (micro-optimization, don't hit me)
+   * @return prefix which can be empty, never null
    */
   private def getIriPrefix(iri: String): String =
     iri.lastIndexOf('#') match
@@ -29,7 +38,23 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
       case _ =>
         iri.lastIndexOf('/') match
           case i if i > -1 => iri.substring(0, i + 1)
-          case _ => null
+          case _ => ""
+
+  /**
+   * Obtain the id for the name lookup table to be communicated to the consumer.
+   * This method checks if new id = last_id + 1, and if so, it returns 0.
+   * 
+   * @param getId the getId from the EncoderLookup
+   * @return the id to be communicated to the consumer
+   */
+  private inline def getNameIdWithRepeat(getId: Int): Int =
+    if lastIriNameId + 1 == getId then
+      // If the last node had id - 1, we can tell it to the consumer in a shorthand manner
+      lastIriNameId = getId
+      0
+    else
+      lastIriNameId = getId
+      getId
 
   /**
    * Encodes an IRI to a protobuf representation.
@@ -39,40 +64,47 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
    * @return protobuf representation of the IRI
    */
   def encodeIri(iri: String, rowsBuffer: ListBuffer[RdfStreamRow]): RdfIri =
-    def plainIriEncode: RdfIri =
-      nameLookup.addEntry(iri) match
-        case EncoderValue(getId, _, false) =>
-          RdfIri(nameId = getId)
-        case EncoderValue(getId, setId, true) =>
-          rowsBuffer.append(
-            RdfStreamRow(RdfStreamRow.Row.Name(
-              RdfNameEntry(id = setId, value = iri)
-            ))
-          )
-          RdfIri(nameId = getId)
-
     if opt.maxPrefixTableSize == 0 then
       // Use a lighter algorithm if the prefix table is disabled
-      return plainIriEncode
-
-    getIriPrefix(iri) match
-      case null => plainIriEncode
-      case prefix =>
-        val postfix = iri.substring(prefix.length)
-        val pVal = prefixLookup.addEntry(prefix)
-        val iVal = if postfix.nonEmpty then nameLookup.addEntry(postfix) else EncoderValue.Empty
-
-        if pVal.newEntry then rowsBuffer.append(
-          RdfStreamRow(RdfStreamRow.Row.Prefix(
-            RdfPrefixEntry(pVal.setId, prefix)
-          ))
-        )
-        if iVal.newEntry then rowsBuffer.append(
+      val nameLookupEntry = nameLookup.addEntry(iri)
+      if nameLookupEntry.newEntry then
+        rowsBuffer.append(
           RdfStreamRow(RdfStreamRow.Row.Name(
-            RdfNameEntry(iVal.setId, postfix)
+            RdfNameEntry(id = nameLookupEntry.setId, value = iri)
           ))
         )
-        RdfIri(prefixId = pVal.getId, nameId = iVal.getId)
+      // We set the prefixId to 0, but it's a special case, because the prefix table is disabled.
+      // The consumer will interpret this as no prefix.
+      RdfIri(nameId = getNameIdWithRepeat(nameLookupEntry.getId))
+    else
+      val prefix = getIriPrefix(iri)
+      val postfix = iri.substring(prefix.length)
+      val prefixLookupEntry = prefixLookup.addEntry(prefix)
+      val nameLookupEntry = nameLookup.addEntry(postfix)
+  
+      if prefixLookupEntry.newEntry then rowsBuffer.append(
+        RdfStreamRow(RdfStreamRow.Row.Prefix(
+          RdfPrefixEntry(prefixLookupEntry.setId, prefix)
+        ))
+      )
+      if nameLookupEntry.newEntry then rowsBuffer.append(
+        RdfStreamRow(RdfStreamRow.Row.Name(
+          RdfNameEntry(nameLookupEntry.setId, postfix)
+        ))
+      )
+  
+      val nameIdWithRepeat = getNameIdWithRepeat(nameLookupEntry.getId)
+      if lastIriPrefixId == prefixLookupEntry.getId then
+        // If the last IRI had the same prefix, we can tell the consumer to reuse it.
+        // prefixId = 0 by default in this constructor.
+        // No need to update lastIriPrefixId, because it's the same.
+        RdfIri(nameId = nameIdWithRepeat)
+      else
+        lastIriPrefixId = prefixLookupEntry.getId
+        RdfIri(
+          prefixId = prefixLookupEntry.getId,
+          nameId = nameIdWithRepeat
+        )
 
   /**
    * Encodes a datatype IRI to a protobuf representation.
@@ -94,6 +126,14 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
           RdfDatatypeEntry(id = dtVal.setId, value = dtIri)
         ))
       )
+      lastDatatype.node = datatype
       datatype
-    else
-      dtTable.get(dtVal.getId)
+    else lastDatatype.node match
+      case lastDtVal: RdfLiteral.LiteralKind.Datatype if lastDtVal.value == dtVal.getId =>
+        // The last datatype was the same, so we can tell the consumer to reuse it
+        repeatDatatype
+      case _ =>
+        // The last datatype was different, specify it explicitly
+        val datatype = dtTable.get(dtVal.getId)
+        lastDatatype.node = datatype
+        datatype

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
@@ -23,6 +23,8 @@ sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +T
   protected final val lastPredicate: LastNodeHolder[TNode] = new LastNodeHolder()
   protected final val lastObject: LastNodeHolder[TNode] = new LastNodeHolder()
   protected final val lastGraph: LastNodeHolder[TNode] = new LastNodeHolder()
+  
+  private var lastDatatypeId: Int = 0
 
   /**
    * Returns the received stream options from the producer.
@@ -44,7 +46,9 @@ sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +T
     case RdfLiteral.LiteralKind.Langtag(lang) =>
       converter.makeLangLiteral(literal.lex, lang)
     case RdfLiteral.LiteralKind.Datatype(dtId) =>
-      converter.makeDtLiteral(literal.lex, dtLookup.get(dtId))
+      if dtId != 0 then
+        lastDatatypeId = dtId
+      converter.makeDtLiteral(literal.lex, dtLookup.get(lastDatatypeId))
     case RdfLiteral.LiteralKind.Empty =>
       throw new RdfProtoDeserializationError("Literal kind is not set.")
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
@@ -23,8 +23,6 @@ sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +T
   protected final val lastPredicate: LastNodeHolder[TNode] = new LastNodeHolder()
   protected final val lastObject: LastNodeHolder[TNode] = new LastNodeHolder()
   protected final val lastGraph: LastNodeHolder[TNode] = new LastNodeHolder()
-  
-  private var lastDatatypeId: Int = 0
 
   /**
    * Returns the received stream options from the producer.
@@ -46,9 +44,7 @@ sealed abstract class ProtoDecoderImpl[TNode, TDatatype : ClassTag, +TTriple, +T
     case RdfLiteral.LiteralKind.Langtag(lang) =>
       converter.makeLangLiteral(literal.lex, lang)
     case RdfLiteral.LiteralKind.Datatype(dtId) =>
-      if dtId != 0 then
-        lastDatatypeId = dtId
-      converter.makeDtLiteral(literal.lex, dtLookup.get(lastDatatypeId))
+      converter.makeDtLiteral(literal.lex, dtLookup.get(dtId))
     case RdfLiteral.LiteralKind.Empty =>
       throw new RdfProtoDeserializationError("Literal kind is not set.")
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NameDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NameDecoderSpec.scala
@@ -27,8 +27,18 @@ class NameDecoderSpec extends AnyWordSpec, Matchers:
         error.nameId should be (5)
       }
 
-      "return empty string for no prefix and no name" in {
+      "throw MissingNameEntryError when trying to retrieve a name with empty LUT" in {
         val dec = NameDecoder(smallOptions)
+        val error = intercept[MissingNameEntryError] {
+          dec.decode(RdfIri(0, 0))
+        }
+        error.getMessage should include ("name table at ID: 1")
+        error.nameId should be (1)
+      }
+
+      "return empty string for no prefix and empty name" in {
+        val dec = NameDecoder(smallOptions)
+        dec.updateNames(RdfNameEntry(0, ""))
         dec.decode(RdfIri(0, 0)) should be ("")
       }
 
@@ -36,6 +46,8 @@ class NameDecoderSpec extends AnyWordSpec, Matchers:
         val dec = NameDecoder(smallOptions)
         dec.updatePrefixes(RdfPrefixEntry(0, "https://test.org/"))
         dec.updatePrefixes(RdfPrefixEntry(0, "https://test.org/2/"))
+        dec.updateNames(RdfNameEntry(0, ""))
+        dec.updateNames(RdfNameEntry(0, ""))
         dec.decode(RdfIri(1, 0)) should be("https://test.org/")
         dec.decode(RdfIri(2, 0)) should be("https://test.org/2/")
       }
@@ -45,6 +57,8 @@ class NameDecoderSpec extends AnyWordSpec, Matchers:
         dec.updatePrefixes(RdfPrefixEntry(4, "https://test.org/"))
         // This ID will resolve to 5
         dec.updatePrefixes(RdfPrefixEntry(0, "https://test.org/2/"))
+        dec.updateNames(RdfNameEntry(0, ""))
+        dec.updateNames(RdfNameEntry(0, ""))
         dec.decode(RdfIri(4, 0)) should be("https://test.org/")
         dec.decode(RdfIri(5, 0)) should be("https://test.org/2/")
       }
@@ -52,6 +66,7 @@ class NameDecoderSpec extends AnyWordSpec, Matchers:
       "accept a new prefix and return it (IRI with no name part)" in {
         val dec = NameDecoder(smallOptions)
         dec.updatePrefixes(RdfPrefixEntry(3, "https://test.org/"))
+        dec.updateNames(RdfNameEntry(0, ""))
         dec.decode(RdfIri(3, 0)) should be ("https://test.org/")
       }
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NameEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NameEncoderSpec.scala
@@ -49,27 +49,6 @@ class NameEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
         )
       }
 
-      "add multiple datatypes using 0 for repeated instances" in {
-        val (encoder, buffer) = getEncoder()
-        for i <- 1 to 2 do
-          val dt = encoder.encodeDatatype(s"dt$i", buffer)
-          dt.value should be (i)
-
-        for i <- 1 to 4 do
-          val dt = encoder.encodeDatatype(s"dt2", buffer)
-          dt.value should be (0)
-
-        // no repeat this time
-        val dt = encoder.encodeDatatype("dt1", buffer)
-        dt.value should be(1)
-
-        buffer.size should be (2)
-        buffer.map(_.row.datatype.get) should contain only (
-          RdfDatatypeEntry(0, "dt1"),
-          RdfDatatypeEntry(0, "dt2"),
-        )
-      }
-
       "add datatypes evicting old ones" in {
         val (encoder, buffer) = getEncoder()
         for i <- 1 to 12 do

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -70,9 +70,9 @@ object ProtoTestCases:
       RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfNameEntry(0, "object"),
       RdfTriple(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 3))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 0))),
       ),
       RdfDatatypeEntry(0, "https://test.org/xsd/integer"),
       RdfTriple(
@@ -80,6 +80,7 @@ object ProtoTestCases:
         TERM_REPEAT,
         RdfTerm(RdfTerm.Term.Literal(RdfLiteral("123", RdfLiteral.LiteralKind.Datatype(1)))),
       ),
+      RdfPrefixEntry(0, ""),
       RdfNameEntry(0, "b"),
       RdfNameEntry(0, "c"),
       RdfTriple(
@@ -87,13 +88,13 @@ object ProtoTestCases:
         TERM_REPEAT,
         RdfTerm(RdfTerm.Term.TripleTerm(RdfTriple(
           RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-          RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 4))),
-          RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 5))),
+          RdfTerm(RdfTerm.Term.Iri(RdfIri(3, 4))),
+          RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
         )))
       ),
       RdfTriple(
         RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 1))),
         TERM_REPEAT,
       ),
     ))
@@ -120,14 +121,14 @@ object ProtoTestCases:
       RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfNameEntry(0, "object"),
       RdfTriple(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 3))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 0))),
       ),
       RdfDatatypeEntry(0, "https://test.org/xsd/integer"),
       RdfTriple(
         RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
         RdfTerm(RdfTerm.Term.Literal(RdfLiteral("123", RdfLiteral.LiteralKind.Datatype(1)))),
       ),
     ))
@@ -169,10 +170,10 @@ object ProtoTestCases:
       RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfNameEntry(0, "graph"),
       RdfQuad(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
         RdfTerm(RdfTerm.Term.Literal(RdfLiteral("test", RdfLiteral.LiteralKind.Langtag("en-gb")))),
-        RdfGraph(RdfGraph.Graph.Iri(RdfIri(2, 3))),
+        RdfGraph(RdfGraph.Graph.Iri(RdfIri(2, 0))),
       ),
       RdfQuad(
         TERM_REPEAT,
@@ -222,10 +223,10 @@ object ProtoTestCases:
       RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfNameEntry(0, "graph"),
       RdfQuad(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
         RdfTerm(RdfTerm.Term.Literal(RdfLiteral("test", RdfLiteral.LiteralKind.Langtag("en-gb")))),
-        RdfGraph(RdfGraph.Graph.Iri(RdfIri(2, 3))),
+        RdfGraph(RdfGraph.Graph.Iri(RdfIri(2, 0))),
       ),
       RdfQuad(
         RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
@@ -259,8 +260,8 @@ object ProtoTestCases:
       RdfNameEntry(0, "subject"),
       RdfNameEntry(0, "predicate"),
       RdfQuad(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
         RdfTerm(RdfTerm.Term.Literal(RdfLiteral("test", RdfLiteral.LiteralKind.Langtag("en-gb")))),
         RdfGraph(RdfGraph.Graph.DefaultGraph(RdfDefaultGraph())),
       ),
@@ -333,9 +334,9 @@ object ProtoTestCases:
       RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfNameEntry(0, "object"),
       RdfTriple(
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 1))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 2))),
-        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 3))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(1, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(0, 0))),
+        RdfTerm(RdfTerm.Term.Iri(RdfIri(2, 0))),
       ),
       RdfDatatypeEntry(0, "https://test.org/xsd/integer"),
       RdfTriple(
@@ -346,7 +347,7 @@ object ProtoTestCases:
       RdfGraphEnd(),
       RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfNameEntry(0, "graph"),
-      RdfGraphStart(RdfGraph(RdfGraph.Graph.Iri(RdfIri(3, 4)))),
+      RdfGraphStart(RdfGraph(RdfGraph.Graph.Iri(RdfIri(3, 0)))),
       RdfTriple(
         TERM_REPEAT,
         TERM_REPEAT,

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/EncoderFlowSpec.scala
@@ -120,11 +120,12 @@ class EncoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
           .withLogicalType(LogicalStreamType.FLAT_TRIPLES)
         )
       )
-      encoded.size should be (4)
+      encoded.size should be (5)
       encoded.head.rows.count(_.row.isTriple) should be (0)
       encoded(1).rows.count(_.row.isTriple) should be (1)
       encoded(2).rows.count(_.row.isTriple) should be (1)
-      encoded(3).rows.count(_.row.isTriple) should be (2)
+      encoded(3).rows.count(_.row.isTriple) should be (1)
+      encoded(4).rows.count(_.row.isTriple) should be (1)
     }
   }
 


### PR DESCRIPTION
Somewhat related to the last PR: #80 

This time I'm changing up the meaning of the default values for references to the lookup tables (not the lookup table entries). Previously for the name and prefix tables, a value of 0 meant "empty string" which is not a very useful thing, this occurs rarely. They both now have a funky repeating behavior that should help with some common patterns in RDF.

For datatypes I've also implemented this, but now I've realized this will conflict with another optimization I want to do later... so I'll probably revert it.