### PR TITLE
Fix deprecated method call in scalameta

### DIFF
--- a/project/Transform3.scala
+++ b/project/Transform3.scala
@@ -11,7 +11,7 @@ object Transform3 {
         inits = templ.inits ++ traits.map { tName =>
           Init.After_4_6_0(Type.Name(tName), Name.Anonymous(), Nil)
         },
-        stats = templ.stats ++ Seq(
+        stats = templ.body.stats ++ Seq(
           Defn.Def.After_4_7_3(
             List(Mod.Override()),
             Term.Name(isName),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,8 @@
 libraryDependencies += "org.scalameta" %% "scalameta" % "4.10.1"
+
+scalacOptions ++= Seq(
+  "-Werror",
+  "-feature",
+  "-deprecation",
+  "-unchecked",
+)


### PR DESCRIPTION
Also add compiler options to the scalameta sub-project to error out on these deprecations. In general, the compiler options were made on par with the main project.