### PR TITLE
Implement max supported stream options in the decoder

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -1,9 +1,17 @@
 package eu.ostrzyciel.jelly.core
 
 import ProtoDecoderImpl.*
-import eu.ostrzyciel.jelly.core.proto.v1.{LogicalStreamType, RdfStreamOptions}
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
 
 import scala.reflect.ClassTag
+
+object ConverterFactory:
+  /**
+   * Convenience method for getting the default supported options for the decoders.
+   *
+   * See: [[eu.ostrzyciel.jelly.core.JellyOptions.defaultSupportedOptions]]
+   */
+  final def defaultSupportedOptions: RdfStreamOptions = JellyOptions.defaultSupportedOptions
 
 /**
  * "Main" trait to be implemented by RDF conversion modules (e.g., for Jena and RDF4J).
@@ -24,50 +32,68 @@ trait ConverterFactory[
   +TDecConv <: ProtoDecoderConverter[TNode, TDatatype, TTriple, TQuad],
   TNode, TDatatype : ClassTag, TTriple, TQuad
 ]:
+  import ConverterFactory.*
+  
   def decoderConverter: TDecConv
 
   /**
    * Create a new [[TriplesDecoder]].
-   * @return
+   * @param supportedOptions maximum supported options for the decoder. If not provided, this.defaultSupportedOptions
+   *                         will be used. If you want to modify this (e.g., to specify an expected logical stream
+   *                         type), you should always use this.defaultSupportedOptions.withXxx.
+   * @return decoder
    */
-  final def triplesDecoder(expLogicalType: Option[LogicalStreamType]): 
+  final def triplesDecoder(supportedOptions: Option[RdfStreamOptions] = None): 
   TriplesDecoder[TNode, TDatatype, TTriple, TQuad] =
-    new TriplesDecoder(decoderConverter, expLogicalType)
+    new TriplesDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions))
 
   /**
    * Create a new [[QuadsDecoder]].
-   * @return
+   * @param supportedOptions maximum supported options for the decoder. If not provided, this.defaultSupportedOptions
+   *                         will be used. If you want to modify this (e.g., to specify an expected logical stream
+   *                         type), you should always use this.defaultSupportedOptions.withXxx.
+   * @return decoder
    */
-  final def quadsDecoder(expLogicalType: Option[LogicalStreamType]): 
+  final def quadsDecoder(supportedOptions: Option[RdfStreamOptions] = None): 
   QuadsDecoder[TNode, TDatatype, TTriple, TQuad] =
-    new QuadsDecoder(decoderConverter, expLogicalType)
+    new QuadsDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions))
 
   /**
    * Create a new [[GraphsAsQuadsDecoder]].
-   * @return
+   * @param supportedOptions maximum supported options for the decoder. If not provided, this.defaultSupportedOptions
+   *                         will be used. If you want to modify this (e.g., to specify an expected logical stream
+   *                         type), you should always use this.defaultSupportedOptions.withXxx.
+   * @return decoder
    */
-  final def graphsAsQuadsDecoder(expLogicalType: Option[LogicalStreamType]): 
+  final def graphsAsQuadsDecoder(supportedOptions: Option[RdfStreamOptions] = None): 
   GraphsAsQuadsDecoder[TNode, TDatatype, TTriple, TQuad] =
-    new GraphsAsQuadsDecoder(decoderConverter, expLogicalType)
+    new GraphsAsQuadsDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions))
 
   /**
    * Create a new [[GraphsDecoder]].
-   * @return
+   * @param supportedOptions maximum supported options for the decoder. If not provided, this.defaultSupportedOptions
+   *                         will be used. If you want to modify this (e.g., to specify an expected logical stream
+   *                         type), you should always use this.defaultSupportedOptions.withXxx.
+   * @return decoder
    */
-  final def graphsDecoder(expLogicalType: Option[LogicalStreamType]): 
+  final def graphsDecoder(supportedOptions: Option[RdfStreamOptions] = None): 
   GraphsDecoder[TNode, TDatatype, TTriple, TQuad] =
-    new GraphsDecoder(decoderConverter, expLogicalType)
+    new GraphsDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions))
 
   /**
    * Create a new [[AnyStatementDecoder]].
-   * @return
+   * @param supportedOptions maximum supported options for the decoder. If not provided, this.defaultSupportedOptions
+   *                         will be used. If you want to modify this (e.g., to specify an expected logical stream
+   *                         type), you should always use this.defaultSupportedOptions.withXxx.
+   * @return decoder
    */
-  final def anyStatementDecoder: AnyStatementDecoder[TNode, TDatatype, TTriple, TQuad] =
-    new AnyStatementDecoder(decoderConverter)
+  final def anyStatementDecoder(supportedOptions: Option[RdfStreamOptions] = None): 
+  AnyStatementDecoder[TNode, TDatatype, TTriple, TQuad] =
+    new AnyStatementDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions))
 
   /**
    * Create a new [[ProtoEncoder]].
    * @param options Jelly serialization options.
-   * @return
+   * @return encoder
    */
   def encoder(options: RdfStreamOptions): TEncoder

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
@@ -61,3 +61,30 @@ object JellyOptions:
     */
   def smallRdfStar: RdfStreamOptions =
     smallStrict.withRdfStar(true)
+
+  /**
+   * Default maximum supported options for Jelly decoders.
+   * 
+   * This means that by default Jelly-JVM will refuse to read streams that exceed these limits (e.g., with a
+   * name lookup table larger than 4096 entries).
+   * 
+   * To change these defaults, you should pass a different RdfStreamOptions object to the decoder.
+   * You should use this method to get the default options and then modify them as needed.
+   * For example, to disable RDF-star support, you can do this:
+   * <code>
+   * val myOptions = JellyOptions.defaultSupportedOptions.withRdfStar(false)
+   * </code>
+   * 
+   * If you were to pass a default RdfStreamOptions object to the decoder, it would simply refuse to read any stream
+   * as (by default) it will have all max table sizes set to 0. So, you should always use this method as the base.
+   * 
+   * @return
+   */
+  def defaultSupportedOptions: RdfStreamOptions = RdfStreamOptions(
+    generalizedStatements = true,
+    rdfStar = true,
+    maxNameTableSize = 4096,
+    maxPrefixTableSize = 1024,
+    maxDatatypeTableSize = 256,
+    version = Constants.protoVersion,
+  )

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -59,14 +59,14 @@ trait ProtoDecoder[+TOut]:
       
     def checkTableSize(name: String, size: Int, supportedSize: Int): Unit =
       if size > supportedSize then
