### PR TITLE
Experiment: Use ByteStrings instead of Strings in protos

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import java.nio.file.{Files, Path}
+
 // We have two builds of Jelly – both compiled using the Scala 3 compiler, but one with
 // Scala 2.13 dependencies and the other with Scala 3 dependencies. This is because we
 // want to at least somewhat support both Scala 2.13 and Scala 3 projects that use Jelly.
@@ -41,6 +43,8 @@ def crossDependencies(binVersion: String, modules: ModuleID*): Seq[ModuleID] = {
   }
   else modules
 }
+
+lazy val preprocessProto = taskKey[Path]("Preprocess a proto file before compilation")
 
 // List of exclusions for the grpc module and its dependencies
 lazy val grpcExclusions = Seq(
@@ -102,9 +106,32 @@ lazy val core = (project in file("core"))
     Compile / PB.targets := Seq(
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
     ),
+    preprocessProto / fileInputs += baseDirectory.value.toGlob / "src" / "main" / "protobuf_shared" / "rdf.proto",
+    preprocessProto := {
+      val inputPath = preprocessProto.inputFiles.head
+      val outputPath = Path.of(inputPath.toString.replace("rdf.proto", ".rdf.proto"))
+      val logger = streams.value.log
+      logger.info(s"Preprocessing $inputPath to $outputPath")
+      val input = Files.newBufferedReader(inputPath)
+      val output = Files.newBufferedWriter(outputPath)
+      try {
+        var line: String = null
+        while ({ line = input.readLine(); line != null }) {
+          if (!line.contains("stream_name")) line = line.replace(" string ", " bytes ")
+          output.write(line + "\n")
+        }
+      } finally {
+        input.close()
+        output.close()
+      }
+      outputPath
+    },
+    // Preprocess the proto file before Protobuf compilation
+    Compile / PB.generate := (Compile / PB.generate).dependsOn(preprocessProto).value,
     // Add the shared proto sources
     Compile / PB.protoSources ++= Seq(baseDirectory.value / "src" / "main" / "protobuf_shared"),
-    Compile / PB.generate / excludeFilter := "grpc.proto",
+    // We use .rdf.proto instead of rdf.proto
+    Compile / PB.generate / excludeFilter := "grpc.proto" || "rdf.proto",
     commonSettings,
   )
 
@@ -190,7 +217,7 @@ lazy val grpc = (project in file("grpc"))
       (core / baseDirectory).value / "src" / "main" / "protobuf_shared",
       (core / baseDirectory).value / "src" / "main" / "protobuf",
     ),
