### PR TITLE
Experiment: remove instanceof in term handling

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -127,7 +127,8 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   protected final inline def makeIriNode(iri: String): SpoTerm =
     iriEncoder.encodeIri(iri, extraRowsBuffer)
 
-  protected final inline def makeBlankNode(label: String): SpoTerm = label
+  protected final inline def makeBlankNode(label: String): SpoTerm =
+    RdfTerm.Bnode(label)
 
   protected final inline def makeSimpleLiteral(lex: String): SpoTerm =
     RdfLiteral(lex, RdfLiteral.LiteralKind.Empty)
@@ -144,7 +145,8 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   protected final inline def makeIriNodeGraph(iri: String): GraphTerm =
     iriEncoder.encodeIri(iri, extraRowsBuffer)
 
-  protected final inline def makeBlankNodeGraph(label: String): GraphTerm = label
+  protected final inline def makeBlankNodeGraph(label: String): GraphTerm =
+    RdfTerm.Bnode(label)
 
   protected final inline def makeSimpleLiteralGraph(lex: String): GraphTerm =
     RdfLiteral(lex, RdfLiteral.LiteralKind.Empty)

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
@@ -43,16 +43,16 @@ final case class RdfGraphStart(graph: GraphTerm = null) extends scalapb.Generate
     _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
     (__field.number: @_root_.scala.unchecked) match {
       case 1 =>
-        if (graph.isInstanceOf[RdfIri]) graph.asInstanceOf[RdfIri].toPMessage
+        if (graph.isIri) graph.iri.toPMessage
         else _root_.scalapb.descriptors.PEmpty
       case 2 =>
-        if (graph.isInstanceOf[String]) _root_.scalapb.descriptors.PString(graph.asInstanceOf[String])
+        if (graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode)
         else _root_.scalapb.descriptors.PEmpty
       case 3 =>
-        if (graph.isInstanceOf[RdfDefaultGraph]) graph.asInstanceOf[RdfDefaultGraph].toPMessage
+        if (graph.isDefaultGraph) graph.defaultGraph.toPMessage
         else _root_.scalapb.descriptors.PEmpty
       case 4 =>
-        if (graph.isInstanceOf[RdfLiteral]) graph.asInstanceOf[RdfLiteral].toPMessage
+        if (graph.isLiteral) graph.literal.toPMessage
         else _root_.scalapb.descriptors.PEmpty
     }
   }
@@ -76,7 +76,7 @@ object RdfGraphStart extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jel
         case 10 =>
           __graph = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 18 =>
-          __graph = _input__.readStringRequireUtf8()
+          __graph = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 26 =>
           __graph = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfDefaultGraph](_input__)
         case 34 =>
@@ -92,7 +92,7 @@ object RdfGraphStart extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jel
     case _root_.scalapb.descriptors.PMessage(__fieldsMap) =>
       _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
       eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart(graph = __fieldsMap.get(scalaDescriptor.findFieldByNumber(1).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-        .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+        .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
         .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(3).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfDefaultGraph]]))
         .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(4).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]])).orNull)
     case _ =>

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -73,7 +73,7 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
       case 14 =>
         graph.bnode
       case 15 =>
-        graph.asInstanceOf[RdfDefaultGraph]
+        graph.defaultGraph
       case 16 =>
         graph.literal
     }
@@ -111,7 +111,7 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
       case 14 =>
         if (graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode) else _root_.scalapb.descriptors.PEmpty
       case 15 =>
-        if (graph.isInstanceOf[RdfDefaultGraph]) graph.asInstanceOf[RdfDefaultGraph].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph.isInstanceOf[RdfDefaultGraph]) graph.defaultGraph.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 16 =>
         if (graph.isLiteral) graph.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
     }

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -111,7 +111,7 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
       case 14 =>
         if (graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode) else _root_.scalapb.descriptors.PEmpty
       case 15 =>