-        throw new RdfProtoDeserializationError(s"The stream uses a $name table size of $size, which is larger than " +
-          s"the maximum supported size of $supportedSize. To read this stream, set max${name}TableSize to at least " +
-          s"$size in the supportedOptions for this decoder."
+        throw new RdfProtoDeserializationError(s"The stream uses a ${name.toLowerCase} table size of $size, which is " +
+          s"larger than the maximum supported size of $supportedSize. To read this stream, set max${name}TableSize " +
+          s"to at least $size in the supportedOptions for this decoder."
         )
       
-    checkTableSize("name", options.maxNameTableSize, supportedOptions.maxNameTableSize)
-    checkTableSize("prefix", options.maxPrefixTableSize, supportedOptions.maxPrefixTableSize)
-    checkTableSize("datatype", options.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize)
+    checkTableSize("Name", options.maxNameTableSize, supportedOptions.maxNameTableSize)
+    checkTableSize("Prefix", options.maxPrefixTableSize, supportedOptions.maxPrefixTableSize)
+    checkTableSize("Datatype", options.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize)
       
     checkLogicalStreamType(options, supportedOptions.logicalType)
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -15,11 +15,67 @@ trait ProtoDecoder[+TOut]:
   def ingestRow(row: RdfStreamRow): Option[TOut]
 
   /**
+   * Checks if the stream options are supported by the decoder.
+   * Throws an exception if not.
+   * 
+   * This MUST be called before any data (besides the stream options) is ingested. Otherwise, the options may
+   * request something dangerous, like allocating a very large lookup table, which could be used to perform a
+   * denial-of-service attack.
+   * 
+   * We check:
+   * - version (must be <= Constants.protoVersion and <= supportedOptions.version)
+   * - generalized statements (must be <= supportedOptions.generalizedStatements)
+   * - RDF star (must be <= supportedOptions.rdfStar)
+   * - max name table size (must be <= supportedOptions.maxNameTableSize).
+   * - max prefix table size (must be <= supportedOptions.maxPrefixTableSize)
+   * - max datatype table size (must be <= supportedOptions.maxDatatypeTableSize)
+   * - logical stream type (must be compatible with physical stream type and compatible with expected log. stream type)
+   * 
+   * We don't check:
+   * - physical stream type (this is done by the implementations of ProtoDecoderImpl)
+   * - stream name (we don't care about it)
+   * 
+   * See also the stream options handling table in the gRPC spec: 
+   * https://jelly-rdf.github.io/1.0/specification/streaming/#stream-options-handling
+   * This is not exactly what we are doing here (the table is about client-server interactions), but it's a good
+   * reference for the logic used here.
+   * 
+   * @param options Options of the stream.
+   * @param supportedOptions Options supported by the decoder.
+   */
+  protected final def checkOptions(options: RdfStreamOptions, supportedOptions: RdfStreamOptions): Unit =
+    if options.version > supportedOptions.version || options.version > Constants.protoVersion then
+      throw new RdfProtoDeserializationError(s"Unsupported proto version: ${options.version}. " +
+        s"Was expecting at most version ${supportedOptions.version}. " +
+        s"This library version supports up to version ${Constants.protoVersion}.")
+      
+    if options.generalizedStatements && !supportedOptions.generalizedStatements then
+      throw new RdfProtoDeserializationError(s"The stream uses generalized statements, which the user marked as not " + 
+        s"supported. To read this stream, set generalizedStatements to true in the supportedOptions for this decoder.")
+      
+    if options.rdfStar && !supportedOptions.rdfStar then
+      throw new RdfProtoDeserializationError(s"The stream uses RDF-star, which the user marked as not supported. " +
+        s"To read this stream, set rdfStar to true in the supportedOptions for this decoder.")
+      
+    def checkTableSize(name: String, size: Int, supportedSize: Int): Unit =
+      if size > supportedSize then
+        throw new RdfProtoDeserializationError(s"The stream uses a $name table size of $size, which is larger than " +
+          s"the maximum supported size of $supportedSize. To read this stream, set max${name}TableSize to at least " +
+          s"$size in the supportedOptions for this decoder."
+        )
+      
+    checkTableSize("name", options.maxNameTableSize, supportedOptions.maxNameTableSize)
+    checkTableSize("prefix", options.maxPrefixTableSize, supportedOptions.maxPrefixTableSize)
+    checkTableSize("datatype", options.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize)
+      
+    checkLogicalStreamType(options, supportedOptions.logicalType)
+
+  /**
    * Checks if the version of the stream is supported.
    * Throws an exception if not.
    * @param options Options of the stream.
    */
-  protected final def checkVersion(options: RdfStreamOptions): Unit =
+  private def checkVersion(options: RdfStreamOptions): Unit =
     if options.version > Constants.protoVersion then
       throw new RdfProtoDeserializationError(s"Unsupported proto version: ${options.version}")
 
@@ -27,9 +83,9 @@ trait ProtoDecoder[+TOut]:
    * Checks if the logical and physical stream types are compatible. Additionally, if the expected logical stream type
    * is provided, checks if the actual logical stream type is a subtype of the expected one.
    * @param options Options of the stream.
-   * @param expLogicalType Expected logical stream type.
+   * @param expLogicalType Expected logical stream type. If UNSPECIFIED, no check is performed.
    */
-  protected final def checkLogicalStreamType(options: RdfStreamOptions, expLogicalType: Option[LogicalStreamType]):
+  private def checkLogicalStreamType(options: RdfStreamOptions, expLogicalType: LogicalStreamType):
   Unit =
     val baseLogicalType = options.logicalType.toBaseType
 
@@ -56,8 +112,8 @@ trait ProtoDecoder[+TOut]:
         s"physical stream type ${options.physicalType}.")
 
     expLogicalType match
-      case Some(v) =>
+      case LogicalStreamType.UNSPECIFIED => ()
+      case v =>
         if !options.logicalType.isEqualOrSubtypeOf(v) then
           throw new RdfProtoDeserializationError(s"Expected logical stream type $v, got ${options.logicalType}. " +
             s"${options.logicalType} is not a subtype of $v.")
-      case None =>

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -70,14 +70,6 @@ trait ProtoDecoder[+TOut]:
       
     checkLogicalStreamType(options, supportedOptions.logicalType)
 
