### PR TITLE
Update and improve JellyOptionsFromTypesafe

### DIFF
--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/JellyOptionsFromTypesafe.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/JellyOptionsFromTypesafe.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
 import com.typesafe.config.{Config, ConfigFactory}
-import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, PhysicalStreamType}
+import eu.ostrzyciel.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType, RdfStreamOptions}
 
 /**
  * Convenience methods for building Jelly's options ([[RdfStreamOptions]]) from [[com.typesafe.Config]].
@@ -10,40 +10,49 @@ import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, PhysicalStreamType}
  */
 object JellyOptionsFromTypesafe:
   private val defaultConfig = ConfigFactory.parseString("""
-    |stream-type = UNSPECIFIED
+    |physical-type = UNSPECIFIED
+    |logical-type = UNSPECIFIED
     |generalized-statements = false
     |rdf-star = false
     |name-table-size = 128
     |prefix-table-size = 16
-    |dt-table-size = 16
+    |datatype-table-size = 16
     |""".stripMargin)
+  
+  private val physicalStreamTypeMap = PhysicalStreamType.values
+    .map(v => v.name.replace("PHYSICAL_STREAM_TYPE_", "") -> v)
+    .toMap
+  
+  private val logicalStreamTypeMap = LogicalStreamType.values
+    .map(v => v.name.replace("LOGICAL_STREAM_TYPE_", "") -> v)
+    .toMap
 
   /**
    * Builds RdfStreamOptions from a typesafe config instance.
    *
    * @param config typesafe config with keys:
-   *               - "stream-type", either UNSPECIFIED, TRIPLES, QUADS, or GRAPHS. Default: UNSPECIFIED.
+   *               - "physical-type", either UNSPECIFIED, TRIPLES, QUADS, or GRAPHS. Default: UNSPECIFIED.
+   *               - "logical-type", one of the defined logical types like "FLAT_TRIPLES" in rdf.proto,
+   *                  LogicalStreamType enum. Default: UNSPECIFIED.
    *               - "generalized-statements", boolean. Default: false.
    *               - "rdf-star", boolean. Default: false.
    *               - "name-table-size", integer. Default: 128.
    *               - "prefix-table-size", integer. Default: 16.
-   *               - "dt-table-size", integer. Default: 16.
+   *               - "datatype-table-size", integer. Default: 16.
    * @return
    */
   def fromTypesafeConfig(config: Config): RdfStreamOptions =
     val merged = config.withFallback(defaultConfig)
     RdfStreamOptions(
-      physicalType = (
-        merged.getString("stream-type") match
-          case "UNSPECIFIED" => PhysicalStreamType.UNSPECIFIED
-          case "TRIPLES" => PhysicalStreamType.TRIPLES
-          case "QUADS" => PhysicalStreamType.QUADS
-          case "GRAPHS" => PhysicalStreamType.GRAPHS
-          case _ => throw IllegalArgumentException()
-        ),
+      physicalType = physicalStreamTypeMap.get(merged.getString("physical-type")) match
+        case Some(v) => v
+        case None => throw new IllegalArgumentException(s"Unknown physical type: ${merged.getString("physical-type")}"),
+      logicalType = logicalStreamTypeMap.get(merged.getString("logical-type")) match
+        case Some(v) => v
+        case None => throw new IllegalArgumentException(s"Unknown logical type: ${merged.getString("logical-type")}"),
       generalizedStatements = merged.getBoolean("generalized-statements"),
       rdfStar = merged.getBoolean("rdf-star"),
       maxNameTableSize = merged.getInt("name-table-size"),
       maxPrefixTableSize = merged.getInt("prefix-table-size"),
-      maxDatatypeTableSize = merged.getInt("dt-table-size"),
+      maxDatatypeTableSize = merged.getInt("datatype-table-size"),
     )

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/JellyOptionsFromTypesafeSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/JellyOptionsFromTypesafeSpec.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.stream
 
 import com.typesafe.config.ConfigFactory