-    Compile / PB.generate / excludeFilter := "rdf.proto",
+    Compile / PB.generate / excludeFilter := "rdf.proto" || ".rdf.proto",
     excludeDependencies ++= {
       if (scalaVersion.value == scala2Version) grpcExclusions
       else Seq()

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/NameDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/NameDecoder.scala
@@ -15,7 +15,7 @@ private[core] final class NameDecoder(opt: RdfStreamOptions):
    * @throws ArrayIndexOutOfBoundsException if id < 1 or id > maxNameTableSize
    */
   inline def updateNames(nameRow: RdfNameEntry): Unit =
-    nameLookup.update(nameRow.id, nameRow.value)
+    nameLookup.update(nameRow.id, nameRow.value.toStringUtf8)
 
   /**
    * Update the prefix table.
@@ -23,7 +23,7 @@ private[core] final class NameDecoder(opt: RdfStreamOptions):
    * @throws ArrayIndexOutOfBoundsException if id < 1 or id > maxPrefixTableSize
    */
   inline def updatePrefixes(prefixRow: RdfPrefixEntry): Unit =
-    prefixLookup.update(prefixRow.id, prefixRow.value)
+    prefixLookup.update(prefixRow.id, prefixRow.value.toStringUtf8)
 
   /**
    * Reconstruct an IRI from its prefix and name ids.

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/NameEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/NameEncoder.scala
@@ -1,5 +1,6 @@
 package eu.ostrzyciel.jelly.core
 
+import com.google.protobuf.ByteString
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 import scala.collection.mutable.ListBuffer
@@ -66,7 +67,7 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
       if nameLookupEntry.newEntry then
         rowsBuffer.append(
           RdfStreamRow(RdfStreamRow.Row.Name(
-            RdfNameEntry(id = nameLookupEntry.setId, value = iri)
+            RdfNameEntry(id = nameLookupEntry.setId, value = ByteString.copyFromUtf8(iri))
           ))
         )
       // We set the prefixId to 0, but it's a special case, because the prefix table is disabled.
@@ -80,12 +81,12 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
 
       if prefixLookupEntry.newEntry then rowsBuffer.append(
         RdfStreamRow(RdfStreamRow.Row.Prefix(
-          RdfPrefixEntry(prefixLookupEntry.setId, prefix)
+          RdfPrefixEntry(prefixLookupEntry.setId, ByteString.copyFromUtf8(prefix))
         ))
       )
       if nameLookupEntry.newEntry then rowsBuffer.append(
         RdfStreamRow(RdfStreamRow.Row.Name(
-          RdfNameEntry(nameLookupEntry.setId, postfix)
+          RdfNameEntry(nameLookupEntry.setId, ByteString.copyFromUtf8(postfix))
         ))
       )
 
@@ -118,7 +119,7 @@ private[core] final class NameEncoder(opt: RdfStreamOptions):
       )
       rowsBuffer.append(
         RdfStreamRow(RdfStreamRow.Row.Datatype(
-          RdfDatatypeEntry(id = dtVal.setId, value = dtIri)
+          RdfDatatypeEntry(id = dtVal.setId, value = ByteString.copyFromUtf8(dtIri))
         ))
       )
       datatype

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -1,7 +1,8 @@
 package eu.ostrzyciel.jelly.core
 
+import com.google.protobuf.ByteString
 import eu.ostrzyciel.jelly.core.proto.v1.*
-import eu.ostrzyciel.jelly.core.proto_adapters.{given, *}
+import eu.ostrzyciel.jelly.core.proto_adapters.{*, given}
 
 import scala.collection.mutable.ListBuffer
 
@@ -131,21 +132,24 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     a.makeIri(iriEncoder.encodeIri(iri, extraRowsBuffer))
 
   protected final inline def makeBlankNode[TTerm](label: String)(using a: RdfTermAdapter[TTerm]): TTerm =
-    a.makeBnode(label)
+    a.makeBnode(ByteString.copyFromUtf8(label))
 
   protected final inline def makeSimpleLiteral[TTerm](lex: String)(using a: RdfTermAdapter[TTerm]): TTerm =
     a.makeLiteral(
-      RdfLiteral(lex, RdfLiteral.LiteralKind.Empty)
+      RdfLiteral(ByteString.copyFromUtf8(lex), RdfLiteral.LiteralKind.Empty)
     )
 
   protected final inline def makeLangLiteral[TTerm](lex: String, lang: String)(using a: RdfTermAdapter[TTerm]): TTerm =
     a.makeLiteral(
-      RdfLiteral(lex, RdfLiteral.LiteralKind.Langtag(lang))
+      RdfLiteral(
+        ByteString.copyFromUtf8(lex), 
+        RdfLiteral.LiteralKind.Langtag(ByteString.copyFromUtf8(lang))
+      )
     )
 
   protected final inline def makeDtLiteral[TTerm](lex: String, dt: String)(using a: RdfTermAdapter[TTerm]): TTerm =
     a.makeLiteral(
-      RdfLiteral(lex, iriEncoder.encodeDatatype(dt, extraRowsBuffer))
+      RdfLiteral(ByteString.copyFromUtf8(lex), iriEncoder.encodeDatatype(dt, extraRowsBuffer))
     )
 
   protected final inline def makeTripleNode[TTerm](triple: TQuoted)(using a: RdfTermAdapter[TTerm]): TTerm =
@@ -155,23 +159,26 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     a.makeIri(iriEncoder.encodeIri(iri, extraRowsBuffer))
 
   protected final inline def makeBlankNodeGraph[TGraph](label: String)(using a: RdfGraphAdapter[TGraph]): TGraph =
-    a.makeBnode(label)
+    a.makeBnode(ByteString.copyFromUtf8(label))
 
   protected final inline def makeSimpleLiteralGraph[TGraph](lex: String)(using a: RdfGraphAdapter[TGraph]): TGraph =
     a.makeLiteral(
-      RdfLiteral(lex, RdfLiteral.LiteralKind.Empty)
+      RdfLiteral(ByteString.copyFromUtf8(lex), RdfLiteral.LiteralKind.Empty)
     )
 
   protected final inline def makeLangLiteralGraph[TGraph]
   (lex: String, lang: String)(using a: RdfGraphAdapter[TGraph]): TGraph =
     a.makeLiteral(
-      RdfLiteral(lex, RdfLiteral.LiteralKind.Langtag(lang))
+      RdfLiteral(
+        ByteString.copyFromUtf8(lex), 
+        RdfLiteral.LiteralKind.Langtag(ByteString.copyFromUtf8(lang))
+      )
     )
 
   protected final inline def makeDtLiteralGraph[TGraph]
   (lex: String, dt: String)(using a: RdfGraphAdapter[TGraph]): TGraph =
     a.makeLiteral(
-      RdfLiteral(lex, iriEncoder.encodeDatatype(dt, extraRowsBuffer))
+      RdfLiteral(ByteString.copyFromUtf8(lex), iriEncoder.encodeDatatype(dt, extraRowsBuffer))
     )
 
   protected final inline def makeDefaultGraph[TGraph](using a: RdfGraphAdapter[TGraph]): TGraph =

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto_adapters/RdfGraphAdapter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto_adapters/RdfGraphAdapter.scala
@@ -1,5 +1,6 @@
 package eu.ostrzyciel.jelly.core.proto_adapters
 
+import com.google.protobuf.ByteString
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 export RdfGraphAdapter.given
@@ -11,12 +12,12 @@ object RdfGraphAdapter:
     override inline def isLiteral(g: RdfQuad.Graph): Boolean = g.isGLiteral
     override inline def isDefaultGraph(g: RdfQuad.Graph): Boolean = g.isGDefaultGraph
     override inline def iri(g: RdfQuad.Graph): RdfIri = g.asInstanceOf[RdfQuad.Graph.GIri].value
-    override inline def bnode(g: RdfQuad.Graph): String = g.asInstanceOf[RdfQuad.Graph.GBnode].value
+    override inline def bnode(g: RdfQuad.Graph): ByteString = g.asInstanceOf[RdfQuad.Graph.GBnode].value
     override inline def literal(g: RdfQuad.Graph): RdfLiteral = g.asInstanceOf[RdfQuad.Graph.GLiteral].value
     override inline def defaultGraph(g: RdfQuad.Graph): RdfDefaultGraph = g.asInstanceOf[RdfQuad.Graph.GDefaultGraph].value
     
     override inline def makeIri(iri: RdfIri): RdfQuad.Graph = RdfQuad.Graph.GIri(iri)
-    override inline def makeBnode(bnode: String): RdfQuad.Graph = RdfQuad.Graph.GBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfQuad.Graph = RdfQuad.Graph.GBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfQuad.Graph = RdfQuad.Graph.GLiteral(literal)
     override val makeDefaultGraph: RdfQuad.Graph = RdfQuad.Graph.GDefaultGraph(RdfDefaultGraph())
     override val makeEmpty: RdfQuad.Graph = RdfQuad.Graph.Empty
@@ -27,12 +28,12 @@ object RdfGraphAdapter:
     override inline def isLiteral(g: RdfGraphStart.Graph): Boolean = g.isGLiteral
     override inline def isDefaultGraph(g: RdfGraphStart.Graph): Boolean = g.isGDefaultGraph
     override inline def iri(g: RdfGraphStart.Graph): RdfIri = g.asInstanceOf[RdfGraphStart.Graph.GIri].value
-    override inline def bnode(g: RdfGraphStart.Graph): String = g.asInstanceOf[RdfGraphStart.Graph.GBnode].value
+    override inline def bnode(g: RdfGraphStart.Graph): ByteString = g.asInstanceOf[RdfGraphStart.Graph.GBnode].value
     override inline def literal(g: RdfGraphStart.Graph): RdfLiteral = g.asInstanceOf[RdfGraphStart.Graph.GLiteral].value
     override inline def defaultGraph(g: RdfGraphStart.Graph): RdfDefaultGraph = g.asInstanceOf[RdfGraphStart.Graph.GDefaultGraph].value
     
     override inline def makeIri(iri: RdfIri): RdfGraphStart.Graph = RdfGraphStart.Graph.GIri(iri)
-    override inline def makeBnode(bnode: String): RdfGraphStart.Graph = RdfGraphStart.Graph.GBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfGraphStart.Graph = RdfGraphStart.Graph.GBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfGraphStart.Graph = RdfGraphStart.Graph.GLiteral(literal)
     override val makeDefaultGraph: RdfGraphStart.Graph = RdfGraphStart.Graph.GDefaultGraph(RdfDefaultGraph())
     override val makeEmpty: RdfGraphStart.Graph = RdfGraphStart.Graph.Empty
@@ -48,12 +49,12 @@ trait RdfGraphAdapter[TInner]:
   def isDefaultGraph(g: TInner): Boolean
   def isLiteral(g: TInner): Boolean
   def iri(g: TInner): RdfIri
-  def bnode(g: TInner): String
+  def bnode(g: TInner): ByteString
   def defaultGraph(g: TInner): RdfDefaultGraph
   def literal(g: TInner): RdfLiteral
 
   def makeIri(iri: RdfIri): TInner
-  def makeBnode(bnode: String): TInner
+  def makeBnode(bnode: ByteString): TInner
   def makeLiteral(literal: RdfLiteral): TInner
   val makeDefaultGraph: TInner
   val makeEmpty: TInner 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto_adapters/RdfTermAdapter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto_adapters/RdfTermAdapter.scala
@@ -1,5 +1,6 @@
 package eu.ostrzyciel.jelly.core.proto_adapters
 
+import com.google.protobuf.ByteString
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 export RdfTermAdapter.given
@@ -13,12 +14,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfTriple.Subject): Boolean = t.isSLiteral
     override inline def isTripleTerm(t: RdfTriple.Subject): Boolean = t.isSTripleTerm
     override inline def iri(t: RdfTriple.Subject): RdfIri = t.asInstanceOf[RdfTriple.Subject.SIri].value
-    override inline def bnode(t: RdfTriple.Subject): String = t.asInstanceOf[RdfTriple.Subject.SBnode].value
+    override inline def bnode(t: RdfTriple.Subject): ByteString = t.asInstanceOf[RdfTriple.Subject.SBnode].value
     override inline def literal(t: RdfTriple.Subject): RdfLiteral = t.asInstanceOf[RdfTriple.Subject.SLiteral].value
     override inline def tripleTerm(t: RdfTriple.Subject): RdfTriple = t.asInstanceOf[RdfTriple.Subject.STripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfTriple.Subject = RdfTriple.Subject.SIri(iri)
-    override inline def makeBnode(bnode: String): RdfTriple.Subject = RdfTriple.Subject.SBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfTriple.Subject = RdfTriple.Subject.SBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfTriple.Subject = RdfTriple.Subject.SLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfTriple.Subject = RdfTriple.Subject.STripleTerm(triple)
     override val makeEmpty: RdfTriple.Subject = RdfTriple.Subject.Empty
@@ -29,12 +30,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfTriple.Predicate): Boolean = t.isPLiteral
     override inline def isTripleTerm(t: RdfTriple.Predicate): Boolean = t.isPTripleTerm
     override inline def iri(t: RdfTriple.Predicate): RdfIri = t.asInstanceOf[RdfTriple.Predicate.PIri].value
-    override inline def bnode(t: RdfTriple.Predicate): String = t.asInstanceOf[RdfTriple.Predicate.PBnode].value
+    override inline def bnode(t: RdfTriple.Predicate): ByteString = t.asInstanceOf[RdfTriple.Predicate.PBnode].value
     override inline def literal(t: RdfTriple.Predicate): RdfLiteral = t.asInstanceOf[RdfTriple.Predicate.PLiteral].value
     override inline def tripleTerm(t: RdfTriple.Predicate): RdfTriple = t.asInstanceOf[RdfTriple.Predicate.PTripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfTriple.Predicate = RdfTriple.Predicate.PIri(iri)
-    override inline def makeBnode(bnode: String): RdfTriple.Predicate = RdfTriple.Predicate.PBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfTriple.Predicate = RdfTriple.Predicate.PBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfTriple.Predicate = RdfTriple.Predicate.PLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfTriple.Predicate = RdfTriple.Predicate.PTripleTerm(triple)
     override val makeEmpty: RdfTriple.Predicate = RdfTriple.Predicate.Empty
@@ -45,12 +46,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfTriple.Object): Boolean = t.isOLiteral
     override inline def isTripleTerm(t: RdfTriple.Object): Boolean = t.isOTripleTerm
     override inline def iri(t: RdfTriple.Object): RdfIri = t.asInstanceOf[RdfTriple.Object.OIri].value
-    override inline def bnode(t: RdfTriple.Object): String = t.asInstanceOf[RdfTriple.Object.OBnode].value
+    override inline def bnode(t: RdfTriple.Object): ByteString = t.asInstanceOf[RdfTriple.Object.OBnode].value
     override inline def literal(t: RdfTriple.Object): RdfLiteral = t.asInstanceOf[RdfTriple.Object.OLiteral].value
     override inline def tripleTerm(t: RdfTriple.Object): RdfTriple = t.asInstanceOf[RdfTriple.Object.OTripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfTriple.Object = RdfTriple.Object.OIri(iri)
-    override inline def makeBnode(bnode: String): RdfTriple.Object = RdfTriple.Object.OBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfTriple.Object = RdfTriple.Object.OBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfTriple.Object = RdfTriple.Object.OLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfTriple.Object = RdfTriple.Object.OTripleTerm(triple)
     override val makeEmpty: RdfTriple.Object = RdfTriple.Object.Empty
@@ -61,12 +62,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfQuad.Subject): Boolean = t.isSLiteral
     override inline def isTripleTerm(t: RdfQuad.Subject): Boolean = t.isSTripleTerm
     override inline def iri(t: RdfQuad.Subject): RdfIri = t.asInstanceOf[RdfQuad.Subject.SIri].value
-    override inline def bnode(t: RdfQuad.Subject): String = t.asInstanceOf[RdfQuad.Subject.SBnode].value
+    override inline def bnode(t: RdfQuad.Subject): ByteString = t.asInstanceOf[RdfQuad.Subject.SBnode].value
     override inline def literal(t: RdfQuad.Subject): RdfLiteral = t.asInstanceOf[RdfQuad.Subject.SLiteral].value
     override inline def tripleTerm(t: RdfQuad.Subject): RdfTriple = t.asInstanceOf[RdfQuad.Subject.STripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfQuad.Subject = RdfQuad.Subject.SIri(iri)
-    override inline def makeBnode(bnode: String): RdfQuad.Subject = RdfQuad.Subject.SBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfQuad.Subject = RdfQuad.Subject.SBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfQuad.Subject = RdfQuad.Subject.SLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfQuad.Subject = RdfQuad.Subject.STripleTerm(triple)
     override val makeEmpty: RdfQuad.Subject = RdfQuad.Subject.Empty
@@ -77,12 +78,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfQuad.Predicate): Boolean = t.isPLiteral
     override inline def isTripleTerm(t: RdfQuad.Predicate): Boolean = t.isPTripleTerm
     override inline def iri(t: RdfQuad.Predicate): RdfIri = t.asInstanceOf[RdfQuad.Predicate.PIri].value
-    override inline def bnode(t: RdfQuad.Predicate): String = t.asInstanceOf[RdfQuad.Predicate.PBnode].value
+    override inline def bnode(t: RdfQuad.Predicate): ByteString = t.asInstanceOf[RdfQuad.Predicate.PBnode].value
     override inline def literal(t: RdfQuad.Predicate): RdfLiteral = t.asInstanceOf[RdfQuad.Predicate.PLiteral].value
     override inline def tripleTerm(t: RdfQuad.Predicate): RdfTriple = t.asInstanceOf[RdfQuad.Predicate.PTripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfQuad.Predicate = RdfQuad.Predicate.PIri(iri)
-    override inline def makeBnode(bnode: String): RdfQuad.Predicate = RdfQuad.Predicate.PBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfQuad.Predicate = RdfQuad.Predicate.PBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfQuad.Predicate = RdfQuad.Predicate.PLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfQuad.Predicate = RdfQuad.Predicate.PTripleTerm(triple)
     override val makeEmpty: RdfQuad.Predicate = RdfQuad.Predicate.Empty
@@ -93,12 +94,12 @@ object RdfTermAdapter:
     override inline def isLiteral(t: RdfQuad.Object): Boolean = t.isOLiteral
     override inline def isTripleTerm(t: RdfQuad.Object): Boolean = t.isOTripleTerm
     override inline def iri(t: RdfQuad.Object): RdfIri = t.asInstanceOf[RdfQuad.Object.OIri].value
-    override inline def bnode(t: RdfQuad.Object): String = t.asInstanceOf[RdfQuad.Object.OBnode].value
+    override inline def bnode(t: RdfQuad.Object): ByteString = t.asInstanceOf[RdfQuad.Object.OBnode].value
     override inline def literal(t: RdfQuad.Object): RdfLiteral = t.asInstanceOf[RdfQuad.Object.OLiteral].value
     override inline def tripleTerm(t: RdfQuad.Object): RdfTriple = t.asInstanceOf[RdfQuad.Object.OTripleTerm].value
 
     override inline def makeIri(iri: RdfIri): RdfQuad.Object = RdfQuad.Object.OIri(iri)
-    override inline def makeBnode(bnode: String): RdfQuad.Object = RdfQuad.Object.OBnode(bnode)
+    override inline def makeBnode(bnode: ByteString): RdfQuad.Object = RdfQuad.Object.OBnode(bnode)
     override inline def makeLiteral(literal: RdfLiteral): RdfQuad.Object = RdfQuad.Object.OLiteral(literal)
     override inline def makeTripleTerm(triple: RdfTriple): RdfQuad.Object = RdfQuad.Object.OTripleTerm(triple)
     override val makeEmpty: RdfQuad.Object = RdfQuad.Object.Empty
@@ -120,12 +121,12 @@ trait RdfTermAdapter[TInner]:
   def isLiteral(t: TInner): Boolean
   def isTripleTerm(t: TInner): Boolean
   def iri(t: TInner): RdfIri
-  def bnode(t: TInner): String
+  def bnode(t: TInner): ByteString
   def literal(t: TInner): RdfLiteral
   def tripleTerm(t: TInner): RdfTriple
 
   def makeIri(iri: RdfIri): TInner
-  def makeBnode(bnode: String): TInner
+  def makeBnode(bnode: ByteString): TInner
   def makeLiteral(literal: RdfLiteral): TInner
   def makeTripleTerm(triple: RdfTriple): TInner
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NameDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NameDecoderSpec.scala
@@ -1,8 +1,11 @@
 package eu.ostrzyciel.jelly.core
 
+import eu.ostrzyciel.jelly.core.helpers.Conversions.given
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.language.implicitConversions
 
 class NameDecoderSpec extends AnyWordSpec, Matchers:
   val smallOptions = RdfStreamOptions(maxNameTableSize = 16, maxPrefixTableSize = 8)

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NameEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NameEncoderSpec.scala
@@ -1,11 +1,14 @@
 package eu.ostrzyciel.jelly.core
 
+import com.google.protobuf.ByteString
+import eu.ostrzyciel.jelly.core.helpers.Conversions.given
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.mutable.ListBuffer
+import scala.language.implicitConversions
 
 class NameEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
   def smallOptions(prefixTableSize: Int) = RdfStreamOptions(
@@ -26,7 +29,7 @@ class NameEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
         dt.value should be (1)
         buffer.size should be (1)
         val dtEntry = buffer.head.row.datatype.get
-        dtEntry.value should be ("dt1")
+        dtEntry.value should be (ByteString.copyFromUtf8("dt1"))
         dtEntry.id should be (0)
       }
 
@@ -76,7 +79,7 @@ class NameEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
         for (r, i) <- buffer.zipWithIndex do
           val dt = r.row.datatype.get
           dt.id should be (expectedIds(i))
-          dt.value should be (s"dt${i + 1}")
+          dt.value should be (ByteString.copyFromUtf8(s"dt${i + 1}"))
       }
     }
 
@@ -177,7 +180,7 @@ class NameEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           (false, 0, "Cake4"),
           (false, 1, "Cake5"),
           (true, 1, ""),
-        )
+        ).map((isPrefix, id, value) => (isPrefix, id, ByteString.copyFromUtf8(value)))
 
         buffer.size should be (expectedBuffer.size)
         for ((isPrefix, eId, eVal), row) <- expectedBuffer.zip(buffer) do

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -1,11 +1,14 @@
 package eu.ostrzyciel.jelly.core
 
 import eu.ostrzyciel.jelly.core.helpers.Assertions.*
+import eu.ostrzyciel.jelly.core.helpers.Conversions.given
 import eu.ostrzyciel.jelly.core.helpers.MockConverterFactory
 import eu.ostrzyciel.jelly.core.helpers.Mrl.*
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.language.implicitConversions
 
 class ProtoDecoderSpec extends AnyWordSpec, Matchers:
   import ProtoDecoderImpl.*

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -1,7 +1,10 @@
 package eu.ostrzyciel.jelly.core
 
+import eu.ostrzyciel.jelly.core.helpers.Conversions.given
 import eu.ostrzyciel.jelly.core.helpers.Mrl.*
 import eu.ostrzyciel.jelly.core.proto.v1.*
+
+import scala.language.implicitConversions
 
 object ProtoTestCases:
   type RowValue = RdfStreamOptions | RdfDatatypeEntry | RdfPrefixEntry | RdfNameEntry | RdfTriple | RdfQuad |

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/Conversions.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/Conversions.scala
@@ -1,0 +1,6 @@
+package eu.ostrzyciel.jelly.core.helpers
+
+import com.google.protobuf.ByteString
+
+object Conversions:
+  given string2ByteString: Conversion[String, ByteString] = str => ByteString.copyFromUtf8(str)

--- a/integration-tests/src/test/resources/triples/nt-syntax-subm-01.nt
+++ b/integration-tests/src/test/resources/triples/nt-syntax-subm-01.nt
@@ -77,3 +77,9 @@ _:anon <http://example.org/property> <http://example.org/resource2> .
 # Typed Literals
 <http://example.org/resource32> <http://example.org/property> "abc"^^<http://example.org/datatype1> .
 # resource33 test removed 2003-08-03
+
+# Additional tests -- added for Jelly
+<http://a.example/s> <http://a.example/p> "߿ࠀ࿿က쿿퀀퟿�𐀀𿿽񀀀󿿽􀀀􏿽" .
+<http://a.zażółć.pl/gęślą_jaźń> <http://a.zażółć.pl/żółć> "żółć" .
+<http://a.zażółć.pl/gęślą_jaźń> <http://a.zażółć.pl/żółć> "żółć"^^<http://a.zażółć.pl/żółć> .
+<http://a.zażółć.pl/gęślą_jaźń> <http://a.zażółć.pl/żółć> "żółć"@pl .


### PR DESCRIPTION
I've noticed in profiling that a lot of the time is spent on computing the serialized sizes of strings... which is because the protobuf lib has to manually count all the code points because Java Strings are horrible – long story.

Let's see if this helps anything. If not, I will revert it.

WHY ARE THERE NO UTF-8 STRINGS IN JAVA? WHY???