### PR TITLE
Encoder: maybe speed up the node cache

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
@@ -1,0 +1,65 @@
+package eu.ostrzyciel.jelly.core;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A terrifyingly simple cache.
+ *
+ * Code copied from Apache Jena 5.2.0:
+ * https://github.com/apache/jena/blob/6443abda6e2717b95b05c45515817584e93ef244/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java#L40
+ *
+ * Authors:
+ * - Andy Seaborne
+ * - A. Soroka
+ * - strangepleasures
+ * - arne-bdt
+ * https://github.com/apache/jena/commits/6443abda6e2717b95b05c45515817584e93ef244/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java
+ *
+ * @param <K>
+ * @param <V>
+ */
+final class EncoderNodeCache<K, V> {
+    private final V[] values;
+    private final K[] keys;
+    private final int sizeMinusOne;
+    // private int currentSize = 0;
+
+    public EncoderNodeCache(int minimumSize) {
+        var size = Integer.highestOneBit(minimumSize);
+        if (size < minimumSize) {
+            size <<= 1;
+        }
+        this.sizeMinusOne = size-1;
+
+        @SuppressWarnings("unchecked")
+        V[] x = (V[])new Object[size];
+        values = x;
+
+        @SuppressWarnings("unchecked")
+        K[] z = (K[])new Object[size];
+        keys = z;
+    }
+
+    private int calcIndex(K key) {
+        return key.hashCode() & sizeMinusOne;
+    }
+
+    public V computeIfAbsent(K key, Function<K, V> function) {
+        final int idx = calcIndex(key);
+        final boolean isExistingKeyNotNull = keys[idx] != null;
+        if (isExistingKeyNotNull && keys[idx].equals(key)) {
+            return values[idx];
+        } else {
+            final var value = function.apply(key);
+            if (value != null) {
+                values[idx] = value;
+//                if (!isExistingKeyNotNull) {
+//                    currentSize++;
+//                }
+                keys[idx] = key;
+            }
+            return value;
+        }
+    }
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -35,24 +35,6 @@ public final class NodeEncoder<TNode> {
         public int lookupSerial2;
     }
 
-    /**
-     * A simple LRU cache for already encoded nodes.
-     * @param <K> Key type
-     * @param <V> Value type
-     */
-    private static final class NodeCache<K, V> extends LinkedHashMap<K, V> {
-        private final int maxSize;
-
-        public NodeCache(int maxSize) {
-            this.maxSize = maxSize;
-        }
-
-        @Override
-        protected boolean removeEldestEntry(java.util.Map.Entry<K, V> eldest) {
-            return size() > maxSize;
-        }
-    }
-
     private final int maxPrefixTableSize;
     private int lastIriNameId;
     private int lastIriPrefixId = -1000;
@@ -63,8 +45,8 @@ public final class NodeEncoder<TNode> {
 
     // We split the node caches in two – the first one is for nodes that depend on the lookups
     // (IRIs and datatype literals). The second one is for nodes that don't depend on the lookups.
-    private final NodeCache<Object, DependentNode> dependentNodeCache;
-    private final NodeCache<Object, UniversalTerm> nodeCache;
+    private final EncoderNodeCache<Object, DependentNode> dependentNodeCache;
+    private final EncoderNodeCache<Object, UniversalTerm> nodeCache;
 
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     static final RdfIri zeroIri = new RdfIri(0, 0);
@@ -82,8 +64,8 @@ public final class NodeEncoder<TNode> {
             prefixLookup = new EncoderLookup(maxPrefixTableSize);
         }
         nameLookup = new EncoderLookup(opt.maxNameTableSize());
-        dependentNodeCache = new NodeCache<>(dependentNodeCacheSize);
-        nodeCache = new NodeCache<>(nodeCacheSize);
+        dependentNodeCache = new EncoderNodeCache<>(dependentNodeCacheSize);
+        nodeCache = new EncoderNodeCache<>(nodeCacheSize);
     }
 
     /**

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -150,8 +150,8 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   // We assume by default that 32 rows should be enough to encode one statement.
   // If not, the buffer will grow.
   private val extraRowsBuffer = new ArrayBuffer[RdfStreamRow](32)
-  // Make the node cache size between 256 and 1024, depending on the user's maxNameTableSize.
-  private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize, 1024), 256)
+  // Make the node cache size between 512 and 4096, depending on the user's maxNameTableSize.
+  private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize * 2, 4096), 256)
   private val nodeEncoder = new NodeEncoder[TNode](options, nodeCacheSize, nodeCacheSize)
   private var emittedOptions = false
 


### PR DESCRIPTION
The LRU policy there is probably way overkill, we can do this much more easily with a dead-simple hashed cache. This implementation is copied over from Jena, let's see if this works.

This will result in more evictions than needed, but the lookups will be way, way faster...

As always, I will finish the tests and docstrings if this works. If not, I will revert it.