-import eu.ostrzyciel.jelly.core.proto.v1.PhysicalStreamType
+import eu.ostrzyciel.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -10,7 +10,9 @@ class JellyOptionsFromTypesafeSpec extends AnyWordSpec, Matchers:
     "produce defaults for empty input" in {
       val opt = JellyOptionsFromTypesafe.fromTypesafeConfig(ConfigFactory.empty())
       opt.physicalType should be (PhysicalStreamType.UNSPECIFIED)
+      opt.logicalType should be (LogicalStreamType.UNSPECIFIED)
       opt.generalizedStatements should be (false)
+      opt.rdfStar should be (false)
       opt.maxNameTableSize should be (128)
       opt.maxPrefixTableSize should be (16)
       opt.maxDatatypeTableSize should be (16)
@@ -18,15 +20,17 @@ class JellyOptionsFromTypesafeSpec extends AnyWordSpec, Matchers:
 
     "override all defaults with a different config" in {
       val conf = ConfigFactory.parseString("""
-        |jelly.stream-type = GRAPHS
+        |jelly.physical-type = GRAPHS
+        |jelly.logical-type = FLAT_QUADS
         |jelly.generalized-statements = true
         |jelly.rdf-star = true
         |jelly.name-table-size = 1024
         |jelly.prefix-table-size = 64
-        |jelly.dt-table-size = 8
+        |jelly.datatype-table-size = 8
         |""".stripMargin)
       val opt = JellyOptionsFromTypesafe.fromTypesafeConfig(conf.getConfig("jelly"))
       opt.physicalType should be (PhysicalStreamType.GRAPHS)
+      opt.logicalType should be (LogicalStreamType.FLAT_QUADS)
       opt.generalizedStatements should be (true)
       opt.rdfStar should be (true)
       opt.maxNameTableSize should be (1024)
@@ -36,16 +40,37 @@ class JellyOptionsFromTypesafeSpec extends AnyWordSpec, Matchers:
 
     "override defaults partially" in {
       val conf = ConfigFactory.parseString("""
-        |jelly.stream-type = QUADS
+        |jelly.physical-type = QUADS
         |jelly.name-table-size = 1024
         |jelly.prefix-table-size = 64
         |""".stripMargin)
       val opt = JellyOptionsFromTypesafe.fromTypesafeConfig(conf.getConfig("jelly"))
       opt.physicalType should be (PhysicalStreamType.QUADS)
+      opt.logicalType should be (LogicalStreamType.UNSPECIFIED)
       opt.generalizedStatements should be (false)
       opt.rdfStar should be (false)
       opt.maxNameTableSize should be (1024)
       opt.maxPrefixTableSize should be (64)
       opt.maxDatatypeTableSize should be (16)
+    }
+
+    "throw exception on unknown physical stream type" in {
+      val conf = ConfigFactory.parseString("""
+        |jelly.physical-type = UNKNOWN
+        |""".stripMargin)
+      val error = intercept[IllegalArgumentException] {
+        JellyOptionsFromTypesafe.fromTypesafeConfig(conf.getConfig("jelly"))
+      }
+      error.getMessage should be ("Unknown physical type: UNKNOWN")
+    }
+
+    "throw exception on unknown logical stream type" in {
+      val conf = ConfigFactory.parseString("""
+        |jelly.logical-type = UNKNOWN
+        |""".stripMargin)
+      val error = intercept[IllegalArgumentException] {
+        JellyOptionsFromTypesafe.fromTypesafeConfig(conf.getConfig("jelly"))
+      }
+      error.getMessage should be ("Unknown logical type: UNKNOWN")
     }
   }


### PR DESCRIPTION
Improved:
- More consistent config option naming
- Support for logical stream types
- Removed reliance on hardcoded cases, use maps to determine the physical and logical stream types.
- Better exception messages.