### PR TITLE
Experiment: unwrap RdfStreamRow contents

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -5,10 +5,8 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 object ProtoEncoder:
-  private val graphEnd = Seq(RdfStreamRow(RdfStreamRow.Row.GraphEnd(RdfGraphEnd.defaultInstance)))
-  private val defaultGraphStart = RdfStreamRow(RdfStreamRow.Row.GraphStart(
-    RdfGraphStart(RdfDefaultGraph.defaultInstance)
-  ))
+  private val graphEnd = Seq(RdfStreamRow(RdfGraphEnd.defaultInstance))
+  private val defaultGraphStart = RdfStreamRow(RdfGraphStart(RdfDefaultGraph.defaultInstance))
 
 /**
  * Stateful encoder of a protobuf RDF stream.
@@ -30,9 +28,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
    */
   final def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(RdfStreamRow.Row.Triple(
-      tripleToProto(triple)
-    ))
+    val mainRow = RdfStreamRow(tripleToProto(triple))
     extraRowsBuffer.append(mainRow).toSeq
 
   /**
@@ -42,9 +38,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
    */
   final def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(RdfStreamRow.Row.Quad(
-      quadToProto(quad)
-    ))
+    val mainRow = RdfStreamRow(quadToProto(quad))
     extraRowsBuffer.append(mainRow).toSeq
 
   /**
@@ -59,9 +53,7 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     else
       handleHeader()
       val graphNode = graphNodeToProto(graph)
-      val mainRow = RdfStreamRow(RdfStreamRow.Row.GraphStart(
-        RdfGraphStart(graphNode)
-      ))
+      val mainRow = RdfStreamRow(RdfGraphStart(graphNode))
       extraRowsBuffer.append(mainRow).toSeq
 
   /**
@@ -203,11 +195,9 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
 
   private def emitOptions(): Unit =
     emittedOptions = true
-    extraRowsBuffer.append(
-      RdfStreamRow(RdfStreamRow.Row.Options(
+    extraRowsBuffer.append(RdfStreamRow(
         // Override whatever the user set in the options.
         options.withVersion(Constants.protoVersion)
-      ))
-    )
+    ))
 
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
@@ -9,7 +9,7 @@ package eu.ostrzyciel.jelly.core.proto.v1
  * optimizations to make this as fast as possible.
  */
 @SerialVersionUID(0L)
-final case class RdfGraphStart(graph: GraphTerm = null) extends scalapb.GeneratedMessage {
+final case class RdfGraphStart(graph: GraphTerm = null) extends scalapb.GeneratedMessage, RdfStreamRowValue {
   @transient
   private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
 
@@ -60,6 +60,12 @@ final case class RdfGraphStart(graph: GraphTerm = null) extends scalapb.Generate
   def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
 
   def companion: eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart.type = eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart
+  
+  override def streamRowValueNumber: Int = 4
+  
+  override def isGraphStart: Boolean = true
+  
+  override def graphStart: RdfGraphStart = this
 }
 
 object RdfGraphStart extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart] {

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -16,7 +16,8 @@ package eu.ostrzyciel.jelly.core.proto.v1
  * optimizations to make this as fast as possible.
  */
 @SerialVersionUID(0L)
-final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `object`: SpoTerm = null, graph: GraphTerm = null) extends scalapb.GeneratedMessage {
+final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `object`: SpoTerm = null, graph: GraphTerm = null)
+  extends scalapb.GeneratedMessage, RdfStreamRowValue {
   @transient private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
 
   private[this] def __computeSerializedSize(): _root_.scala.Int = {
@@ -120,6 +121,12 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
   def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
 
   def companion: eu.ostrzyciel.jelly.core.proto.v1.RdfQuad.type = eu.ostrzyciel.jelly.core.proto.v1.RdfQuad
+
+  override def streamRowValueNumber: Int = 3
+
+  override def isQuad: Boolean = true
+
+  override def quad: RdfQuad = this
 }
 
 object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfQuad] {
@@ -243,7 +250,7 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
 
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)
 