-  /**
-   * Checks if the version of the stream is supported.
-   * Throws an exception if not.
-   * @param options Options of the stream.
-   */
-  private def checkVersion(options: RdfStreamOptions): Unit =
-    if options.version > Constants.protoVersion then
-      throw new RdfProtoDeserializationError(s"Unsupported proto version: ${options.version}")
 
   /**
    * Checks if the logical and physical stream types are compatible. Additionally, if the expected logical stream type

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/DecoderSupportedOptions.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/DecoderSupportedOptions.scala
@@ -1,0 +1,6 @@
+package eu.ostrzyciel.jelly.examples
+
+object DecoderSupportedOptions {
+// TODO
+
+}

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/DecoderSupportedOptions.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/DecoderSupportedOptions.scala
@@ -1,6 +1,0 @@
-package eu.ostrzyciel.jelly.examples
-
-object DecoderSupportedOptions {
-// TODO
-
-}

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoGrpc.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoGrpc.scala
@@ -130,7 +130,7 @@ object PekkoGrpc extends shared.Example:
         Some(JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.GRAPHS))
       ))
       // Decode the response and transform it into a stream of quads
-      .via(DecoderFlow.decodeGraphs.asDatasetStreamOfQuads())
+      .via(DecoderFlow.decodeGraphs.asDatasetStreamOfQuads)
       .mapConcat(identity)
       .runFold(0L)((acc, _) => acc + 1)
       // Process the result of the stream (Future[Long])
@@ -150,7 +150,7 @@ object PekkoGrpc extends shared.Example:
         "weather",
         Some(JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.TRIPLES))
       ))
-      .via(DecoderFlow.decodeTriples.asFlatTripleStream())
+      .via(DecoderFlow.decodeTriples.asFlatTripleStream)
       .runFold(0L)((acc, _) => acc + 1)
       .map { counter =>
         println(s"[CLIENT] Received $counter triples.")

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoGrpc.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoGrpc.scala
@@ -111,7 +111,7 @@ object PekkoGrpc extends shared.Example:
         "weather",
         Some(JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.QUADS))
       ))
-      .via(DecoderFlow.decodeQuads.asFlatQuadStream(strict = true))
+      .via(DecoderFlow.decodeQuads.asFlatQuadStreamStrict)
       .runFold(0L)((acc, _) => acc + 1)
       // Process the result of the stream (Future[Long])
       .map { counter =>

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoStreamsWithIo.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/PekkoStreamsWithIo.scala
@@ -49,7 +49,7 @@ object PekkoStreamsWithIo extends shared.Example:
       val decodedTriplesFuture = JellyIo.fromIoStream(inputStream)
         // Decode the Jelly frames to triples.
         // Under the hood it uses the RdfStreamFrame.parseDelimitedFrom method.
-        .via(DecoderFlow.decodeTriples.asFlatTripleStream())
+        .via(DecoderFlow.decodeTriples.asFlatTripleStream)
         .runWith(Sink.seq)
 
       Await.result(decodedTriplesFuture, 10.seconds)

--- a/examples/src/main/scala/eu/ostrzyciel/jelly/examples/Rdf4jRio.scala
+++ b/examples/src/main/scala/eu/ostrzyciel/jelly/examples/Rdf4jRio.scala
@@ -1,8 +1,8 @@
 package eu.ostrzyciel.jelly.examples
 
 import eu.ostrzyciel.jelly.convert.rdf4j.rio.*
-import eu.ostrzyciel.jelly.core.JellyOptions
-import eu.ostrzyciel.jelly.core.proto.v1.PhysicalStreamType
+import eu.ostrzyciel.jelly.core.*
+import eu.ostrzyciel.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamOptions}
 import org.eclipse.rdf4j.model.Statement
 import org.eclipse.rdf4j.rio.helpers.StatementCollector
 import org.eclipse.rdf4j.rio.{RDFFormat, Rio}
@@ -20,7 +20,7 @@ object Rdf4jRio extends shared.Example:
   def main(args: Array[String]): Unit =
     // Load the RDF graph from an N-Triples file
     val inputFile = File(getClass.getResource("/weather.nt").toURI)
-    val triples = readRdf4j(inputFile, RDFFormat.TURTLE)
+    val triples = readRdf4j(inputFile, RDFFormat.TURTLE, None)
 
     // Print the size of the graph
     println(s"Loaded ${triples.size} triples from an N-Triples file")
@@ -48,22 +48,44 @@ object Rdf4jRio extends shared.Example:
 
     // Load the RDF graph from the Jelly file
     val jellyFile = File("weather.jelly")
-    val jellyTriples = readRdf4j(jellyFile, JELLY)
+    val jellyTriples = readRdf4j(jellyFile, JELLY, None)
 
     // Print the size of the graph
     println(s"Loaded ${jellyTriples.size} triples from a Jelly file")
+
+    // ---------------------------------
+    println("\n")
+    // By default, the parser has limits on for example the maximum size of the lookup tables.
+    // The default supported options are [[JellyOptions.defaultSupportedOptions]].
+    // You can change these limits by creating your own options object.
+    val customOptions = JellyOptions.defaultSupportedOptions
+      .withMaxPrefixTableSize(10) // set the maximum size of the prefix table to 10
+    println("Trying to read the Jelly file with custom options...")
+    try
+      // This operation should fail because the Jelly file uses a prefix table larger than 10
+      val customTriples = readRdf4j(jellyFile, JELLY, Some(customOptions))
+    catch
+      case e: RdfProtoDeserializationError =>
+        // The stream uses a prefix table size of 16, which is larger than the maximum supported size of 10.
+        // To read this stream, set maxPrefixTableSize to at least 16 in the supportedOptions for this decoder.
+        println(s"Failed to read the Jelly file with custom options: ${e.getMessage}")
 
 
   /**
    * Helper function to read RDF data using RDF4J's Rio library.
    * @param file file to read from
    * @param format RDF format
+   * @param supportedOptions supported options for reading Jelly streams (optional)
    * @return sequence of RDF statements
    */
-  private def readRdf4j(file: File, format: RDFFormat): Seq[Statement] =
+  private def readRdf4j(file: File, format: RDFFormat, supportedOptions: Option[RdfStreamOptions]): Seq[Statement] =
     val parser = Rio.createParser(format)
     val collector = new StatementCollector()
     parser.setRDFHandler(collector)
+    supportedOptions.foreach(opt =>
+      // If the user provided supported options, set them on the parser
+      parser.setParserConfig(JellyParserSettings.configFromOptions(opt))
+    )
     Using.resource(file.toURI.toURL.openStream()) { is =>
       parser.parse(is)
     }

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/JenaTestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/JenaTestStream.scala
@@ -35,18 +35,18 @@ case object JenaTestStream extends TestStream:
 
   override def tripleSink(os: OutputStream)(using ExecutionContext) =
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeTriples.asFlatTripleStream())
+      .via(DecoderFlow.decodeTriples.asFlatTripleStream)
       // buffer the triples to avoid OOMs and keep some perf
       .grouped(32)
       .toMat(Sink.foreach(triples => RDFDataMgr.writeTriples(os, triples.iterator.asJava)))(Keep.right)
 
   override def quadSink(os: OutputStream)(using ExecutionContext) =
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeQuads.asFlatQuadStream())
+      .via(DecoderFlow.decodeQuads.asFlatQuadStream)
       .grouped(32)
       .toMat(Sink.foreach(quads => RDFDataMgr.writeQuads(os, quads.iterator.asJava)))(Keep.right)
 
   override def graphSink(os: OutputStream)(using ExecutionContext) =
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeGraphs.asDatasetStreamOfQuads())
+      .via(DecoderFlow.decodeGraphs.asDatasetStreamOfQuads)
       .toMat(Sink.foreach(quads => RDFDataMgr.writeQuads(os, quads.iterator.asJava)))(Keep.right)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/Rdf4jTestStream.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/Rdf4jTestStream.scala
