### PR TITLE
Fix handling of Jena's default graph in parser

### DIFF
--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaDecoderConverter.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaDecoderConverter.scala
@@ -20,7 +20,7 @@ final class JenaDecoderConverter extends ProtoDecoderConverter[Node, RDFDatatype
 
   override inline def makeTripleNode(s: Node, p: Node, o: Node) = NodeFactory.createTripleNode(s, p, o)
 
-  override inline def makeDefaultGraphNode(): Node = null
+  override inline def makeDefaultGraphNode(): Node = Quad.defaultGraphIRI
 
   override inline def makeTriple(s: Node, p: Node, o: Node) = Triple.create(s, p, o)
 

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaDecoderConverterSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaDecoderConverterSpec.scala
@@ -1,0 +1,14 @@
+package eu.ostrzyciel.jelly.convert.jena
+
+import org.apache.jena.sparql.core.Quad
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JenaDecoderConverterSpec extends AnyWordSpec, Matchers:
+  val instance = JenaDecoderConverter()
+
+  "JenaDecoderConverter" should {
+    "make a default graph node" in {
+      instance.makeDefaultGraphNode() should be (Quad.defaultGraphIRI)
+    }
+  }

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoderSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoderSpec.scala
@@ -1,0 +1,43 @@
+package eu.ostrzyciel.jelly.convert.jena
+
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import org.apache.jena.sparql.core.Quad
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+
+/**
+ * Test the handling of the many ways to represent the default graph in Jena.
+ */
+class JenaProtoEncoderSpec extends AnyWordSpec, Matchers:
+  private val encodedDefaultGraph = RdfStreamRow(
+    RdfStreamRow.Row.GraphStart(
+      RdfGraphStart(RdfGraphStart.Graph.GDefaultGraph(
+        RdfDefaultGraph()
+      ))
+    )
+  )
+  
+  "JenaProtoEncoder" should {
+    "encode a null graph node as default graph" in {
+      val encoder = JenaProtoEncoder(JellyOptions.smallGeneralized)
+      val rows = encoder.startGraph(null).toSeq
+      rows.size should be (2)
+      rows(1) should be (encodedDefaultGraph)
+    }
+    
+    "encode an explicitly named default graph as default graph" in {
+      val encoder = JenaProtoEncoder(JellyOptions.smallGeneralized)
+      val rows = encoder.startGraph(Quad.defaultGraphIRI).toSeq
+      rows.size should be (2)
+      rows(1) should be (encodedDefaultGraph)
+    }
+    
+    "encode a generated default graph as default graph" in {
+      val encoder = JenaProtoEncoder(JellyOptions.smallGeneralized)
+      val rows = encoder.startGraph(Quad.defaultGraphNodeGenerated).toSeq
+      rows.size should be (2)
+      rows(1) should be (encodedDefaultGraph)
+    }
+  }


### PR DESCRIPTION
See: https://github.com/apache/jena/issues/2578

We used to emit "null" as the default graph, which (I think) is incorrect. We should be outputting Quad.defaultGraphIRI, which is correctly handled by the rest of Jena.

I've added a test for the parser that should pass now and a test for the serializer if it covers all types of default graphs in Jena.