### PR TITLE
Enable HTTP/2 ping frames in jelly-grpc

### DIFF
--- a/grpc/src/main/resources/application.conf
+++ b/grpc/src/main/resources/application.conf
@@ -1,2 +1,6 @@
 # Enable HTTP/2 support in Pekko server so that gRPC works
 pekko.http.server.preview.enable-http2 = on
+
+# Enable HTTP/2 keep-alive pings to prevent long-running streams from being closed when there is no activity.
+# The server will ping the client every 10 seconds – you can change this to a less aggressive setting if needed.
+pekko.http.server.http2.ping-interval = 10s

--- a/grpc/src/main/resources/reference.conf
+++ b/grpc/src/main/resources/reference.conf
@@ -1,2 +1,6 @@
 # Enable HTTP/2 support in Pekko server so that gRPC works
 pekko.http.server.preview.enable-http2 = on
+
+# Enable HTTP/2 keep-alive pings to prevent long-running streams from being closed when there is no activity.
+# The server will ping the client every 10 seconds – you can change this to a less aggressive setting if needed.
+pekko.http.server.http2.ping-interval = 10s


### PR DESCRIPTION
This should prevent any intermediaries from closing a long-running stream if there is no activity for some time.

The default of 10 seconds may be a bit aggressive, but it should work on most setups.