@@ -46,7 +46,7 @@ case object Rdf4jTestStream extends TestStream:
     val writer = Rio.createWriter(RDFFormat.TURTLESTAR, os)
     writer.startRDF()
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeTriples.asFlatTripleStream())
+      .via(DecoderFlow.decodeTriples.asFlatTripleStream)
       .toMat(Sink.foreach(st => writer.handleStatement(st)))(Keep.right)
       .mapMaterializedValue(f => f.map(_ => {
         writer.endRDF()
@@ -57,7 +57,7 @@ case object Rdf4jTestStream extends TestStream:
     val writer = Rio.createWriter(RDFFormat.NQUADS, os)
     writer.startRDF()
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeQuads.asFlatQuadStream())
+      .via(DecoderFlow.decodeQuads.asFlatQuadStream)
       .toMat(Sink.foreach(st => writer.handleStatement(st)))(Keep.right)
       .mapMaterializedValue(f => f.map(_ => {
         writer.endRDF()
@@ -68,7 +68,7 @@ case object Rdf4jTestStream extends TestStream:
     val writer = Rio.createWriter(RDFFormat.NQUADS, os)
     writer.startRDF()
     Flow[RdfStreamFrame]
-      .via(DecoderFlow.decodeGraphs.asFlatQuadStream())
+      .via(DecoderFlow.decodeGraphs.asFlatQuadStream)
       .toMat(Sink.foreach(st => writer.handleStatement(st)))(Keep.right)
       .mapMaterializedValue(f => f.map(_ => {
         writer.endRDF()

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaReactiveSerDes.scala
@@ -17,20 +17,22 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
 
   override def readTriplesW3C(is: InputStream) = JenaSerDes.readTriplesW3C(is)
 
-  def readQuadsW3C(is: InputStream): Dataset = JenaSerDes.readQuadsW3C(is)
+  override def readQuadsW3C(is: InputStream): Dataset = JenaSerDes.readQuadsW3C(is)
 
-  def readQuadsJelly(is: InputStream): Dataset = JenaSerDes.readQuadsJelly(is)
+  override def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Dataset = 
+    JenaSerDes.readQuadsJelly(is, supportedOptions)
 
-  def readTriplesJelly(is: InputStream): Model = JenaSerDes.readTriplesJelly(is)
+  override def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Model = 
+    JenaSerDes.readTriplesJelly(is, supportedOptions)
 
-  def writeQuadsJelly
+  override def writeQuadsJelly
   (os: OutputStream, dataset: Dataset, opt: RdfStreamOptions, frameSize: Int): Unit =
     val f = EncoderSource.fromDatasetAsQuads(dataset, ByteSizeLimiter(32_000), opt)
       (using jenaIterableAdapter, jenaConverterFactory)
       .runWith(JellyIo.toIoStream(os))
     Await.ready(f, 10.seconds)
 
-  def writeTriplesJelly
+  override def writeTriplesJelly
   (os: OutputStream, model: Model, opt: RdfStreamOptions, frameSize: Int): Unit =
     val f = EncoderSource.fromGraph(model, ByteSizeLimiter(32_000), opt)
       (using jenaIterableAdapter, jenaConverterFactory)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
@@ -1,13 +1,14 @@
 package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.jena.riot.{JellyFormatVariant, JellyLanguage}
+import eu.ostrzyciel.jelly.core.JellyOptions
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
 import org.apache.jena.query.{Dataset, DatasetFactory}
 import org.apache.jena.rdf.model.{Model, ModelFactory}
-import org.apache.jena.riot.{RDFDataMgr, RDFFormat, RDFLanguages}
+import org.apache.jena.riot.*
 
 import java.io.{InputStream, OutputStream}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 given Measure[Model] = (m: Model) => m.size()
 given Measure[Dataset] = (ds: Dataset) => ds.asDatasetGraph().find().asScala.size
@@ -25,14 +26,26 @@ object JenaSerDes extends NativeSerDes[Model, Dataset]:
     RDFDataMgr.read(ds, is, RDFLanguages.NQUADS)
     ds
 
-  def readQuadsJelly(is: InputStream): Dataset =
+  def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Dataset =
+    val context = RIOT.getContext.copy()
+      .set(JellyLanguage.SYMBOL_SUPPORTED_OPTIONS, supportedOptions.getOrElse(JellyOptions.defaultSupportedOptions))
     val ds = DatasetFactory.create()
-    RDFDataMgr.read(ds, is, JellyLanguage.JELLY)
+    RDFParser.create()
+      .source(is)
+      .lang(JellyLanguage.JELLY)
+      .context(context)
+      .parse(ds)
     ds
 
-  def readTriplesJelly(is: InputStream): Model =
+  def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Model =
+    val context = RIOT.getContext.copy()
+      .set(JellyLanguage.SYMBOL_SUPPORTED_OPTIONS, supportedOptions.getOrElse(JellyOptions.defaultSupportedOptions))
     val m = ModelFactory.createDefaultModel()
-    RDFDataMgr.read(m, is, JellyLanguage.JELLY)
+    RDFParser.create()
+      .source(is)
+      .lang(JellyLanguage.JELLY)
+      .context(context)
+      .parse(m)
     m
 
   def writeQuadsJelly

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
@@ -1,6 +1,7 @@
 package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.jena.riot.JellyLanguage
+import eu.ostrzyciel.jelly.core.JellyOptions
 import eu.ostrzyciel.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamOptions}
 import org.apache.jena.graph.Triple
 import org.apache.jena.riot.system.{StreamRDFLib, StreamRDFWriter}
@@ -33,17 +34,23 @@ object JenaStreamSerDes extends NativeSerDes[Seq[Triple], Seq[Quad]]:
       .parse(StreamRDFLib.sinkQuads(sink))
     sink.result
 
-  override def readTriplesJelly(is: InputStream): Seq[Triple] =
+  override def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Seq[Triple] =
+    val context = RIOT.getContext.copy()
+      .set(JellyLanguage.SYMBOL_SUPPORTED_OPTIONS, supportedOptions.getOrElse(JellyOptions.defaultSupportedOptions))
     val sink = SinkSeq[Triple]()
     RDFParser.source(is)
       .lang(JellyLanguage.JELLY)
+      .context(context)
       .parse(StreamRDFLib.sinkTriples(sink))
     sink.result
 
-  override def readQuadsJelly(is: InputStream): Seq[Quad] =
+  override def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Seq[Quad] =
+    val context = RIOT.getContext.copy()
+      .set(JellyLanguage.SYMBOL_SUPPORTED_OPTIONS, supportedOptions.getOrElse(JellyOptions.defaultSupportedOptions))
     val sink = SinkSeq[Quad]()
     RDFParser.source(is)
       .lang(JellyLanguage.JELLY)
+      .context(context)
       .parse(StreamRDFLib.sinkQuads(sink))
     sink.result
 

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
@@ -15,7 +15,7 @@ trait NativeSerDes[TModel : Measure, TDataset : Measure]:
   def name: String
   def readTriplesW3C(is: InputStream): TModel
   def readQuadsW3C(is: InputStream): TDataset
-  def readTriplesJelly(is: InputStream): TModel
-  def readQuadsJelly(is: InputStream): TDataset
+  def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): TModel
+  def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): TDataset
   def writeTriplesJelly(os: OutputStream, model: TModel, opt: RdfStreamOptions, frameSize: Int): Unit
   def writeQuadsJelly(os: OutputStream, dataset: TDataset, opt: RdfStreamOptions, frameSize: Int): Unit

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
@@ -30,6 +30,17 @@ object JellyLanguage:
   val SYMBOL_STREAM_OPTIONS: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "streamOptions")
 
   /**
+   * Symbol for the maximum supported options of the Jelly parser. Use this to for example allow for decoding Jelly
+   * files with very large lookup tables or to disable RDF-star support.
+   * 
+   * Set this in Jena's Context to instances of [[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions]].
+   * 
+   * You should always first obtain the default supported options from 
+   * [[eu.ostrzyciel.jelly.core.JellyOptions.defaultSupportedOptions]] and then modify them as needed.
+   */
+  val SYMBOL_SUPPORTED_OPTIONS: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "supportedOptions")
+
+  /**
    * Symbol for the frame size to be used when writing RDF data.
    *
    * Set this in Jena's Context to an integer (not long!) value.

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
@@ -22,7 +22,7 @@ object JellyReader extends ReaderRIOT:
       "Please use an InputStream.")
 
   override def read(in: InputStream, baseURI: String, ct: ContentType, output: StreamRDF, context: Context): Unit =
-    val decoder = JenaConverterFactory.anyStatementDecoder
+    val decoder = JenaConverterFactory.anyStatementDecoder()
     output.start()
     try {
       while in.available() > 0 do

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
@@ -2,7 +2,8 @@ package eu.ostrzyciel.jelly.convert.jena.riot
 
 import eu.ostrzyciel.jelly.convert.jena.JenaConverterFactory
 import eu.ostrzyciel.jelly.core.Constants.*
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
 import org.apache.jena.atlas.web.ContentType
 import org.apache.jena.graph.Triple
 import org.apache.jena.riot.adapters.RDFReaderRIOT
@@ -14,15 +15,20 @@ import org.apache.jena.sparql.util.Context
 import java.io.{InputStream, Reader}
 
 object JellyReaderFactory extends ReaderRIOTFactory:
-  override def create(language: Lang, profile: ParserProfile) = JellyReader
+  override def create(language: Lang, profile: ParserProfile): JellyReader.type = JellyReader
 
 object JellyReader extends ReaderRIOT:
   override def read(reader: Reader, baseURI: String, ct: ContentType, output: StreamRDF, context: Context): Unit =
     throw new RiotException("RDF Jelly: Reading binary data from a java.io.Reader is not supported. " +
       "Please use an InputStream.")
-
+  
+  
   override def read(in: InputStream, baseURI: String, ct: ContentType, output: StreamRDF, context: Context): Unit =
-    val decoder = JenaConverterFactory.anyStatementDecoder()
+    // Get the supported options specified by the user in the context -- or the default if not available
+    val supportedOptions = context.get[RdfStreamOptions](
+      JellyLanguage.SYMBOL_SUPPORTED_OPTIONS, JellyOptions.defaultSupportedOptions
+    )
+    val decoder = JenaConverterFactory.anyStatementDecoder(Some(supportedOptions))
     output.start()
     try {
       while in.available() > 0 do

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
@@ -7,7 +7,7 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser
 import java.io.{InputStream, Reader}
 
 final class JellyParser extends AbstractRDFParser:
-  private val decoder = Rdf4jConverterFactory.anyStatementDecoder
+  private val decoder = Rdf4jConverterFactory.anyStatementDecoder()
 
   override def getRDFFormat = JELLY
 

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
@@ -1,18 +1,41 @@
 package eu.ostrzyciel.jelly.convert.rdf4j.rio
 
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
+import org.eclipse.rdf4j.rio.{RDFFormat, RioSetting}
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser
 
 import java.io.{InputStream, Reader}
+import java.util
 
 final class JellyParser extends AbstractRDFParser:
-  private val decoder = Rdf4jConverterFactory.anyStatementDecoder()
+  import JellyParserSettings.*
 
-  override def getRDFFormat = JELLY
+  override def getRDFFormat: RDFFormat = JELLY
+
+  override def getSupportedSettings: util.HashSet[RioSetting[_]] =
+    val s = new util.HashSet[RioSetting[_]](super.getSupportedSettings)
+    s.add(PROTO_VERSION)
+    s.add(ALLOW_GENERALIZED_STATEMENTS)
+    s.add(ALLOW_RDF_STAR)
+    s.add(MAX_NAME_TABLE_SIZE)
+    s.add(MAX_PREFIX_TABLE_SIZE)
+    s.add(MAX_DATATYPE_TABLE_SIZE)
+    s
 
   override def parse(in: InputStream, baseURI: String): Unit =
     if (in == null) throw new IllegalArgumentException("Input stream must not be null")
+
+    val config = getParserConfig
+    val decoder = Rdf4jConverterFactory.anyStatementDecoder(Some(RdfStreamOptions(
+      generalizedStatements = config.get(ALLOW_GENERALIZED_STATEMENTS).booleanValue(),
+      rdfStar = config.get(ALLOW_RDF_STAR).booleanValue(),
+      maxNameTableSize = config.get(MAX_NAME_TABLE_SIZE).toInt,
+      maxPrefixTableSize = config.get(MAX_PREFIX_TABLE_SIZE).toInt,
+      maxDatatypeTableSize = config.get(MAX_DATATYPE_TABLE_SIZE).toInt,
+      version = config.get(PROTO_VERSION).toInt,
+    )))
+
     rdfHandler.startRDF()
     try {
       while in.available() > 0 do

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParserSettings.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParserSettings.scala
@@ -1,66 +1,56 @@
 package eu.ostrzyciel.jelly.convert.rdf4j.rio
 
-import eu.ostrzyciel.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamOptions}
-import org.eclipse.rdf4j.rio.WriterConfig
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import org.eclipse.rdf4j.rio.ParserConfig
 import org.eclipse.rdf4j.rio.helpers.*
 
-object JellyWriterSettings:
-  def configFromOptions(opt: RdfStreamOptions, frameSize: Long = 256L): WriterConfig =
-    val c = new WriterConfig()
-    c.set(FRAME_SIZE, frameSize)
-    c.set(STREAM_NAME, opt.streamName)
-    c.set(PHYSICAL_TYPE, opt.physicalType)
+object JellyParserSettings:
+  val defaultOptions: RdfStreamOptions = JellyOptions.defaultSupportedOptions
+
+  def configFromOptions(opt: RdfStreamOptions): ParserConfig =
+    val c = new ParserConfig()
+    c.set(PROTO_VERSION, opt.version.toLong)
     c.set(ALLOW_GENERALIZED_STATEMENTS, opt.generalizedStatements)
     c.set(ALLOW_RDF_STAR, opt.rdfStar)
     c.set(MAX_NAME_TABLE_SIZE, opt.maxNameTableSize.toLong)
     c.set(MAX_PREFIX_TABLE_SIZE, opt.maxPrefixTableSize.toLong)
     c.set(MAX_DATATYPE_TABLE_SIZE, opt.maxDatatypeTableSize.toLong)
     c
-  
-  val FRAME_SIZE = new LongRioSetting(
-    "eu.ostrzyciel.jelly.convert.rdf4j.rio.frameSize",
-    "Target RDF frame size",
-    256L
-  )
 
-  val STREAM_NAME = new StringRioSetting(
-    "eu.ostrzyciel.jelly.convert.rdf4j.rio.streamName",
-    "Stream name",
-    ""
-  )
-
-  val PHYSICAL_TYPE = new ClassRioSetting[PhysicalStreamType](
-    "eu.ostrzyciel.jelly.convert.rdf4j.rio.physicalType",
-    "Physical stream type",
-    PhysicalStreamType.TRIPLES
+  val PROTO_VERSION = new LongRioSetting(
+    "eu.ostrzyciel.jelly.convert.rdf4j.rio.protoVersion",
+    "Maximum supported Jelly protocol version",
+    defaultOptions.version.toLong
   )
 
   val ALLOW_GENERALIZED_STATEMENTS = new BooleanRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.allowGeneralizedStatements",
-    "Allow generalized statements",
-    false
+    "Allow decoding generalized statements",
+    defaultOptions.generalizedStatements
   )
-  
+
   val ALLOW_RDF_STAR = new BooleanRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.allowRdfStar",
-    "Allow RDF-star statements",
-    false
+    "Allow decoding RDF-star statements",
+    defaultOptions.rdfStar
   )
 
   val MAX_NAME_TABLE_SIZE = new LongRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.maxNameTableSize",
     "Maximum size of the name table",
-    128L
+    defaultOptions.maxNameTableSize.toLong
   )
 
   val MAX_PREFIX_TABLE_SIZE = new LongRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.maxPrefixTableSize",
     "Maximum size of the prefix table",
-    16L
+    defaultOptions.maxPrefixTableSize.toLong
   )
 
   val MAX_DATATYPE_TABLE_SIZE = new LongRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.maxDatatypeTableSize",
     "Maximum size of the datatype table",
-    16L
+    defaultOptions.maxDatatypeTableSize.toLong
   )
+

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
@@ -3,7 +3,7 @@ package eu.ostrzyciel.jelly.convert.rdf4j.rio
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jProtoEncoder
 import eu.ostrzyciel.jelly.core.proto.v1.{LogicalStreamType, RdfStreamFrame, RdfStreamOptions, RdfStreamRow}
 import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.rio.RioSetting
+import org.eclipse.rdf4j.rio.{RDFFormat, RioSetting}
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter
 
 import java.io.OutputStream
@@ -20,9 +20,9 @@ final class JellyWriter(out: OutputStream) extends AbstractRDFWriter:
   private val buffer: ArrayBuffer[RdfStreamRow] = new ArrayBuffer[RdfStreamRow]()
   private var frameSize: Long = 256L
 
-  override def getRDFFormat = JELLY
+  override def getRDFFormat: RDFFormat = JELLY
 
-  override def getSupportedSettings =
+  override def getSupportedSettings: util.HashSet[RioSetting[_]] =
     val s = new util.HashSet[RioSetting[_]](super.getSupportedSettings)
     s.add(STREAM_NAME)
     s.add(PHYSICAL_TYPE)

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterFactory.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterFactory.scala
@@ -1,16 +1,16 @@
 package eu.ostrzyciel.jelly.convert.rdf4j.rio
 
-import org.eclipse.rdf4j.rio.RDFWriterFactory
+import org.eclipse.rdf4j.rio.{RDFFormat, RDFWriter, RDFWriterFactory}
 
 import java.io.{OutputStream, Writer}
 
 final class JellyWriterFactory extends RDFWriterFactory:
-  override def getRDFFormat = JELLY
+  override def getRDFFormat: RDFFormat = JELLY
 
-  override def getWriter(out: OutputStream) = JellyWriter(out)
+  override def getWriter(out: OutputStream): JellyWriter = JellyWriter(out)
 
-  override def getWriter(out: OutputStream, baseURI: String) = getWriter(out)
+  override def getWriter(out: OutputStream, baseURI: String): JellyWriter = getWriter(out)
 
-  override def getWriter(writer: Writer) = throw new UnsupportedOperationException
+  override def getWriter(writer: Writer): RDFWriter = throw new UnsupportedOperationException
 
-  override def getWriter(writer: Writer, baseURI: String) = throw new UnsupportedOperationException
+  override def getWriter(writer: Writer, baseURI: String): RDFWriter = throw new UnsupportedOperationException

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
@@ -67,6 +67,7 @@ object DecoderFlow:
       .mapConcat(frame => frame.rows)
       .mapConcat(row => decoder.ingestRow(row))
 
+
   private def groupedStream[TOut](decoder: ProtoDecoder[TOut]):
   Flow[RdfStreamFrame, IterableOnce[TOut], NotUsed] =
     Flow[RdfStreamFrame]

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/DecoderFlow.scala
@@ -87,15 +87,17 @@ object DecoderFlow:
       InterpretableAs.FlatTripleStream,
       InterpretableAs.GraphStream:
 
-      override def asFlatTripleStream[TTriple](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asFlatTripleStream[TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
       Flow[RdfStreamFrame, TTriple, NotUsed] =
-        flatStream(factory.triplesDecoder(s(strict, LogicalStreamType.FLAT_TRIPLES)))
+        flatStream(factory.triplesDecoder(Some(supportedOptions)))
 
-      override def asGraphStream[TTriple](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asGraphStream[TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
       Flow[RdfStreamFrame, IterableOnce[TTriple], NotUsed] =
-        groupedStream(factory.triplesDecoder(s(strict, LogicalStreamType.GRAPHS)))
+        groupedStream(factory.triplesDecoder(Some(supportedOptions)))
 
     end TriplesIngestFlowOps
 
@@ -107,15 +109,17 @@ object DecoderFlow:
       InterpretableAs.FlatQuadStream,
       InterpretableAs.DatasetStreamOfQuads:
 
-      override def asFlatQuadStream[TQuad](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asFlatQuadStream[TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
       Flow[RdfStreamFrame, TQuad, NotUsed] =
-        flatStream(factory.quadsDecoder(s(strict, LogicalStreamType.FLAT_QUADS)))
+        flatStream(factory.quadsDecoder(Some(supportedOptions)))
 
-      override def asDatasetStreamOfQuads[TQuad](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asDatasetStreamOfQuads[TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
       Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed] =
-        groupedStream(factory.quadsDecoder(s(strict, LogicalStreamType.DATASETS)))
+        groupedStream(factory.quadsDecoder(Some(supportedOptions)))
 
     end QuadsIngestFlowOps
 
@@ -128,25 +132,29 @@ object DecoderFlow:
       InterpretableAs.DatasetStreamOfQuads,
       InterpretableAs.DatasetStream:
 
-      override def asFlatQuadStream[TQuad](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asFlatQuadStream[TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
       Flow[RdfStreamFrame, TQuad, NotUsed] =
-        flatStream(factory.graphsAsQuadsDecoder(s(strict, LogicalStreamType.FLAT_QUADS)))
+        flatStream(factory.graphsAsQuadsDecoder(Some(supportedOptions)))
 
-      override def asDatasetStreamOfQuads[TQuad](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asDatasetStreamOfQuads[TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
       Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed] =
-        groupedStream(factory.graphsAsQuadsDecoder(s(strict, LogicalStreamType.DATASETS)))
+        groupedStream(factory.graphsAsQuadsDecoder(Some(supportedOptions)))
 
-      override def asDatasetStream[TNode, TTriple](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asDatasetStream[TNode, TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
       Flow[RdfStreamFrame, IterableOnce[(TNode, Iterable[TTriple])], NotUsed] =
-        groupedStream(factory.graphsDecoder(s(strict, LogicalStreamType.DATASETS)))
+        groupedStream(factory.graphsDecoder(Some(supportedOptions)))
 
-      override def asNamedGraphStream[TNode, TTriple](strict: Boolean = false)
+      /** @inheritdoc */
+      override def asNamedGraphStream[TNode, TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
       Flow[RdfStreamFrame, (TNode, Iterable[TTriple]), NotUsed] =
-        flatStream(factory.graphsDecoder(s(strict, LogicalStreamType.NAMED_GRAPHS)))
+        flatStream(factory.graphsDecoder(Some(supportedOptions)))
 
     end GraphsIngestFlowOps
 
@@ -157,111 +165,309 @@ object DecoderFlow:
       DecoderIngestFlowOps,
       InterpretableAs.AnyStream:
 
-      override def asGroupedStream[TNode, TTriple, TQuad]
+      /** @inheritdoc */
+      override def asGroupedStream[TNode, TTriple, TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, TQuad]):
       Flow[RdfStreamFrame, IterableOnce[TTriple | TQuad], NotUsed] =
-        groupedStream(factory.anyStatementDecoder)
+        groupedStream(factory.anyStatementDecoder(Some(supportedOptions)))
 
-      override def asFlatStream[TTriple, TQuad]
+      /** @inheritdoc */
+      override def asFlatStream[TTriple, TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, TTriple, TQuad]):
       Flow[RdfStreamFrame, TTriple | TQuad, NotUsed] =
-        flatStream(factory.anyStatementDecoder)
+        flatStream(factory.anyStatementDecoder(Some(supportedOptions)))
 
 
+  
   private object InterpretableAs:
     trait FlatTripleStream:
       /**
        * Interpret the incoming stream as a flat RDF triple stream from RDF-STaX.
        *
-       * @param strict If true, the incoming stream must have its logical type set to FLAT_TRIPLES or its subtype,
-       *               otherwise the decoding will fail.
+       * The incoming stream must have its logical type set to FLAT_TRIPLES or its subtype, 
+       * otherwise the decoding will fail. To allow for any logical type, use .asFlatTripleStream.
+       * 
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TTriple Type of triple statements.
        * @return Pekko Streams flow
        */
-      def asFlatTripleStream[TTriple](strict: Boolean = false)(using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
-        Flow[RdfStreamFrame, TTriple, NotUsed]
+      final def asFlatTripleStreamStrict[TTriple](using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]): 
+      Flow[RdfStreamFrame, TTriple, NotUsed] =
+        asFlatTripleStream(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.FLAT_TRIPLES))
 
+      /**
+       * Interpret the incoming stream as a flat RDF triple stream from RDF-STaX.
+       *
+       * This method will not check the logical stream type of the incoming stream. Use .asFlatTripleStreamStrict
+       * if you want to check this.
+       *
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      final def asFlatTripleStream[TTriple](using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, TTriple, NotUsed] =
+        asFlatTripleStream(ConverterFactory.defaultSupportedOptions)
+
+      /**
+       * Interpret the incoming stream as a flat RDF triple stream from RDF-STaX.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      def asFlatTripleStream[TTriple](supportedOptions: RdfStreamOptions)(
+        using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]
+      ): Flow[RdfStreamFrame, TTriple, NotUsed]
+
+    
     trait FlatQuadStream:
       /**
        * Interpret the incoming stream as a flat RDF quad stream from RDF-STaX.
        *
-       * @param strict If true, the incoming stream must have its logical type set to FLAT_QUADS or its subtype,
-       *               otherwise the decoding will fail.
+       * The incoming stream must have its logical type set to FLAT_QUADS or its subtype, 
+       * otherwise the decoding will fail. To allow for any logical type, use .asFlatQuadStream.
+       * 
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TQuad Type of quad statements.
        * @return Pekko Streams flow
        */
-      def asFlatQuadStream[TQuad](strict: Boolean = false)(using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
-        Flow[RdfStreamFrame, TQuad, NotUsed]
+      final def asFlatQuadStreamStrict[TQuad](using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]): 
+      Flow[RdfStreamFrame, TQuad, NotUsed] =
+        asFlatQuadStream(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.FLAT_QUADS))
+
+      /**
+       * Interpret the incoming stream as a flat RDF quad stream from RDF-STaX.
+       *
+       * This method will not check the logical stream type of the incoming stream. Use .asFlatQuadStreamStrict
+       * if you want to check this.
+       *
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      final def asFlatQuadStream[TQuad](using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
+      Flow[RdfStreamFrame, TQuad, NotUsed] =
+        asFlatQuadStream(ConverterFactory.defaultSupportedOptions)
+
+      /**
+       * Interpret the incoming stream as a flat RDF quad stream from RDF-STaX.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      def asFlatQuadStream[TQuad](supportedOptions: RdfStreamOptions)(
+        using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]
+      ): Flow[RdfStreamFrame, TQuad, NotUsed]
+        
 
     trait GraphStream:
       /**
        * Interpret the incoming stream as an RDF graph stream from RDF-STaX.
        * Each iterable (graph) in the output stream corresponds to one incoming [[RdfStreamFrame]].
        *
-       * @param strict If true, the incoming stream must have its logical type set to GRAPHS or its subtype,
-       *               otherwise the decoding will fail.
+       * The incoming stream must have its logical type set to GRAPHS or its subtype, 
+       * otherwise the decoding will fail. To allow for any logical type, use .asGraphStream.
+       * 
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TTriple Type of triple statements.
        * @return Pekko Streams flow
        */