-  lazy val defaultInstance = eu.ostrzyciel.jelly.core.proto.v1.RdfQuad(subject = null, predicate = null, `object` = null, graph = null)
+  val defaultInstance: RdfQuad = eu.ostrzyciel.jelly.core.proto.v1.RdfQuad(subject = null, predicate = null, `object` = null, graph = null)
 
   def of(subject: SpoTerm, predicate: SpoTerm, `object`: SpoTerm, graph: GraphTerm): _root_.eu.ostrzyciel.jelly.core.proto.v1.RdfQuad = _root_.eu.ostrzyciel.jelly.core.proto.v1.RdfQuad(subject, predicate, `object`, graph)
 }

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
@@ -1,0 +1,230 @@
+package eu.ostrzyciel.jelly.core.proto.v1
+
+import scala.annotation.switch
+
+@SerialVersionUID(0L) final case class RdfStreamRow(row: RdfStreamRowValue = null) extends scalapb.GeneratedMessage {
+  @transient private var __serializedSizeMemoized: _root_.scala.Int = 0
+
+  private def __computeSerializedSize(): _root_.scala.Int = {
+    // This compiles into a JVM tableswitch instruction ... which is very, very fast
+    (row.streamRowValueNumber : @switch) match
+      case 1 =>
+        val __value = row.options
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 2 =>
+        val __value = row.triple
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 3 =>
+        val __value = row.quad
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 4 =>
+        val __value = row.graphStart
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 5 =>
+        val __value = row.graphEnd
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 9 =>
+        val __value = row.name
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 10 =>
+        val __value = row.prefix
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+      case 11 =>
+        val __value = row.datatype
+        1 + _root_.com.google.protobuf.CodedOutputStream.computeUInt32SizeNoTag(__value.serializedSize) + __value.serializedSize
+  }
+
+  override def serializedSize: _root_.scala.Int = {
+    var __size = __serializedSizeMemoized
+    if (__size == 0) {
+      __size = __computeSerializedSize() + 1
+      __serializedSizeMemoized = __size
+    }
+    __size - 1
+  }
+
+  def writeTo(_output__ : _root_.com.google.protobuf.CodedOutputStream): _root_.scala.Unit = {
+    (row.streamRowValueNumber : @switch) match
+      case 1 =>
+        val __m = row.options
+        _output__.writeTag(1, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 2 =>
+        val __m = row.triple
+        _output__.writeTag(2, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 3 =>
+        val __m = row.quad
+        _output__.writeTag(3, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 4 =>
+        val __m = row.graphStart
+        _output__.writeTag(4, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 5 =>
+        val __m = row.graphEnd
+        _output__.writeTag(5, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 9 =>
+        val __m = row.name
+        _output__.writeTag(9, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 10 =>
+        val __m = row.prefix
+        _output__.writeTag(10, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+      case 11 =>
+        val __m = row.datatype
+        _output__.writeTag(11, 2)
+        _output__.writeUInt32NoTag(__m.serializedSize)
+        __m.writeTo(_output__)
+  }
+  
+  def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = {
+    (__fieldNumber: @_root_.scala.unchecked) match {
+      case 1 =>
+        row.options
+      case 2 =>
+        row.triple
+      case 3 =>
+        row.quad
+      case 4 =>
+        row.graphStart
+      case 5 =>
+        row.graphEnd
+      case 9 =>
+        row.name
+      case 10 =>
+        row.prefix
+      case 11 =>
+        row.datatype
+    }
+  }
+  
+  def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = {
+    _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
+    (__field.number: @_root_.scala.unchecked) match {
+      case 1 =>
+        if (row.isOptions) row.options.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 2 =>
+        if (row.isTriple) row.triple.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 3 =>
+        if (row.isQuad) row.quad.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 4 =>
+        if (row.isGraphStart) row.graphStart.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 5 =>
+        if (row.isGraphEnd) row.graphEnd.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 9 =>
+        if (row.isName) row.name.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 10 =>
+        if (row.isPrefix) row.prefix.toPMessage else _root_.scalapb.descriptors.PEmpty
+      case 11 =>
+        if (row.isDatatype) row.datatype.toPMessage else _root_.scalapb.descriptors.PEmpty
+    }
+  }
+  
+  def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
+  
+  def companion: eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow.type = eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow
+}
+
+object RdfStreamRow extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow] {
+  implicit def messageCompanion: scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow] = this
+  def parseFrom(_input__ : _root_.com.google.protobuf.CodedInputStream): eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow = {
+    var __row: RdfStreamRowValue = null
+    var _done__ = false
+    while (!_done__) {
+      val _tag__ = _input__.readTag()
+      _tag__ match {
+        case 0 =>
+          _done__ = true
+        case 10 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions](_input__)
+        case 18 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple](_input__)
+        case 26 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfQuad](_input__)
+        case 34 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart](_input__)
+        case 42 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphEnd](_input__)
+        case 74 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfNameEntry](_input__)
+        case 82 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfPrefixEntry](_input__)
+        case 90 =>
+          __row = _root_.scalapb.LiteParser.readMessage[eu.ostrzyciel.jelly.core.proto.v1.RdfDatatypeEntry](_input__)
+        case tag =>
+          _input__.skipField(tag)
+      }
+    }
+    eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow(row = __row)
+  }
+  
+  implicit def messageReads: _root_.scalapb.descriptors.Reads[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow] = _root_.scalapb.descriptors.Reads {
+    case _root_.scalapb.descriptors.PMessage(__fieldsMap) =>
+      _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
+      eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow(
+        row = __fieldsMap.get(scalaDescriptor.findFieldByNumber(1).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions]])
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(3).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfQuad]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(4).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(5).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphEnd]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(9).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfNameEntry]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(10).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfPrefixEntry]]))
+          .orElse[RdfStreamRowValue](__fieldsMap.get(scalaDescriptor.findFieldByNumber(11).get).flatMap(_.as[_root_.scala.Option[eu.ostrzyciel.jelly.core.proto.v1.RdfDatatypeEntry]]))
+          .orNull
+      )
+    case _ =>
+      throw new RuntimeException("Expected PMessage")
+  }
+  
+  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(11)
+  
+  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(11)
+  
+  def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[?] = {
+    var __out: _root_.scalapb.GeneratedMessageCompanion[?] = null
+    (__number: @_root_.scala.unchecked) match {
+      case 1 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+      case 2 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfTriple
+      case 3 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfQuad
+      case 4 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart
+      case 5 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfGraphEnd
+      case 9 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfNameEntry
+      case 10 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfPrefixEntry
+      case 11 =>
+        __out = eu.ostrzyciel.jelly.core.proto.v1.RdfDatatypeEntry
+    }
+    __out
+  }
+  
+  lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[? <: _root_.scalapb.GeneratedMessage]] = Seq.empty
+  
+  def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[?] = throw new MatchError(__fieldNumber)
+  
+  val defaultInstance: RdfStreamRow = eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow(row = null)
+  
+  final val OPTIONS_FIELD_NUMBER = 1
+  final val TRIPLE_FIELD_NUMBER = 2
+  final val QUAD_FIELD_NUMBER = 3
+  final val GRAPH_START_FIELD_NUMBER = 4
+  final val GRAPH_END_FIELD_NUMBER = 5
+  final val NAME_FIELD_NUMBER = 9
+  final val PREFIX_FIELD_NUMBER = 10
+  final val DATATYPE_FIELD_NUMBER = 11
+}

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
@@ -1,0 +1,23 @@
+package eu.ostrzyciel.jelly.core.proto.v1
+
+private[core] trait RdfStreamRowValue:
+  
+  def streamRowValueNumber: Int
+
+  def isOptions: Boolean = false
+  def isTriple: Boolean = false
+  def isQuad: Boolean = false
+  def isGraphStart: Boolean = false
+  def isGraphEnd: Boolean = false
+  def isName: Boolean = false
+  def isPrefix: Boolean = false
+  def isDatatype: Boolean = false
+
+  def options: RdfStreamOptions = null
+  def triple: RdfTriple = null
+  def quad: RdfQuad = null
+  def graphStart: RdfGraphStart = null
+  def graphEnd: RdfGraphEnd = null
+  def name: RdfNameEntry = null
+  def prefix: RdfPrefixEntry = null
+  def datatype: RdfDatatypeEntry = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
@@ -20,7 +20,7 @@ package eu.ostrzyciel.jelly.core.proto.v1
  */
 @SerialVersionUID(0L)
 final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `object`: SpoTerm = null)
