### PR TITLE
Try different settings for node cache map

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -3,6 +3,7 @@ package eu.ostrzyciel.jelly.core;
 import eu.ostrzyciel.jelly.core.proto.v1.*;
 import scala.collection.mutable.ArrayBuffer;
 
+import java.util.ConcurrentModificationException;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
 
@@ -44,6 +45,7 @@ public final class NodeEncoder<TNode> {
         private final int maxSize;
 
         public NodeCache(int maxSize) {
+            super(maxSize + 16, 1f, true);
             this.maxSize = maxSize;
         }
 

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -3,7 +3,6 @@ package eu.ostrzyciel.jelly.core;
 import eu.ostrzyciel.jelly.core.proto.v1.*;
 import scala.collection.mutable.ArrayBuffer;
 
-import java.util.ConcurrentModificationException;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
 


### PR DESCRIPTION
I've just noticed that we were tracking insertion order there, not access order... could this help?

Also: size the cache appropriately so that it doesn't need to be resized later.