-      def asGraphStream[TTriple](strict: Boolean = false)(using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
-        Flow[RdfStreamFrame, IterableOnce[TTriple], NotUsed]
+      final def asGraphStreamStrict[TTriple](using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, IterableOnce[TTriple], NotUsed] =
+        asGraphStream(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.GRAPHS))
 
+      /**
+       * Interpret the incoming stream as an RDF graph stream from RDF-STaX.
+       * Each iterable (graph) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       * 
+       * This method will not check the logical stream type of the incoming stream. Use .asGraphStreamStrict
+       * if you want to check this.
+       * 
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      final def asGraphStream[TTriple](using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, IterableOnce[TTriple], NotUsed] =
+        asGraphStream(ConverterFactory.defaultSupportedOptions)
+      
+      /**
+       * Interpret the incoming stream as an RDF graph stream from RDF-STaX.
+       * Each iterable (graph) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      def asGraphStream[TTriple](supportedOptions: RdfStreamOptions)
+        (using factory: ConverterFactory[?, ?, ?, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, IterableOnce[TTriple], NotUsed]
+
+    
     trait DatasetStreamOfQuads:
       /**
        * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
        * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
        * The dataset is represented as a sequence of quads.
        *
-       * @param strict If true, the incoming stream must have its logical type set to DATASETS or its subtype,
-       *               otherwise the decoding will fail.
+       * The incoming stream must have its logical type set to DATASETS or its subtype, 
+       * otherwise the decoding will fail. To allow for any logical type, use .asDatasetStreamOfQuads.
+       * 
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TQuad Type of quad statements.
        * @return Pekko Streams flow
        */
