### PR TITLE
Encoder: maybe speed up the node cache (2)

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/DependentNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/DependentNodeCache.java
@@ -1,0 +1,51 @@
+package eu.ostrzyciel.jelly.core;
+
+import eu.ostrzyciel.jelly.core.proto.v1.UniversalTerm;
+
+import java.util.function.Function;
+
+/**
+ * A cached node that depends on other lookups (RdfIri and RdfLiteral in the datatype variant).
+ */
+final class DependentNode {
+    // The actual cached node
+    public UniversalTerm encoded;
+    // 1: datatypes and IRI names
+    // The pointer is the index in the lookup table, the serial is the serial number of the entry.
+    // The serial in the lookup table must be equal to the serial here for the entry to be valid.
+    public int lookupPointer1;
+    public int lookupSerial1;
+    // 2: IRI prefixes
+    public int lookupPointer2;
+    public int lookupSerial2;
+}
+
+final class DependentNodeCache extends EncoderNodeCache<Object, DependentNode> {
+    private final DependentNode[] values;
+
+    public DependentNodeCache(int minimumSize) {
+        super(minimumSize);
+
+        DependentNode[] x = new DependentNode[sizeMinusOne + 1];
+        values = x;
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = new DependentNode();
+        }
+    }
+
+    public DependentNode getOrClearIfAbsent(Object key) {
+        final int idx = calcIndex(key);
+        final DependentNode node = (DependentNode) values[idx];
+        if (node != null && node.equals(key)) {
+            return node;
+        } else {
+            node.encoded = null;
+            node.lookupPointer1 = 0;
+            node.lookupPointer2 = 0;
+            keys[idx] = key;
+            return node;
+        }
+    }
+
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/DependentNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/DependentNodeCache.java
@@ -2,8 +2,6 @@ package eu.ostrzyciel.jelly.core;
 
 import eu.ostrzyciel.jelly.core.proto.v1.UniversalTerm;
 
-import java.util.function.Function;
-
 /**
  * A cached node that depends on other lookups (RdfIri and RdfLiteral in the datatype variant).
  */

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
@@ -1,8 +1,5 @@
 package eu.ostrzyciel.jelly.core;
 
-import java.util.Objects;
-import java.util.function.Function;
-
 /**
  * A terrifyingly simple cache.
  *

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
@@ -6,8 +6,12 @@ import java.util.function.Function;
 /**
  * A terrifyingly simple cache.
  *
+ * TODO: modifications
+ *
  * Code copied from Apache Jena 5.2.0:
  * https://github.com/apache/jena/blob/6443abda6e2717b95b05c45515817584e93ef244/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java#L40
+ *
+ * TODO: license
  *
  * Authors:
  * - Andy Seaborne
@@ -19,47 +23,25 @@ import java.util.function.Function;
  * @param <K>
  * @param <V>
  */
