### PR TITLE
Encoder: Maybe speed up stream row buffer

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/FastBuffer.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/FastBuffer.java
@@ -1,0 +1,45 @@
+package eu.ostrzyciel.jelly.core;
+
+class FastBuffer<T> {
+    private static final int CAPACITY_INCREASE = 16;
+
+    private T[] buffer;
+    private int size;
+    private int capacity;
+
+    public FastBuffer(int capacity) {
+        this.capacity = capacity;
+        this.size = 0;
+        this.buffer = (T[]) new Object[capacity];
+    }
+
+    public FastBuffer<T> append(T element) {
+        if (size == capacity) {
+            capacity += CAPACITY_INCREASE;
+            T[] newBuffer = (T[]) new Object[capacity];
+            System.arraycopy(buffer, 0, newBuffer, 0, size);
+            buffer = newBuffer;
+        }
+        buffer[size++] = element;
+        return this;
+    }
+
+    public T get(int index) {
+        return buffer[index];
+    }
+
+    public FastBuffer<T> clear() {
+        size = 0;
+        return this;
+    }
+
+    public T[] getBufferCopy() {
+        T[] copy = (T[]) new Object[size];
+        System.arraycopy(buffer, 0, copy, 0, size);
+        return copy;
+    }
+
+    public int size() {
+        return size;
+    }
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -1,7 +1,6 @@
 package eu.ostrzyciel.jelly.core;
 
 import eu.ostrzyciel.jelly.core.proto.v1.*;
-import scala.collection.mutable.ArrayBuffer;
 
 import java.util.LinkedHashMap;
 import java.util.function.Function;
@@ -95,7 +94,7 @@ public final class NodeEncoder<TNode> {
      * @return The encoded literal
      */
     public UniversalTerm encodeDtLiteral(
-            TNode key, String lex, String datatypeName, ArrayBuffer<RdfStreamRow> rowsBuffer
+            TNode key, String lex, String datatypeName, FastBuffer<RdfStreamRow> rowsBuffer
     ) {
         var cachedNode = dependentNodeCache.computeIfAbsent(key, k -> new DependentNode());
         // Check if the value is still valid
@@ -130,7 +129,7 @@ public final class NodeEncoder<TNode> {
      * @param rowsBuffer The buffer to which the new name and prefix lookup entries should be appended
      * @return The encoded IRI
      */
-    public UniversalTerm encodeIri(String iri, ArrayBuffer<RdfStreamRow> rowsBuffer) {
+    public UniversalTerm encodeIri(String iri, FastBuffer<RdfStreamRow> rowsBuffer) {
         var cachedNode = dependentNodeCache.computeIfAbsent(iri, k -> new DependentNode());
         // Check if the value is still valid
         if (cachedNode.encoded != null &&

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -2,8 +2,6 @@ package eu.ostrzyciel.jelly.core
 
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-
 object ProtoEncoder:
   private val graphEnd = Seq(RdfStreamRow(RdfStreamRow.Row.GraphEnd(RdfGraphEnd.defaultInstance)))
   private val defaultGraphStart = RdfStreamRow(RdfStreamRow.Row.GraphStart(
@@ -33,7 +31,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     val mainRow = RdfStreamRow(RdfStreamRow.Row.Triple(
       tripleToProto(triple)
     ))
-    extraRowsBuffer.append(mainRow).toSeq
+    extraRowsBuffer.append(mainRow).getBufferCopy
 
   /**
    * Add an RDF quad statement to the stream.
@@ -45,7 +43,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     val mainRow = RdfStreamRow(RdfStreamRow.Row.Quad(
       quadToProto(quad)
     ))
-    extraRowsBuffer.append(mainRow).toSeq
+    extraRowsBuffer.append(mainRow).getBufferCopy
 
   /**
    * Signal the start of a new (named) delimited graph in a GRAPHS stream.
@@ -62,7 +60,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
       val mainRow = RdfStreamRow(RdfStreamRow.Row.GraphStart(
         RdfGraphStart(graphNode)
       ))
-      extraRowsBuffer.append(mainRow).toSeq
+      extraRowsBuffer.append(mainRow).getBufferCopy
 
   /**
    * Signal the start of the default delimited graph in a GRAPHS stream.
@@ -70,7 +68,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
    */
   final def startDefaultGraph(): Iterable[RdfStreamRow] =
     handleHeader()
-    extraRowsBuffer.append(defaultGraphStart).toSeq
+    extraRowsBuffer.append(defaultGraphStart).getBufferCopy
 
   /**
    * Signal the end of a delimited graph in a GRAPHS stream.
@@ -149,7 +147,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   // *************************************
   // We assume by default that 32 rows should be enough to encode one statement.
   // If not, the buffer will grow.
-  private val extraRowsBuffer = new ArrayBuffer[RdfStreamRow](32)
+  private val extraRowsBuffer = new FastBuffer[RdfStreamRow](32)
   // Make the node cache size between 256 and 1024, depending on the user's maxNameTableSize.
   private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize, 1024), 256)
   private val nodeEncoder = new NodeEncoder[TNode](options, nodeCacheSize, nodeCacheSize)


### PR DESCRIPTION
I thought that ArrayBuffer in Scala is smart enough to NOT allocate things if it still has existing capacity, but somehow in the profiler I'm reading a lot of allocations there. Let's try a custom implementation of the row buffer – as simple as possible.

If this works, I will finish the docstrings. If not, I will revert it.