-        if (graph.isInstanceOf[RdfDefaultGraph]) graph.defaultGraph.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph.isDefaultGraph) graph.defaultGraph.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 16 =>
         if (graph.isLiteral) graph.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
     }

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -45,37 +45,37 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
   def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = {
     (__fieldNumber: @_root_.scala.unchecked) match {
       case 1 =>
-        subject.asInstanceOf[RdfIri]
+        subject.iri
       case 2 =>
-        subject.asInstanceOf[String]
+        subject.bnode
       case 3 =>
-        subject.asInstanceOf[RdfLiteral]
+        subject.literal
       case 4 =>
-        subject.asInstanceOf[RdfTriple]
+        subject.tripleTerm
       case 5 =>
-        predicate.asInstanceOf[RdfIri]
+        predicate.iri
       case 6 =>
-        predicate.asInstanceOf[String]
+        predicate.bnode
       case 7 =>
-        predicate.asInstanceOf[RdfLiteral]
+        predicate.literal
       case 8 =>
-        predicate.asInstanceOf[RdfTriple]
+        predicate.tripleTerm
       case 9 =>
-        `object`.asInstanceOf[RdfIri]
+        `object`.iri
       case 10 =>
-        `object`.asInstanceOf[String]
+        `object`.bnode
       case 11 =>
-        `object`.asInstanceOf[RdfLiteral]
+        `object`.literal
       case 12 =>
-        `object`.asInstanceOf[RdfTriple]
+        `object`.tripleTerm
       case 13 =>
-        graph.asInstanceOf[RdfIri]
+        graph.iri
       case 14 =>
-        graph.asInstanceOf[String]
+        graph.bnode
       case 15 =>
         graph.asInstanceOf[RdfDefaultGraph]
       case 16 =>
-        graph.asInstanceOf[RdfLiteral]
+        graph.literal
     }
   }
 
@@ -83,37 +83,37 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
     _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
     (__field.number: @_root_.scala.unchecked) match {
       case 1 =>
-        if (subject.isInstanceOf[RdfIri]) subject.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 2 =>
-        if (subject.isInstanceOf[String]) _root_.scalapb.descriptors.PString(subject.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
       case 3 =>
-        if (subject.isInstanceOf[RdfLiteral]) subject.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 4 =>
-        if (subject.isInstanceOf[RdfTriple]) subject.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 5 =>
-        if (predicate.isInstanceOf[RdfIri]) predicate.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 6 =>
-        if (predicate.isInstanceOf[String]) _root_.scalapb.descriptors.PString(predicate.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
       case 7 =>
-        if (predicate.isInstanceOf[RdfLiteral]) predicate.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 8 =>
-        if (predicate.isInstanceOf[RdfTriple]) predicate.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 9 =>
-        if (`object`.isInstanceOf[RdfIri]) `object`.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 10 =>
-        if (`object`.isInstanceOf[String]) _root_.scalapb.descriptors.PString(`object`.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
       case 11 =>
-        if (`object`.isInstanceOf[RdfLiteral]) `object`.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 12 =>
-        if (`object`.isInstanceOf[RdfTriple]) `object`.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 13 =>
-        if (graph.isInstanceOf[RdfIri]) graph.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph.isIri) graph.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 14 =>
-        if (graph.isInstanceOf[String]) _root_.scalapb.descriptors.PString(graph.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode) else _root_.scalapb.descriptors.PEmpty
       case 15 =>
         if (graph.isInstanceOf[RdfDefaultGraph]) graph.asInstanceOf[RdfDefaultGraph].toPMessage else _root_.scalapb.descriptors.PEmpty
       case 16 =>
-        if (graph.isInstanceOf[RdfLiteral]) graph.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph.isLiteral) graph.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
     }
   }
 
@@ -139,7 +139,7 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
         case 10 =>
           __subject = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 18 =>
-          __subject = _input__.readStringRequireUtf8()
+          __subject = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 26 =>
           __subject = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 34 =>
@@ -147,7 +147,7 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
         case 42 =>
           __predicate = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 50 =>
-          __predicate = _input__.readStringRequireUtf8()
+          __predicate = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 58 =>
           __predicate = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 66 =>
@@ -155,7 +155,7 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
         case 74 =>
           __object = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 82 =>
-          __object = _input__.readStringRequireUtf8()
+          __object = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 90 =>
           __object = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 98 =>
