### PR TITLE
Update Jena to 5.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 lazy val pekkoV = "1.1.2"
 lazy val pekkoGrpcV = "1.1.0"
-lazy val jenaV = "5.1.0"
+lazy val jenaV = "5.2.0"
 lazy val rdf4jV = "5.0.2"
 // !! When updating ScalaPB also change the version of the plugin in plugins.sbt
 lazy val scalapbV = "0.11.17"

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
@@ -2,9 +2,7 @@ package eu.ostrzyciel.jelly.convert.jena
 
 import eu.ostrzyciel.jelly.core.*
 import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, SpoTerm}
-import org.apache.jena.JenaRuntime
 import org.apache.jena.datatypes.xsd.XSDDatatype
-import org.apache.jena.datatypes.xsd.impl.RDFLangString
 import org.apache.jena.graph.*
 import org.apache.jena.sparql.core.Quad
 


### PR DESCRIPTION
We had some leftover imports that should not have been used since 5.0.0. Because we weren't really using this classes, this should be fine bincompat-wise.