### PR TITLE
Require Java 17 for Jelly 1.1.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'sbt'
 
       - run: sbt ci-release
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'sbt'
 
       - name: 'Build plugins'

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            java: 11
-          - os: ubuntu-latest
             java: 17
           - os: ubuntu-latest
             java: 21
+          - os: ubuntu-latest
+            java: 22
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -47,9 +47,10 @@ The Jelly-JVM implementation is compatible with Java 11 and newer. Java 11, 17, 
 
 The following table shows the compatibility of the Jelly-JVM implementation with other libraries:
 
-| Jelly-JVM | Scala       | Java | RDF4J | Apache Jena | Apache Pekko |
-| ----- | :---------: | :--: | :---: | :---------: | :----------: |
-| **1.0.x** | 3.3.x (LTS)<br>2.13.x[^1] | 11+  | 4.x.x | 4.x.x       | 1.0.x        |
+| Jelly-JVM | Scala                     | Java | RDF4J | Apache Jena | Apache Pekko |
+| --------- | :-----------------------: | :--: | :---: | :---------: | :----------: |
+| **1.1.x** | 3.3.x (LTS)<br>2.13.x[^1] | 17+  | 4.x.x | 4.x.x       | 1.0.x        |
+| 1.0.x     | 3.3.x (LTS)<br>2.13.x[^1] | 11+  | 4.x.x | 4.x.x       | 1.0.x        |
 
 See the **[compatibility policy](user/compatibility.md)** for more details and the **[release notes on GitHub](https://github.com/Jelly-RDF/jelly-jvm/releases)**.
 

--- a/docs/docs/user/compatibility.md
+++ b/docs/docs/user/compatibility.md
@@ -4,7 +4,7 @@ Jelly-JVM follows [Semantic Versioning 2.0.0](https://semver.org/), with MAJOR.M
 
 ## JVM and Scala
 
-The current version of Jelly-JVM is compatible with Java 11 and newer. Java 11, 17, and 21 are tested in CI and are guaranteed to work. We recommend using a recent release of [GraalVM](https://www.graalvm.org/) to get the best performance.
+The current version of Jelly-JVM is compatible with Java 17 and newer. Java 17, 21, and 22 are tested in CI and are guaranteed to work. We recommend using a recent release of [GraalVM](https://www.graalvm.org/) to get the best performance. If you need Java 11 support, you should use [Jelly-JVM 1.0.x](https://w3id.org/jelly/jelly-jvm/1.0.x).
 
 Jelly is built with [Scala 3 LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html), however, [Scala 2.13-compatible builds are available as well](scala2.md).
 


### PR DESCRIPTION
Issue: #135 

- Increased the minimum Java version in CI.
- Updated compatibility table in the documentation.
- Switched from testing in CI Java 11, 17, 21 to 17, 21, 22.