@@ -163,7 +163,7 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
         case 106 =>
           __graph = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 114 =>
-          __graph = _input__.readStringRequireUtf8()
+          __graph = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 122 =>
           __graph = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfDefaultGraph](_input__)
         case 130 =>
@@ -180,22 +180,22 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
       _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
       eu.ostrzyciel.jelly.core.proto.v1.RdfQuad(
         subject = __fieldsMap.get(scalaDescriptor.findFieldByNumber(1).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(3).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(4).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull,
         predicate = __fieldsMap.get(scalaDescriptor.findFieldByNumber(5).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(6).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(6).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(7).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(8).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull,
         `object` = __fieldsMap.get(scalaDescriptor.findFieldByNumber(9).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(10).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(10).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(11).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(12).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull,
         graph = __fieldsMap.get(scalaDescriptor.findFieldByNumber(13).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(14).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(14).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(15).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfDefaultGraph]]))
           .orElse[GraphTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(16).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orNull

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTerm.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTerm.scala
@@ -4,75 +4,109 @@ import com.google.protobuf.CodedOutputStream
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 /**
- * Union type for RDF terms, used in RdfTriple, RdfQuad, and RdfGraphStart.
+ * Trait enabling access into the fields of RDF terms (subjects, predicates, objects, graphs) in the
+ * protobuf encoding.
+ *
+ * See also [[eu.ostrzyciel.jelly.core.proto_adapters.RdfTermCompanion]].
  */
-type RdfTerm = RdfIri | String | RdfLiteral | Null
+sealed trait RdfTerm:
+  def isIri: Boolean = false
+  def isBnode: Boolean = false
+  def isLiteral: Boolean = false
+  def iri: RdfIri = null
+  def bnode: String = ""
+  def literal: RdfLiteral = null
 
-/**
- * Union type for RDF terms, used in RdfTriple and RdfQuad in S, P, O positions
- */
-type SpoTerm = RdfTerm | RdfTriple
+/** @inheritdoc */
+trait SpoTerm extends RdfTerm:
+  def isTripleTerm: Boolean = false
+  def tripleTerm: RdfTriple = null
 
-/**
- * Union type for RDF terms, used in RdfQuad and RdfGraphStart in G position
- */
-type GraphTerm = RdfTerm | RdfDefaultGraph
+/** @inheritdoc */
+trait GraphTerm extends RdfTerm:
+  def isDefaultGraph: Boolean = false
+  def defaultGraph: RdfDefaultGraph = null
+
+
+object RdfTerm:
+  /**
+   * Wrapper class for blank nodes, because in the proto they are simply represented as strings, and
+   * we cannot inherit from String. We must use a wrapper.
+   */
+  final case class Bnode(override val bnode: String) extends SpoTerm, GraphTerm:
+    override def isBnode: Boolean = true
 
 // Methods below are used in RdfTriple, RdfQuad, and RdfGraphStart instead of generated code. They are all
 // inlined by the Scala compiler.
 
 private[v1] inline def fieldTagSize(inline tag: Int) = if tag < 16 then 1 else 2
 
-private[v1] inline def graphTermSerializedSize(g: GraphTerm, inline tagOffset: Int) = g match
-  case null => 0
-  case iri: RdfIri => fieldTagSize(1 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(iri.serializedSize) + iri.serializedSize
-  case bnode: String => CodedOutputStream.computeStringSize(2 + tagOffset, bnode)
-  case defaultGraph: RdfDefaultGraph => fieldTagSize(3 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(defaultGraph.serializedSize) + defaultGraph.serializedSize
-  case literal: RdfLiteral => fieldTagSize(4 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(literal.serializedSize)+ literal.serializedSize
+private[v1] inline def graphTermSerializedSize(g: GraphTerm, inline tagOffset: Int): Int =
+  if g == null then 0
+  else if g.isIri then
+    val iriS = g.iri.serializedSize
+    fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
+  else if g.isDefaultGraph then
+    val dgS = g.defaultGraph.serializedSize
+    fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(dgS) + dgS
+  else if g.isBnode then
+    CodedOutputStream.computeStringSize(2 + tagOffset, g.bnode)
+  else if g.isLiteral then
+    val litS = g.literal.serializedSize
+    fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(litS) + litS
+  else 0
   
-private[v1] inline def graphTermWriteTo(g: GraphTerm, inline tagOffset: Int, out: CodedOutputStream): Unit = g match
-  case null => ()
-  case iri: RdfIri =>
+private[v1] inline def graphTermWriteTo(g: GraphTerm, inline tagOffset: Int, out: CodedOutputStream): Unit =
+  if g == null then ()
+  else if g.isIri then
+    val iri = g.iri
     out.writeTag(1 + tagOffset, 2)
     out.writeUInt32NoTag(iri.serializedSize)
     iri.writeTo(out)
-  case bnode: String =>
-    out.writeString(2 + tagOffset, bnode)
-  case defaultGraph: RdfDefaultGraph =>
+  else if g.isDefaultGraph then
+    val defaultGraph = g.defaultGraph
     out.writeTag(3 + tagOffset, 2)
     out.writeUInt32NoTag(defaultGraph.serializedSize)
     defaultGraph.writeTo(out)
-  case literal: RdfLiteral =>
+  else if g.isBnode then
+    out.writeString(2 + tagOffset, g.bnode)
+  else if g.isLiteral then
+    val literal = g.literal
     out.writeTag(4 + tagOffset, 2)
     out.writeUInt32NoTag(literal.serializedSize)
     literal.writeTo(out)
   
-private[v1] inline def spoTermSerializedSize(t: SpoTerm, inline tagOffset: Int) = t match
-  case null => 0
-  case iri: RdfIri => fieldTagSize(1 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(iri.serializedSize) + iri.serializedSize
-  case bnode: String => CodedOutputStream.computeStringSize(2 + tagOffset, bnode)
-  case literal: RdfLiteral => fieldTagSize(3 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(literal.serializedSize) + literal.serializedSize
-  case triple: RdfTriple => fieldTagSize(4 + tagOffset)
-    + CodedOutputStream.computeUInt32SizeNoTag(triple.serializedSize) + triple.serializedSize
+private[v1] inline def spoTermSerializedSize(t: SpoTerm, inline tagOffset: Int) =
+  if t == null then 0
+  else if t.isIri then
+    val iriS = t.iri.serializedSize
+    fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
+  else if t.isBnode then
+    CodedOutputStream.computeStringSize(2 + tagOffset, t.bnode)
+  else if t.isLiteral then
+    val literalS = t.literal.serializedSize
+    fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(literalS) + literalS
+  else if t.isTripleTerm then
+    val tripleS = t.tripleTerm.serializedSize
+    fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(tripleS) + tripleS
+  else 0
 
-private[v1] inline def spoTermWriteTo(t: SpoTerm, inline tagOffset: Int, out: CodedOutputStream): Unit = t match
-  case null => ()
-  case iri: RdfIri =>
+private[v1] inline def spoTermWriteTo(t: SpoTerm, inline tagOffset: Int, out: CodedOutputStream): Unit =
+  if t == null then ()
+  else if t.isIri then
+    val iri = t.iri
     out.writeTag(1 + tagOffset, 2)
     out.writeUInt32NoTag(iri.serializedSize)
     iri.writeTo(out)
-  case bnode: String =>
-    out.writeString(2 + tagOffset, bnode)
-  case literal: RdfLiteral =>
+  else if t.isBnode then
+    out.writeString(2 + tagOffset, t.bnode)
+  else if t.isLiteral then
+    val literal = t.literal
     out.writeTag(3 + tagOffset, 2)
     out.writeUInt32NoTag(literal.serializedSize)
     literal.writeTo(out)
-  case triple: RdfTriple =>
+  else if t.isTripleTerm then
+    val triple = t.tripleTerm
     out.writeTag(4 + tagOffset, 2)
     out.writeUInt32NoTag(triple.serializedSize)
     triple.writeTo(out)

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
@@ -19,7 +19,8 @@ package eu.ostrzyciel.jelly.core.proto.v1
  * optimizations to make this as fast as possible.
  */
 @SerialVersionUID(0L)
-final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `object`: SpoTerm = null) extends scalapb.GeneratedMessage {
+final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `object`: SpoTerm = null)
+  extends scalapb.GeneratedMessage, SpoTerm, GraphTerm {
   @transient private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
 
   private[this] def __computeSerializedSize(): _root_.scala.Int = {
@@ -46,29 +47,29 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
   def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = {
     (__fieldNumber: @_root_.scala.unchecked) match {
       case 1 =>
-        subject.asInstanceOf[RdfIri]
+        subject.iri
       case 2 =>
-        subject.asInstanceOf[String]
+        subject.bnode
       case 3 =>
-        subject.asInstanceOf[RdfLiteral]
+        subject.literal
       case 4 =>
-        subject.asInstanceOf[RdfTriple]
+        subject.tripleTerm
       case 5 =>
-        predicate.asInstanceOf[RdfIri]
+        predicate.iri
       case 6 =>
-        predicate.asInstanceOf[String]
+        predicate.bnode
       case 7 =>
-        predicate.asInstanceOf[RdfLiteral]
+        predicate.literal
       case 8 =>
-        predicate.asInstanceOf[RdfTriple]
+        predicate.tripleTerm
       case 9 =>
-        `object`.asInstanceOf[RdfIri]
+        `object`.iri
       case 10 =>
-        `object`.asInstanceOf[String]
+        `object`.bnode
       case 11 =>
-        `object`.asInstanceOf[RdfLiteral]
+        `object`.literal
       case 12 =>
-        `object`.asInstanceOf[RdfTriple]
+        `object`.tripleTerm
     }
   }
 
@@ -76,35 +77,39 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
     _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
     (__field.number: @_root_.scala.unchecked) match {
       case 1 =>
-        if (subject.isInstanceOf[RdfIri]) subject.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 2 =>
-        if (subject.isInstanceOf[String]) _root_.scalapb.descriptors.PString(subject.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
       case 3 =>
-        if (subject.isInstanceOf[RdfLiteral]) subject.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 4 =>
-        if (subject.isInstanceOf[RdfTriple]) subject.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 5 =>
-        if (predicate.isInstanceOf[RdfIri]) predicate.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 6 =>
-        if (predicate.isInstanceOf[String]) _root_.scalapb.descriptors.PString(predicate.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
       case 7 =>
-        if (predicate.isInstanceOf[RdfLiteral]) predicate.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 8 =>
-        if (predicate.isInstanceOf[RdfTriple]) predicate.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 9 =>
-        if (`object`.isInstanceOf[RdfIri]) `object`.asInstanceOf[RdfIri].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 10 =>
-        if (`object`.isInstanceOf[String]) _root_.scalapb.descriptors.PString(`object`.asInstanceOf[String]) else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
       case 11 =>
-        if (`object`.isInstanceOf[RdfLiteral]) `object`.asInstanceOf[RdfLiteral].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 12 =>
-        if (`object`.isInstanceOf[RdfTriple]) `object`.asInstanceOf[RdfTriple].toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
     }
   }
 
   def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
 
   def companion: eu.ostrzyciel.jelly.core.proto.v1.RdfTriple.type = eu.ostrzyciel.jelly.core.proto.v1.RdfTriple
+
+  override def isTripleTerm: Boolean = true
+
+  override def tripleTerm: RdfTriple = this
 }
 
 object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple] {
@@ -123,7 +128,7 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
         case 10 =>
           __subject = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 18 =>
-          __subject = _input__.readStringRequireUtf8()
+          __subject = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 26 =>
           __subject = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 34 =>
@@ -131,7 +136,7 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
         case 42 =>
           __predicate = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 50 =>
-          __predicate = _input__.readStringRequireUtf8()
+          __predicate = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 58 =>
           __predicate = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 66 =>
@@ -139,7 +144,7 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
         case 74 =>
           __object = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfIri](_input__)
         case 82 =>
-          __object = _input__.readStringRequireUtf8()
+          __object = RdfTerm.Bnode(_input__.readStringRequireUtf8())
         case 90 =>
           __object = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral](_input__)
         case 98 =>
@@ -156,17 +161,17 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
       _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
       eu.ostrzyciel.jelly.core.proto.v1.RdfTriple(
         subject = __fieldsMap.get(scalaDescriptor.findFieldByNumber(1).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(3).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(4).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull,
         predicate = __fieldsMap.get(scalaDescriptor.findFieldByNumber(5).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(6).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(6).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(7).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(8).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull,
         `object` = __fieldsMap.get(scalaDescriptor.findFieldByNumber(9).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfIri]])
-          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(10).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]))
+          .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(10).get).flatMap(_.as[_root_.scala.Option[_root_.scala.Predef.String]]).map(RdfTerm.Bnode.apply))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(11).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfLiteral]]))
           .orElse[SpoTerm](__fieldsMap.get(scalaDescriptor.findFieldByNumber(12).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
           .orNull

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -151,10 +151,10 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.TRIPLES),
         RdfQuad(
-          "1",
-          "2",
-          "3",
-          "4",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
+          RdfTerm.Bnode("4"),
         ),
       ))
       decoder.ingestRow(data.head)
