### PR TITLE
Move Fuseki integration to a Jena module

### DIFF
--- a/docs/docs/getting-started-plugins.md
+++ b/docs/docs/getting-started-plugins.md
@@ -20,13 +20,9 @@ You can simply add Jelly format support to [Apache Jena](https://jena.apache.org
     - For other applications, consult the manual of the application.
 - You can now use the Jelly format for parsing, serialization, and streaming serialization in your Jena application.
 
-!!! bug "Content negotiation in Fuseki"
+!!! warning "Content negotiation in Fuseki"
 
-    Content negotiation using the `application/x-jelly-rdf` media type in the `Accept` header works in Fuseki "Main" distribution since version 5.2.0. To get it working, you need to run Fuseki with the `--modules=true` command-line option. Content negotiation does not work in the "webapp" distribution with UI due to an [upstream bug](https://github.com/apache/jena/issues/2774).
-
-    In Fuseki 5.1.0 and older, content negotiation with Jelly does not work at all.
-    
-    To work around these issues, you can specify the `output=application/x-jelly-rdf` parameter (either in the URL or in the URL-encoded form body) when querying the endpoint.
+    Content negotiation using the `application/x-jelly-rdf` media type in the `Accept` header works in Fuseki since Apache Jena version 5.2.0. Previous versions of Fuseki did not support media type registration.
     
 
 ### Eclipse RDF4J

--- a/jena/src/main/resources/META-INF/services/org.apache.jena.fuseki.main.sys.FusekiAutoModule
+++ b/jena/src/main/resources/META-INF/services/org.apache.jena.fuseki.main.sys.FusekiAutoModule
@@ -1,1 +1,0 @@
-eu.ostrzyciel.jelly.convert.jena.fuseki.JellyFusekiModule

--- a/jena/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
+++ b/jena/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
@@ -1,1 +1,2 @@
 eu.ostrzyciel.jelly.convert.jena.riot.JellySubsystemLifecycle
+eu.ostrzyciel.jelly.convert.jena.fuseki.JellyFusekiLifecycle

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
@@ -1,15 +1,18 @@
 package eu.ostrzyciel.jelly.convert.jena.fuseki
 
+import eu.ostrzyciel.jelly.convert.jena.riot.JellySubsystemLifecycle
 import org.apache.jena.fuseki.DEF
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters.*
 
-class JellyFusekiModuleSpec extends AnyWordSpec, Matchers:
-  "JellyFusekiModule" should {
-    "have a name" in {
-      JellyFusekiLifecycle().name() should be ("Jelly")
+class JellyFusekiLifecycleSpec extends AnyWordSpec, Matchers:
+  "JellyFusekiLifecycle" should {
+    "initialize after JenaSubsystemLifecycle" in {
+      val jenaModule = JellySubsystemLifecycle()
+      val module = JellyFusekiLifecycle()
+      module.level() should be > jenaModule.level()
     }
 
     "use the correct content type for Jelly" in {

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
@@ -2,6 +2,7 @@ package eu.ostrzyciel.jelly.convert.jena.fuseki
 
 import eu.ostrzyciel.jelly.convert.jena.riot.JellySubsystemLifecycle
 import org.apache.jena.fuseki.DEF
+import org.apache.jena.sys.JenaSystem
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -20,6 +21,11 @@ class JellyFusekiLifecycleSpec extends AnyWordSpec, Matchers:
     }
 
     "register the Jelly content type in the lists of accepted content types" in {
+      // This assumption is broken for `jenaPlugin` tests, because there the JenaSystem is initialized
+      // and reads the service definition.
+      // This test thus only can be executed in the `jena` module.
+      assume(DEF.constructOffer == DEF.constructOfferDefault())
+
       val oldLists = List(DEF.constructOffer, DEF.rdfOffer, DEF.quadsOffer)
       for list <- oldLists do
         list.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiLifecycleSpec.scala
@@ -29,9 +29,6 @@ class JellyFusekiLifecycleSpec extends AnyWordSpec, Matchers:
       val oldLists = List(DEF.constructOffer, DEF.rdfOffer, DEF.quadsOffer)
       for list <- oldLists do
         list.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
-      DEF.constructOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
-      DEF.rdfOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
-      DEF.quadsOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
 
       val module = JellyFusekiLifecycle()
       module.start()

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiModuleSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/fuseki/JellyFusekiModuleSpec.scala
@@ -9,38 +9,38 @@ import scala.jdk.CollectionConverters.*
 class JellyFusekiModuleSpec extends AnyWordSpec, Matchers:
   "JellyFusekiModule" should {
     "have a name" in {
-      JellyFusekiModule().name() should be ("Jelly")
+      JellyFusekiLifecycle().name() should be ("Jelly")
     }
 
     "use the correct content type for Jelly" in {
-      JellyFusekiModule.mediaRangeJelly.getContentTypeStr should be ("application/x-jelly-rdf")
+      JellyFusekiLifecycle.mediaRangeJelly.getContentTypeStr should be ("application/x-jelly-rdf")
     }
 
     "register the Jelly content type in the lists of accepted content types" in {
       val oldLists = List(DEF.constructOffer, DEF.rdfOffer, DEF.quadsOffer)
       for list <- oldLists do
-        list.entries().asScala should not contain JellyFusekiModule.mediaRangeJelly
-      DEF.constructOffer.entries().asScala should not contain JellyFusekiModule.mediaRangeJelly
-      DEF.rdfOffer.entries().asScala should not contain JellyFusekiModule.mediaRangeJelly
-      DEF.quadsOffer.entries().asScala should not contain JellyFusekiModule.mediaRangeJelly
+        list.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
+      DEF.constructOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
+      DEF.rdfOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
+      DEF.quadsOffer.entries().asScala should not contain JellyFusekiLifecycle.mediaRangeJelly
 
-      val module = JellyFusekiModule()
+      val module = JellyFusekiLifecycle()
       module.start()
 
       val lists = List(DEF.constructOffer, DEF.rdfOffer, DEF.quadsOffer)
       for (list, oldList) <- lists.zip(oldLists) do
-        list.entries().asScala should contain (JellyFusekiModule.mediaRangeJelly)
+        list.entries().asScala should contain (JellyFusekiLifecycle.mediaRangeJelly)
         list.entries().size() should be (oldList.entries().size() + 1)
     }
 
     "not register the Jelly content type if it's already registered" in {
-      val module = JellyFusekiModule()
+      val module = JellyFusekiLifecycle()
       module.start()
-      DEF.rdfOffer.entries().asScala should contain (JellyFusekiModule.mediaRangeJelly)
+      DEF.rdfOffer.entries().asScala should contain (JellyFusekiLifecycle.mediaRangeJelly)
       val size1 = DEF.rdfOffer.entries().size()
 
       module.start()
-      DEF.rdfOffer.entries().asScala should contain (JellyFusekiModule.mediaRangeJelly)
+      DEF.rdfOffer.entries().asScala should contain (JellyFusekiLifecycle.mediaRangeJelly)
       val size2 = DEF.rdfOffer.entries().size()
       size2 should be (size1)
     }


### PR DESCRIPTION
Follow-up from #136

Fuseki modules are not supported in all Fuseki distributions, so it makes more sense to move the functionality to a Jena module. The only disadvantage is that the module loads regardless of whether we are in a Fuseki instance or not, but that can be solved with some exception catching...

I tested this on:

- Fuseki 5.2.0: works perfectly and displays a message that the media type was registered
- Fuseki 5.1.0: displays a warning that the registration doesn't work because Fuseki is too old
- Jena CLI utils: module initialization fails silently, the CLI tool works as expected