### PR TITLE
Build plugins for Jena and RDF4J

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,48 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+  publish-plugins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'sbt'
+
+      - name: 'Build plugins'
+        run: |
+          sbt jena/assembly
+          sbt rdf4j/assembly
+
+      - name: 'Publish plugins (pre-release)'
+        if: github.ref == 'refs/heads/main'
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          allowUpdates: true
+          prerelease: true
+          draft: false
+          omitDraftDuringUpdate: false
+          makeLatest: false
+          tag: dev
+          name: "Development build"
+          artifacts: 'jena/target/scala-*/*-plugin.jar,rdf4j/target/scala-*/*-plugin.jar'
+          generateReleaseNotes: true
+
+      - name: 'Publish plugins (tagged release)'
+        if: github.ref != 'refs/heads/main'
+        uses: ncipollo/release-action@v1.14.0
+        with:
+          prerelease: false
+          draft: false
+          makeLatest: true
+          tag: "${{ env.GITHUB_REF_NAME }}"
+          name: "${{ env.GITHUB_REF_NAME }}"
+          artifacts: 'jena/target/scala-*/*-plugin.jar,rdf4j/target/scala-*/*-plugin.jar'
+          generateReleaseNotes: true

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,13 @@ lazy val commonSettings = Seq(
     "-feature",
     "-deprecation",
     "-unchecked",
-  )
+  ),
+  assemblyJarName := s"${name.value}-plugin.jar",
+  assemblyMergeStrategy := {
+    case x if x.endsWith("module-info.class") => MergeStrategy.concat
+    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
+    case x => assemblyMergeStrategy.value(x)
+  },
 )
 
 lazy val core = (project in file("core"))
@@ -60,8 +66,9 @@ lazy val jena = (project in file("jena"))
   .settings(
     name := "jelly-jena",
     libraryDependencies ++= Seq(
-      "org.apache.jena" % "jena-core" % jenaV,
-      "org.apache.jena" % "jena-arq" % jenaV,
+      // Use the "provided" scope to not include the Jena dependencies in the plugin JAR
+      "org.apache.jena" % "jena-core" % jenaV % "provided",
+      "org.apache.jena" % "jena-arq" % jenaV % "provided",
     ),
     commonSettings,
   )
@@ -71,8 +78,9 @@ lazy val rdf4j = (project in file("rdf4j"))
   .settings(
     name := "jelly-rdf4j",
     libraryDependencies ++= Seq(
-      "org.eclipse.rdf4j" % "rdf4j-model" % rdf4jV,
-      "org.eclipse.rdf4j" % "rdf4j-rio-api" % rdf4jV,
+      // Use the "provided" scope to not include the RDF4J dependencies in the plugin JAR
+      "org.eclipse.rdf4j" % "rdf4j-model" % rdf4jV % "provided",
+      "org.eclipse.rdf4j" % "rdf4j-rio-api" % rdf4jV % "provided",
     ),
     commonSettings,
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 addDependencyTreePlugin
 
 lazy val scalapbV = "0.11.13"


### PR DESCRIPTION
These plugins should be simply included in Jena's/RDF4J's classpath to enable Jelly support. The plugins do not include Jena/RDF4J themselves, as this is not needed – only the protobuf stuff, Scala standard library, and our code.

The plugins will be published to GH releases – let's see if it works.