@@ -202,8 +202,8 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.TRIPLES),
         RdfTriple(
-          "1",
-          "2",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
           RdfTriple(null, null, null),
         )
       ))
@@ -227,8 +227,8 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.TRIPLES),
         RdfTriple(
-          "1",
-          "2",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
           RdfLiteral("test", RdfLiteral.LiteralKind.Empty),
         ),
       ))
@@ -264,9 +264,9 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.QUADS),
         RdfTriple(
-          "1",
-          "2",
-          "3",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
         ),
       ))
       decoder.ingestRow(data.head)
@@ -331,10 +331,10 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.GRAPHS),
         RdfQuad(
-          "1",
-          "2",
-          "3",
-          "4",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
+          RdfTerm.Bnode("4"),
         ),
       ))
       decoder.ingestRow(data.head)
@@ -349,9 +349,9 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.GRAPHS),
         RdfTriple(
-          "1",
-          "2",
-          "3",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
         ),
         RdfGraphEnd(),
       ))
@@ -394,9 +394,9 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.GRAPHS),
         RdfTriple(
-          "1",
-          "2",
-          "3",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
         ),
       ))
       decoder.ingestRow(data.head)
@@ -436,9 +436,9 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       val decoder = MockConverterFactory.anyStatementDecoder()
       val data = wrapEncodedFull(Seq(
         RdfTriple(
-          "1",
-          "2",
-          "3",
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
         ),
       ))
       val error = intercept[RdfProtoDeserializationError] {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -140,7 +140,7 @@ object ProtoTestCases:
       ),
       RdfQuad(
         null,
-        "blank",
+        RdfTerm.Bnode("blank"),
         RdfLiteral(
           "test", RdfLiteral.LiteralKind.Empty
         ),
@@ -150,7 +150,7 @@ object ProtoTestCases:
         null,
         null,
         null,
-        "blank",
+        RdfTerm.Bnode("blank"),
       ),
       RdfQuad(
         null,
@@ -191,7 +191,7 @@ object ProtoTestCases:
       ),
       RdfQuad(
         null,
-        "blank",
+        RdfTerm.Bnode("blank"),
         RdfLiteral("test", RdfLiteral.LiteralKind.Empty),
         null,
       ),

--- a/project/ProtoTransformer.scala
+++ b/project/ProtoTransformer.scala
@@ -4,6 +4,7 @@ object ProtoTransformer {
   val transformations: Seq[Transformer] = Seq(
     Transform1.transformer,
     Transform2.transformer,
+    Transform3.transformer,
   )
 
   def transform(input: String): String = {


### PR DESCRIPTION
Continuation of #118

The previous PR did improve deserialization speed significantly, but it made serialization slightly slower, which was not expected. I assume that might be due to the large number of instanceof checks and class casts involved. I've replaced this with a hybrid of the previous solution, where only for blank nodes we use a custom wrapper class (because String is final), and for the rest (e.g., RdfIri), we simply extend their interfaces to include the checker and accessor methods that we need from them.

Let's see if this helps. If not, I will revert this together with #118.