-  extends scalapb.GeneratedMessage, SpoTerm, GraphTerm {
+  extends scalapb.GeneratedMessage, SpoTerm, GraphTerm, RdfStreamRowValue {
   @transient private[this] var __serializedSizeMemoized: _root_.scala.Int = 0
 
   private[this] def __computeSerializedSize(): _root_.scala.Int = {
@@ -110,6 +110,12 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
   override def isTripleTerm: Boolean = true
 
   override def tripleTerm: RdfTriple = this
+
+  override def streamRowValueNumber: Int = 2
+
+  override def isTriple: Boolean = true
+
+  override def triple: RdfTriple = this
 }
 
 object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple] {
@@ -213,7 +219,7 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
 
   def enumCompanionForFieldNumber(__fieldNumber: _root_.scala.Int): _root_.scalapb.GeneratedEnumCompanion[_] = throw new MatchError(__fieldNumber)
 
-  lazy val defaultInstance = eu.ostrzyciel.jelly.core.proto.v1.RdfTriple(subject = null, predicate = null, `object` = null)
+  val defaultInstance: RdfTriple = eu.ostrzyciel.jelly.core.proto.v1.RdfTriple(subject = null, predicate = null, `object` = null)
 
   def of(subject: SpoTerm, predicate: SpoTerm, `object`: SpoTerm): _root_.eu.ostrzyciel.jelly.core.proto.v1.RdfTriple = _root_.eu.ostrzyciel.jelly.core.proto.v1.RdfTriple(subject, predicate, `object`)
 }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
@@ -8,19 +8,19 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
 class IoUtilsSpec extends AnyWordSpec, Matchers:
   private val frameLarge = RdfStreamFrame(Seq(
-    RdfStreamRow(RdfStreamRow.Row.Name(
+    RdfStreamRow(
       RdfNameEntry(1, "name name name name")
-    ))
+    )
   ))
   private val frameSize10 = RdfStreamFrame(Seq(
-    RdfStreamRow(RdfStreamRow.Row.Name(
+    RdfStreamRow(
       RdfNameEntry(0, "name")
-    ))
+    )
   ))
   private val frameOptionsSize10 = RdfStreamFrame(Seq(
-    RdfStreamRow(RdfStreamRow.Row.Options(
+    RdfStreamRow(
       RdfStreamOptions(streamName = "name12")
-    ))
+    )
   ))
 
   "IoUtils" should {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
@@ -192,12 +192,12 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
         iri.prefixId should be (1)
 
         buffer.size should be (2)
-        buffer should contain (RdfStreamRow(RdfStreamRow.Row.Prefix(
+        buffer should contain (RdfStreamRow(
           RdfPrefixEntry(id = 0, value = "https://test.org/")
-        )))
-        buffer should contain (RdfStreamRow(RdfStreamRow.Row.Name(
+        ))
+        buffer should contain (RdfStreamRow(
           RdfNameEntry(id = 0, value = "Cake")
-        )))
+        ))
       }
 
       "add a prefix-only IRI" in {
@@ -208,12 +208,12 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
         // an empty name entry still has to be allocated
         buffer.size should be (2)
-        buffer should contain (RdfStreamRow(RdfStreamRow.Row.Prefix(
+        buffer should contain (RdfStreamRow(
           RdfPrefixEntry(id = 0, value = "https://test.org/test/")
-        )))
-        buffer should contain(RdfStreamRow(RdfStreamRow.Row.Name(
+        ))
+        buffer should contain(RdfStreamRow(
           RdfNameEntry(id = 0, value = "")
-        )))
+        ))
       }
 
       "add a name-only IRI" in {
@@ -224,12 +224,12 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
         // in the mode with the prefix table enabled, an empty prefix entry still has to be allocated
         buffer.size should be (2)
-        buffer should contain(RdfStreamRow(RdfStreamRow.Row.Prefix(
+        buffer should contain (RdfStreamRow(
           RdfPrefixEntry(id = 0, value = "")
-        )))
-        buffer should contain (RdfStreamRow(RdfStreamRow.Row.Name(
+        ))
+        buffer should contain (RdfStreamRow(
           RdfNameEntry(id = 0, value = "testTestTest")
-        )))
+        ))
       }
 
       "add a full IRI in no-prefix table mode" in {
@@ -240,9 +240,9 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
         // in the no prefix mode, there must be no prefix entries
         buffer.size should be (1)
-        buffer should contain (RdfStreamRow(RdfStreamRow.Row.Name(
+        buffer should contain (RdfStreamRow(
           RdfNameEntry(id = 0, value = "https://test.org/Cake")
-        )))
+        ))
       }
 
       "add IRIs while evicting old ones" in {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -217,7 +217,7 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
     "throw exception on unset row kind" in {
       val decoder = MockConverterFactory.triplesDecoder(None)
       val error = intercept[RdfProtoDeserializationError] {
-        decoder.ingestRow(RdfStreamRow(RdfStreamRow.Row.Empty))
+        decoder.ingestRow(RdfStreamRow())
       }
       error.getMessage should include ("Row kind is not set")
     }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -4,30 +4,21 @@ import eu.ostrzyciel.jelly.core.helpers.Mrl.*
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 object ProtoTestCases:
-  type RowValue = RdfStreamOptions | RdfDatatypeEntry | RdfPrefixEntry | RdfNameEntry | RdfTriple | RdfQuad |
-    RdfGraphStart | RdfGraphEnd
-
-  def wrapEncoded(rows: Seq[RowValue]): Seq[RdfStreamRow.Row] = rows map {
+  def wrapEncoded(rows: Seq[RdfStreamRowValue]): Seq[RdfStreamRowValue] = rows map {
     case v: RdfStreamOptions => v.version match
       // If the version is not set, set it to the current version
-      case 0 => RdfStreamRow.Row.Options(v.withVersion(Constants.protoVersion))
+      case 0 => v.withVersion(Constants.protoVersion)
       // Otherwise assume we are checking version compatibility
-      case _ => RdfStreamRow.Row.Options(v)
-    case v: RdfDatatypeEntry => RdfStreamRow.Row.Datatype(v)
-    case v: RdfPrefixEntry => RdfStreamRow.Row.Prefix(v)
-    case v: RdfNameEntry => RdfStreamRow.Row.Name(v)
-    case v: RdfTriple => RdfStreamRow.Row.Triple(v)
-    case v: RdfQuad => RdfStreamRow.Row.Quad(v)
-    case v: RdfGraphStart => RdfStreamRow.Row.GraphStart(v)
-    case v: RdfGraphEnd => RdfStreamRow.Row.GraphEnd(v)
+      case _ => v
+    case v => v
   }
 
-  def wrapEncodedFull(rows: Seq[RowValue]): Seq[RdfStreamRow] =
+  def wrapEncodedFull(rows: Seq[RdfStreamRowValue]): Seq[RdfStreamRow] =
     wrapEncoded(rows).map(row => RdfStreamRow(row))
 
   trait TestCase[TStatement]:
     def mrl: Seq[TStatement]
-    def encoded(opt: RdfStreamOptions): Seq[RdfStreamRow.Row]
+    def encoded(opt: RdfStreamOptions): Seq[RdfStreamRowValue]
     def encodedFull(opt: RdfStreamOptions, groupByN: Int) =
       encoded(opt)
         .map(row => RdfStreamRow(row))

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/Assertions.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/Assertions.scala
@@ -1,12 +1,12 @@
 package eu.ostrzyciel.jelly.core.helpers
 
 import eu.ostrzyciel.jelly.core.helpers.Mrl.Statement
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamRow, RdfStreamRowValue}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 object Assertions extends AnyWordSpec, Matchers:
-  def assertEncoded(observed: Seq[RdfStreamRow], expected: Seq[RdfStreamRow.Row]): Unit =
+  def assertEncoded(observed: Seq[RdfStreamRow], expected: Seq[RdfStreamRowValue]): Unit =
     for ix <- 0 until observed.size.max(expected.size) do
       val obsRow = observed.applyOrElse(ix, null)
       withClue(s"Row $ix:") {

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/ForwardCompatSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/ForwardCompatSpec.scala
@@ -80,8 +80,8 @@ class ForwardCompatSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
       options.maxDatatypeTableSize should be (32)
       options.version should be (123)
 
-      parsed.rows(1).row.isEmpty should be (true)
-      parsed.rows(2).row.isEmpty should be (true)
+      parsed.rows(1).row should be (null)
+      parsed.rows(2).row should be (null)
     }
   }
 

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoderSpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoderSpec.scala
@@ -13,9 +13,7 @@ import org.scalatest.wordspec.AnyWordSpec
  */
 class JenaProtoEncoderSpec extends AnyWordSpec, Matchers, JenaTest:
   private val encodedDefaultGraph = RdfStreamRow(
-    RdfStreamRow.Row.GraphStart(
-      RdfGraphStart(RdfDefaultGraph())
-    )
+    RdfGraphStart(RdfDefaultGraph())
   )
   
   "JenaProtoEncoder" should {

--- a/project/Generator.scala
+++ b/project/Generator.scala
@@ -8,7 +8,7 @@ object Generator {
     println(s"Generating Scala files from $inputDir to $outputDir")
     val finder: PathFinder = inputDir ** "*.scala"
 
-    val exclusions = Seq("RdfTriple.scala", "RdfQuad.scala", "RdfGraphStart.scala")
+    val exclusions = Seq("RdfTriple.scala", "RdfQuad.scala", "RdfGraphStart.scala", "RdfStreamRow.scala")
 
     val files = for (inputFile <- finder.get) yield {
       if (exclusions.contains(inputFile.getName)) {

--- a/project/Transform3.scala
+++ b/project/Transform3.scala
@@ -6,7 +6,8 @@ import scala.meta.*
  */
 object Transform3 {
   val transformer: Transformer = new Transformer {
-    def copyTemplate(templ: Template, traits: Seq[String], name: String, isName: String): Template = {
+    def copyTemplate(templ: Template, traits: Seq[String], name: String, isName: String, number: Option[Int] = None):
+    Template = {
       templ.copy(
         inits = templ.inits ++ traits.map { tName =>
           Init.After_4_6_0(Type.Name(tName), Name.Anonymous(), Nil)
@@ -26,16 +27,32 @@ object Transform3 {
             None,
             Term.This(Name.Anonymous()),
           ),
-        )
+        ) ++ number.map { n =>
+          Defn.Def.After_4_7_3(
+            List(Mod.Override()),
+            Term.Name("streamRowValueNumber"),
+            Nil,
+            None,
+            Lit.Int(n),
+          )
+        }
       )
     }
 
     override def apply(tree: Tree): Tree = tree match {
       case Defn.Class.After_4_6_0(_, Type.Name(name), _, _, templ) =>
         val newTempl = name match {
+          // RdfTerm
           case "RdfIri" => Some(copyTemplate(templ, Seq("UniversalTerm"), "iri", "isIri"))
           case "RdfLiteral" => Some(copyTemplate(templ, Seq("UniversalTerm"), "literal", "isLiteral"))
           case "RdfDefaultGraph" => Some(copyTemplate(templ, Seq("GraphTerm"), "defaultGraph", "isDefaultGraph"))
+
+          // RdfStreamRowValue
+          case "RdfStreamOptions" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "options", "isOptions", Some(1)))
+          case "RdfGraphEnd" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "graphEnd", "isGraphEnd", Some(5)))
+          case "RdfNameEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "name", "isName", Some(9)))
+          case "RdfPrefixEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "prefix", "isPrefix", Some(10)))
+          case "RdfDatatypeEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "datatype", "isDatatype", Some(11)))
           case _ => None
         }
         newTempl.map(templ => tree.asInstanceOf[Defn.Class].copy(templ = templ)).getOrElse(tree)


### PR DESCRIPTION
This is the same story as with #118, just a bit more straightforward.

This will save us one allocation per stream row in serialization AND deserialization, and also reduce the overhead of going through the ugly if-else chains. Now the JVM should use the tableswitch instruction which is way, way faster.

Let's see if it helps. If not, I will revert the whole thing. If yes, I will complete the docstrings.