### PR TITLE
Add fake Scala 2 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,9 @@ jobs:
           cache: 'sbt'
 
       - name: 'Build plugins'
-        run: sbt -v jenaPlugin/assembly rdf4jPlugin/assembly
+        run: |
+          sbt -v +jenaPlugin/assembly +rdf4jPlugin/assembly
+          LATEST_SCALA_VERSION=`ls -1 jena-plugin/target | grep scala- | sort -V | tail -n1`
 
       - name: 'Publish plugins (pre-release)'
         if: github.ref == 'refs/heads/main'
@@ -53,7 +55,7 @@ jobs:
           makeLatest: false
           tag: dev
           name: "Development build"
-          artifacts: 'jena-plugin/target/scala-*/*-plugin.jar,rdf4j-plugin/target/scala-*/*-plugin.jar'
+          artifacts: 'jena-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,rdf4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar'
           generateReleaseNotes: true
 
       - name: 'Publish plugins (tagged release)'
@@ -65,7 +67,7 @@ jobs:
           makeLatest: true
           tag: "${{ github.ref_name }}"
           name: "${{ github.ref_name }}"
-          artifacts: 'jena-plugin/target/scala-*/*-plugin.jar,rdf4j-plugin/target/scala-*/*-plugin.jar'
+          artifacts: 'jena-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,rdf4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar'
           generateReleaseNotes: true
 
   publish-docs:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Test building assemblies
       shell: bash
-      run: sbt -v jenaPlugin/assembly rdf4jPlugin/assembly
+      run: sbt -v +jenaPlugin/assembly +rdf4jPlugin/assembly

--- a/grpc/src/main/scala/eu/ostrzyciel/jelly/grpc/RdfStreamServer.scala
+++ b/grpc/src/main/scala/eu/ostrzyciel/jelly/grpc/RdfStreamServer.scala
@@ -8,6 +8,7 @@ import org.apache.pekko.actor.typed.ActorSystem
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.Http.ServerBinding
 import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse}
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,8 +40,10 @@ object RdfStreamServer:
  * @param system actor system
  */
 final class RdfStreamServer(options: RdfStreamServer.Options, streamService: RdfStreamService)
-                     (using system: ActorSystem[_]) extends LazyLogging:
+                     (using system: ActorSystem[_]):
   given ExecutionContext = system.executionContext
+
+  private val logger = LoggerFactory.getLogger(getClass)
   private var binding: Option[ServerBinding] = _
 
   /**


### PR DESCRIPTION
This is a blatant misuse of sbt's facilities to make it possible to publish a Scala 3 library compiled using the Scala 3 compiler, but with two different sets of dependencies: for Scala 2 and 3. This *SHOULD* allow others to use Jelly in Scala 2 projects without worrying about conflicting transitive dependencies. I hope.