-      def asDatasetStreamOfQuads[TQuad](strict: Boolean = false)(using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
-        Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed]
+      final def asDatasetStreamOfQuadsStrict[TQuad](using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
+      Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed] =
+        asDatasetStreamOfQuads(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.DATASETS))
 
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
+       * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       * The dataset is represented as a sequence of quads.
+       *
+       * This method will not check the logical stream type of the incoming stream. Use .asDatasetStreamOfQuadsStrict
+       * if you want to check this.
+       *
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      final def asDatasetStreamOfQuads[TQuad](using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]):
+      Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed] =
+        asDatasetStreamOfQuads(ConverterFactory.defaultSupportedOptions)
+      
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
+       * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       * The dataset is represented as a sequence of quads.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      def asDatasetStreamOfQuads[TQuad](supportedOptions: RdfStreamOptions)
+        (using factory: ConverterFactory[?, ?, ?, ?, ?, TQuad]): 
+      Flow[RdfStreamFrame, IterableOnce[TQuad], NotUsed]
+
+    
     trait DatasetStream:
       /**
        * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
        * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
        * The dataset is represented as a sequence of triples grouped by the graph node.
        *
-       * @param strict If true, the incoming stream must have its logical type set to DATASETS or its subtype,
-       *               otherwise the decoding will fail.
+       * The incoming stream must have its logical type set to DATASETS or its subtype, 
+       * otherwise the decoding will fail. To allow for any logical type, use .asDatasetStream.
+       * 
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TNode Type of graph node.
        * @tparam TTriple Type of triple statements.
        * @return Pekko Streams flow
        */