-final class EncoderNodeCache<K, V> {
-    private final V[] values;
-    private final K[] keys;
-    private final int sizeMinusOne;
-    // private int currentSize = 0;
+abstract class EncoderNodeCache<K, V> {
+    protected final Object[] keys;
+    protected final int sizeMinusOne;
 
-    public EncoderNodeCache(int minimumSize) {
+    protected EncoderNodeCache(int minimumSize) {
         var size = Integer.highestOneBit(minimumSize);
         if (size < minimumSize) {
             size <<= 1;
         }
-        this.sizeMinusOne = size-1;
+        this.sizeMinusOne = size - 1;
 
         @SuppressWarnings("unchecked")
-        V[] x = (V[])new Object[size];
-        values = x;
-
-        @SuppressWarnings("unchecked")
-        K[] z = (K[])new Object[size];
+        K[] z = (K[]) new Object[size];
         keys = z;
     }
 
-    private int calcIndex(K key) {
+    protected int calcIndex(Object key) {
         return key.hashCode() & sizeMinusOne;
     }
-
-    public V computeIfAbsent(K key, Function<K, V> function) {
-        final int idx = calcIndex(key);
-        final boolean isExistingKeyNotNull = keys[idx] != null;
-        if (isExistingKeyNotNull && keys[idx].equals(key)) {
-            return values[idx];
-        } else {
-            final var value = function.apply(key);
-            if (value != null) {
-                values[idx] = value;
-//                if (!isExistingKeyNotNull) {
-//                    currentSize++;
-//                }
-                keys[idx] = key;
-            }
-            return value;
-        }
-    }
 }
+
+

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -5,6 +5,7 @@ import scala.collection.mutable.ArrayBuffer;
 
 import java.util.LinkedHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Encodes RDF nodes native to the used RDF library (e.g., Apache Jena, RDF4J) into Jelly's protobuf objects.
@@ -209,7 +210,7 @@ public final class NodeEncoder<TNode> {
      * @param encoder The function that encodes the node
      * @return The encoded node
      */
-    public UniversalTerm encodeOther(Object key, Function<Object, UniversalTerm> encoder) {
+    public UniversalTerm encodeOther(Object key, Supplier<UniversalTerm> encoder) {
         return nodeCache.computeIfAbsent(key, encoder);
     }
 }

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -4,7 +4,6 @@ import eu.ostrzyciel.jelly.core.proto.v1.*;
 import scala.collection.mutable.ArrayBuffer;
 
 import java.util.LinkedHashMap;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/OtherNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/OtherNodeCache.java
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.core;
 
 import eu.ostrzyciel.jelly.core.proto.v1.*;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class OtherNodeCache extends EncoderNodeCache<Object, UniversalTerm> {
     private final UniversalTerm[] values;
@@ -13,12 +13,12 @@ public class OtherNodeCache extends EncoderNodeCache<Object, UniversalTerm> {
         values = x;
     }
 
-    public UniversalTerm computeIfAbsent(Object key, Function<Object, UniversalTerm> function) {
+    public UniversalTerm computeIfAbsent(Object key, Supplier<UniversalTerm> supplier) {
         final int idx = calcIndex(key);
         if (keys[idx] != null && keys[idx].equals(key)) {
             return values[idx];
         } else {
-            final var value = function.apply(key);
+            final var value = supplier.get();
             values[idx] = value;
             keys[idx] = key;
             return value;

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/OtherNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/OtherNodeCache.java
@@ -1,0 +1,27 @@
+package eu.ostrzyciel.jelly.core;
+
+import eu.ostrzyciel.jelly.core.proto.v1.*;
+import java.util.function.Function;
+
+public class OtherNodeCache extends EncoderNodeCache<Object, UniversalTerm> {
+    private final UniversalTerm[] values;
+
+    public OtherNodeCache(int minimumSize) {
+        super(minimumSize);
+
+        UniversalTerm[] x = new UniversalTerm[sizeMinusOne + 1];
+        values = x;
+    }
+
+    public UniversalTerm computeIfAbsent(Object key, Function<Object, UniversalTerm> function) {
+        final int idx = calcIndex(key);
+        if (keys[idx] != null && keys[idx].equals(key)) {
+            return values[idx];
+        } else {
+            final var value = function.apply(key);
+            values[idx] = value;
+            keys[idx] = key;
+            return value;
+        }
+    }
+}

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -128,13 +128,13 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     nodeEncoder.encodeIri(iri, extraRowsBuffer)
 
   protected final inline def makeBlankNode(label: String): UniversalTerm =
-    nodeEncoder.encodeOther(label, _ => RdfTerm.Bnode(label))
+    nodeEncoder.encodeOther(label, () => RdfTerm.Bnode(label))
 
   protected final inline def makeSimpleLiteral(lex: String): UniversalTerm =
-    nodeEncoder.encodeOther(lex, _ => RdfLiteral(lex, RdfLiteral.LiteralKind.Empty))
+    nodeEncoder.encodeOther(lex, () => RdfLiteral(lex, RdfLiteral.LiteralKind.Empty))
 
   protected final inline def makeLangLiteral(lit: TNode, lex: String, lang: String): UniversalTerm =
-    nodeEncoder.encodeOther(lit, _ => RdfLiteral(lex, RdfLiteral.LiteralKind.Langtag(lang)))
+    nodeEncoder.encodeOther(lit, () => RdfLiteral(lex, RdfLiteral.LiteralKind.Langtag(lang)))
 
   protected final inline def makeDtLiteral(lit: TNode, lex: String, dt: String): UniversalTerm =
     nodeEncoder.encodeDtLiteral(lit, lex, dt, extraRowsBuffer)

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -150,8 +150,9 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   // We assume by default that 32 rows should be enough to encode one statement.
   // If not, the buffer will grow.
   private val extraRowsBuffer = new ArrayBuffer[RdfStreamRow](32)
-  // Make the node cache size between 512 and 4096, depending on the user's maxNameTableSize.
-  private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize * 2, 4096), 256)
+  // Make the node cache size between 4096 and 8192, depending on the user's maxNameTableSize.
+  // Kind of. Fix this tomorrow.
+  private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize * 4, 8192), 4096)
   private val nodeEncoder = new NodeEncoder[TNode](options, nodeCacheSize, nodeCacheSize)
   private var emittedOptions = false
 


### PR DESCRIPTION
For jelly-big I saw similar performance, but for jelly-small much worse...

Here I've increased the node cache size significantly (hey, it's just an array of pointers, what does that cost in the era of Google Chrome) and made optimized implementations for both caches to avoid doing useless operations.