### PR TITLE
Use Scala 3 for proto compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val commonSettings = Seq(
 // Intermediate project that generates the Scala code from the protobuf files
 lazy val rdfProtos = (project in file("rdf-protos"))
   .settings(
-    name := "jelly-scalameta-test",
+    name := "jelly-scalameta",
     libraryDependencies ++= protobufCompilerDeps,
     Compile / PB.targets := Seq(
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
@@ -75,7 +75,6 @@ lazy val rdfProtos = (project in file("rdf-protos"))
     // Add the shared proto sources
     Compile / PB.protoSources ++= Seq(baseDirectory.value / "src" / "main" / "protobuf_shared"),
     Compile / PB.generate / excludeFilter := "grpc.proto",
-    scalaVersion := "2.13.15",
     publishArtifact := false,
   )
 
@@ -90,7 +89,7 @@ lazy val core = (project in file("core"))
     // Add the generated proto classes after transforming them with Scalameta
     Compile / sourceGenerators += Def.task {
       Generator.gen(
-        inputDir = (rdfProtos / target).value / "scala-2.13" / "src_managed" / "main",
+        inputDir = (rdfProtos / target).value / ("scala-" + scalaVersion.value) / "src_managed" / "main",
         outputDir = sourceManaged.value / "scalapb",
       )
     }.dependsOn(rdfProtos / Compile / PB.generate),

--- a/rdf-protos/src/main/protobuf/package.proto
+++ b/rdf-protos/src/main/protobuf/package.proto
@@ -14,6 +14,7 @@ option (scalapb.options) = {
   // Disabling this can substantially improve performance
   preserve_unknown_fields: false
   enum_strip_prefix: true
+  scala3_sources: true
 };
 
 option java_package = "eu.ostrzyciel.jelly.core.proto.v1";


### PR DESCRIPTION
This removes the need to use Scala 2 in proto compilation. Now we use it only for scalameta.