### PR TITLE
Fix native parsing from Java InputStream

### DIFF
--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
@@ -38,15 +38,15 @@ final class JellyParser extends AbstractRDFParser:
 
     rdfHandler.startRDF()
     try {
-      while in.available() > 0 do
-        val frame = RdfStreamFrame.parseDelimitedFrom(in)
-        frame match
-          case Some(f) =>
-            for row <- f.rows do
-              decoder.ingestRow(row) match
-                case Some(st) => rdfHandler.handleStatement(st)
-                case None => ()
-          case None => ()
+      Iterator.continually(RdfStreamFrame.parseDelimitedFrom(in))
+        .takeWhile(_.isDefined)
+        .foreach { maybeFrame =>
+          val frame = maybeFrame.get
+          for row <- frame.rows do
+            decoder.ingestRow(row) match
+              case Some(st) => rdfHandler.handleStatement(st)
+              case None => ()
+        }
     }
     finally {
       rdfHandler.endRDF()


### PR DESCRIPTION
We checked if more bytes are available in the InputStream using .available()... which absolutely not how Java byte streams work, I have no idea how I made this mistake. Anyway, the proto lib checks this for us, so we can also simplify the code a bit.