-      def asDatasetStream[TNode, TTriple](strict: Boolean = false)
+      final def asDatasetStreamStrict[TNode, TTriple](using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, IterableOnce[(TNode, Iterable[TTriple])], NotUsed] =
+        asDatasetStream(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.DATASETS))
+
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
+       * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       * The dataset is represented as a sequence of triples grouped by the graph node.
+       *
+       * This method will not check the logical stream type of the incoming stream. Use .asDatasetStreamStrict
+       * if you want to check this.
+       *
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TNode Type of graph node.
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      final def asDatasetStream[TNode, TTriple](using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, IterableOnce[(TNode, Iterable[TTriple])], NotUsed] =
+        asDatasetStream(ConverterFactory.defaultSupportedOptions)
+      
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX.
+       * Each iterable (dataset) in the output stream corresponds to one incoming [[RdfStreamFrame]].
+       * The dataset is represented as a sequence of triples grouped by the graph node.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TNode Type of graph node.
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      def asDatasetStream[TNode, TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
       Flow[RdfStreamFrame, IterableOnce[(TNode, Iterable[TTriple])], NotUsed]
+      
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX and then flatten it.
+       * The borders between stream frames are ignored and the triples are grouped by the graph node.
+       * The dataset is represented as a sequence of triples grouped by the graph node.
+       * 
+       * The incoming stream must have its logical type set to NAMED_GRAPHS or its subtype,
+       * otherwise the decoding will fail. To allow for any logical type, use .asNamedGraphStream.
+       *
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TNode Type of graph node.
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      final def asNamedGraphStreamStrict[TNode, TTriple](using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, (TNode, Iterable[TTriple]), NotUsed] =
+        asNamedGraphStream(ConverterFactory.defaultSupportedOptions.withLogicalType(LogicalStreamType.NAMED_GRAPHS))
 
       /**
        * Interpret the incoming stream as an RDF dataset stream from RDF-STaX and then flatten it.
        * The borders between stream frames are ignored and the triples are grouped by the graph node.
        * The dataset is represented as a sequence of triples grouped by the graph node.
        *
-       * @param strict If true, the incoming stream must have its logical type set to DATASETS or its subtype,
-       *               otherwise the decoding will fail.
+       * This method will not check the logical stream type of the incoming stream. Use .asNamedGraphStreamStrict
+       * if you want to check this.
+       *
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
        * @tparam TNode Type of graph node.
        * @tparam TTriple Type of triple statements.
        * @return Pekko Streams flow
        */
-      def asNamedGraphStream[TNode, TTriple](strict: Boolean = false)
+      final def asNamedGraphStream[TNode, TTriple](using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
+      Flow[RdfStreamFrame, (TNode, Iterable[TTriple]), NotUsed] =
+        asNamedGraphStream(ConverterFactory.defaultSupportedOptions)
+
+      /**
+       * Interpret the incoming stream as an RDF dataset stream from RDF-STaX and then flatten it.
+       * The borders between stream frames are ignored and the triples are grouped by the graph node.
+       * The dataset is represented as a sequence of triples grouped by the graph node.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TNode Type of graph node.
+       * @tparam TTriple Type of triple statements.
+       * @return Pekko Streams flow
+       */
+      def asNamedGraphStream[TNode, TTriple](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, ?]):
       Flow[RdfStreamFrame, (TNode, Iterable[TTriple]), NotUsed]
 
     trait AnyStream:
+      
       /**
-       * Interpret the incoming stream as any grouped RDF stream from RDF stax.
-       * The type of RDF statements is determined by the stream type specified in the stream options header.
-       * The stream must have a set stream type (UNSPECIFIED is not allowed) and the stream type must not change
+       * Interpret the incoming stream as any grouped RDF stream from RDF-STaX.
+       * The type of RDF statements is determined by the physical stream type specified in the stream options header.
+       * The stream must have a set physical type (UNSPECIFIED is not allowed) and the physical type must not change
        * during the stream.
        *
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
@@ -270,14 +476,33 @@ object DecoderFlow:
        * @tparam TQuad Type of quad statements.
        * @return Pekko Streams flow
        */
-      def asGroupedStream[TNode, TTriple, TQuad]
+      final def asGroupedStream[TNode, TTriple, TQuad]
+        (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, TQuad]):
+      Flow[RdfStreamFrame, IterableOnce[TTriple | TQuad], NotUsed] =
+        asGroupedStream(ConverterFactory.defaultSupportedOptions)
+      
+      /**
+       * Interpret the incoming stream as any grouped RDF stream from RDF-STaX.
+       * The type of RDF statements is determined by the physical stream type specified in the stream options header.
+       * The stream must have a set physical type (UNSPECIFIED is not allowed) and the physical type must not change
+       * during the stream.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TNode Type of graph node.
+       * @tparam TTriple Type of triple statements.
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      def asGroupedStream[TNode, TTriple, TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, TQuad]):
       Flow[RdfStreamFrame, IterableOnce[TTriple | TQuad], NotUsed]
-
+      
       /**
-       * Interpret the incoming stream as any flat RDF stream from RDF stax.
-       * The type of RDF statements is determined by the stream type specified in the stream options header.
-       * The stream must have a set stream type (UNSPECIFIED is not allowed) and the stream type must not change
+       * Interpret the incoming stream as any flat RDF stream from RDF-STaX.
+       * The type of RDF statements is determined by the physical stream type specified in the stream options header.
+       * The stream must have a set physical type (UNSPECIFIED is not allowed) and the physical type must not change
        * during the stream.
        *
        * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
@@ -285,6 +510,23 @@ object DecoderFlow:
        * @tparam TQuad Type of quad statements.
        * @return Pekko Streams flow
        */
-      def asFlatStream[TTriple, TQuad]
+      final def asFlatStream[TTriple, TQuad](using factory: ConverterFactory[?, ?, ?, ?, TTriple, TQuad]):
+      Flow[RdfStreamFrame, TTriple | TQuad, NotUsed] =
+        asFlatStream(ConverterFactory.defaultSupportedOptions)
+
+      /**
+       * Interpret the incoming stream as any flat RDF stream from RDF-STaX.
+       * The type of RDF statements is determined by the physical stream type specified in the stream options header.
+       * The stream must have a set physical type (UNSPECIFIED is not allowed) and the physical type must not change
+       * during the stream.
+       *
+       * @param supportedOptions Options to be supported by the decoder. Use ConvertedFactory.defaultSupportedOptions
+       *                         to get the default options and modify them as needed.
+       * @param factory Implementation of [[ConverterFactory]] (e.g., JenaConverterFactory).
+       * @tparam TTriple Type of triple statements.
+       * @tparam TQuad Type of quad statements.
+       * @return Pekko Streams flow
+       */
+      def asFlatStream[TTriple, TQuad](supportedOptions: RdfStreamOptions)
         (using factory: ConverterFactory[?, ?, ?, ?, TTriple, TQuad]):
       Flow[RdfStreamFrame, TTriple | TQuad, NotUsed]


### PR DESCRIPTION
The decoder should refuse to process streams that use options not matching the user's expectations. This includes: overly large lookup tables (can lead to OOM – DoS attack vector), unwanted RDF-star, unwanted generalized statements, limiting the protocol version to something lower than what's supported by the library.

This was implemented in core, along with a refactor of how stream option checks work in general. The stream module (DecoderFlow) was also refactored to allow passing supported options to the decoder. At the same time, the ugly boolean `strict` parameter was removed there and replaced with the more meaningful method variants. Lastly, this was implemented in the RDF4J/Jena parsers.

There are extensive tests and examples for all of this.