### PR TITLE
Use tableswitches in term encoding

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
@@ -1,7 +1,13 @@
 package eu.ostrzyciel.jelly.core.proto.v1
 
 private[core] trait RdfStreamRowValue:
-  
+  /**
+   * Returns the internal stream row value number, which is used in switch statements to determine the type of the row.
+   * This is NOT guaranteed to be the same as the field number in the protobuf encoding!
+   * (although this is the case in the current implementation)
+   * The values returned by this method may change in future versions of Jelly-JVM without warning.
+   * @return
+   */
   def streamRowValueNumber: Int
 
   def isOptions: Boolean = false

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTerm.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTerm.scala
@@ -3,6 +3,8 @@ package eu.ostrzyciel.jelly.core.proto.v1
 import com.google.protobuf.CodedOutputStream
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
+import scala.annotation.switch
+
 /**
  * Trait enabling access into the fields of RDF terms (subjects, predicates, objects, graphs) in the
  * protobuf encoding.
@@ -10,6 +12,14 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
  * See also [[eu.ostrzyciel.jelly.core.proto_adapters.RdfTermCompanion]].
  */
 sealed trait RdfTerm:
+  /**
+   * Returns the internal term number, which is used in switch statements to determine the type of the term.
+   * This is NOT the field number in the protobuf encoding!
+   * The values returned by this method may change in future versions of Jelly-JVM without warning.
+   * @return the term number
+   */
+  def termNumber: Int
+
   def isIri: Boolean = false
   def isBnode: Boolean = false
   def isLiteral: Boolean = false
@@ -34,11 +44,19 @@ trait GraphTerm extends RdfTerm:
 trait UniversalTerm extends SpoTerm, GraphTerm
 
 object RdfTerm:
+  // Inlined constants for term numbers (.termNumber)
+  private[core] inline val TERM_IRI = 1
+  private[core] inline val TERM_BNODE = 2
+  private[core] inline val TERM_LITERAL = 3
+  private[core] inline val TERM_TRIPLE = 4
+  private[core] inline val TERM_DEFAULT_GRAPH = 5
+
   /**
    * Wrapper class for blank nodes, because in the proto they are simply represented as strings, and
    * we cannot inherit from String. We must use a wrapper.
    */
   final case class Bnode(override val bnode: String) extends UniversalTerm:
+    override def termNumber: Int = 2
     override def isBnode: Boolean = true
 
 // Methods below are used in RdfTriple, RdfQuad, and RdfGraphStart instead of generated code. They are all
@@ -48,70 +66,76 @@ private[v1] inline def fieldTagSize(inline tag: Int) = if tag < 16 then 1 else 2
 
 private[v1] inline def graphTermSerializedSize(g: GraphTerm, inline tagOffset: Int): Int =
   if g == null then 0
-  else if g.isIri then
-    val iriS = g.iri.serializedSize
-    fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
-  else if g.isDefaultGraph then
-    val dgS = g.defaultGraph.serializedSize
-    fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(dgS) + dgS
-  else if g.isBnode then
-    CodedOutputStream.computeStringSize(2 + tagOffset, g.bnode)
-  else if g.isLiteral then
-    val litS = g.literal.serializedSize
-    fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(litS) + litS
-  else 0
+  else (g.termNumber : @switch) match
+    case RdfTerm.TERM_IRI =>
+      val iriS = g.iri.serializedSize
+      fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
+    case RdfTerm.TERM_BNODE =>
+      CodedOutputStream.computeStringSize(2 + tagOffset, g.bnode)
+    case RdfTerm.TERM_LITERAL =>
+      val litS = g.literal.serializedSize
+      fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(litS) + litS
+    case RdfTerm.TERM_DEFAULT_GRAPH =>
+      val dgS = g.defaultGraph.serializedSize
+      fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(dgS) + dgS
+    case _ => 0
   
 private[v1] inline def graphTermWriteTo(g: GraphTerm, inline tagOffset: Int, out: CodedOutputStream): Unit =
   if g == null then ()
-  else if g.isIri then
-    val iri = g.iri
-    out.writeTag(1 + tagOffset, 2)
-    out.writeUInt32NoTag(iri.serializedSize)
-    iri.writeTo(out)
-  else if g.isDefaultGraph then
-    val defaultGraph = g.defaultGraph
-    out.writeTag(3 + tagOffset, 2)
-    out.writeUInt32NoTag(defaultGraph.serializedSize)
-    defaultGraph.writeTo(out)
-  else if g.isBnode then
-    out.writeString(2 + tagOffset, g.bnode)
-  else if g.isLiteral then
-    val literal = g.literal
-    out.writeTag(4 + tagOffset, 2)
-    out.writeUInt32NoTag(literal.serializedSize)
-    literal.writeTo(out)
+  else (g.termNumber : @switch) match
+    case RdfTerm.TERM_IRI =>
+      val iri = g.iri
+      out.writeTag(1 + tagOffset, 2)
+      out.writeUInt32NoTag(iri.serializedSize)
+      iri.writeTo(out)
+    case RdfTerm.TERM_BNODE =>
+      out.writeString(2 + tagOffset, g.bnode)
+    case RdfTerm.TERM_LITERAL =>
+      val literal = g.literal
+      out.writeTag(4 + tagOffset, 2)
+      out.writeUInt32NoTag(literal.serializedSize)
+      literal.writeTo(out)
+    case RdfTerm.TERM_DEFAULT_GRAPH =>
+      val defaultGraph = g.defaultGraph
+      out.writeTag(3 + tagOffset, 2)
+      out.writeUInt32NoTag(defaultGraph.serializedSize)
+      defaultGraph.writeTo(out)
+    case _ => ()
   
 private[v1] inline def spoTermSerializedSize(t: SpoTerm, inline tagOffset: Int) =
   if t == null then 0
-  else if t.isIri then
-    val iriS = t.iri.serializedSize
-    fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
-  else if t.isBnode then
-    CodedOutputStream.computeStringSize(2 + tagOffset, t.bnode)
-  else if t.isLiteral then
-    val literalS = t.literal.serializedSize
-    fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(literalS) + literalS
-  else if t.isTripleTerm then
-    val tripleS = t.tripleTerm.serializedSize
-    fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(tripleS) + tripleS
-  else 0
+  else (t.termNumber : @switch) match
+    case RdfTerm.TERM_IRI =>
+      val iriS = t.iri.serializedSize
+      fieldTagSize(1 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(iriS) + iriS
+    case RdfTerm.TERM_BNODE =>
+      CodedOutputStream.computeStringSize(2 + tagOffset, t.bnode)
+    case RdfTerm.TERM_LITERAL =>
+      val literalS = t.literal.serializedSize
+      fieldTagSize(3 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(literalS) + literalS
+    case RdfTerm.TERM_TRIPLE =>
+      val tripleS = t.tripleTerm.serializedSize
+      fieldTagSize(4 + tagOffset) + CodedOutputStream.computeUInt32SizeNoTag(tripleS) + tripleS
+    case _ => 0
 
 private[v1] inline def spoTermWriteTo(t: SpoTerm, inline tagOffset: Int, out: CodedOutputStream): Unit =
   if t == null then ()
-  else if t.isIri then
-    val iri = t.iri
-    out.writeTag(1 + tagOffset, 2)
-    out.writeUInt32NoTag(iri.serializedSize)
-    iri.writeTo(out)
-  else if t.isBnode then
-    out.writeString(2 + tagOffset, t.bnode)
-  else if t.isLiteral then
-    val literal = t.literal
-    out.writeTag(3 + tagOffset, 2)
-    out.writeUInt32NoTag(literal.serializedSize)
-    literal.writeTo(out)
-  else if t.isTripleTerm then
-    val triple = t.tripleTerm
-    out.writeTag(4 + tagOffset, 2)
-    out.writeUInt32NoTag(triple.serializedSize)
-    triple.writeTo(out)
+  else (t.termNumber : @switch) match
+    case RdfTerm.TERM_IRI =>
+      val iri = t.iri
+      out.writeTag(1 + tagOffset, 2)
+      out.writeUInt32NoTag(iri.serializedSize)
+      iri.writeTo(out)
+    case RdfTerm.TERM_BNODE =>
+      out.writeString(2 + tagOffset, t.bnode)
+    case RdfTerm.TERM_LITERAL =>
+      val literal = t.literal
+      out.writeTag(3 + tagOffset, 2)
+      out.writeUInt32NoTag(literal.serializedSize)
+      literal.writeTo(out)
+    case RdfTerm.TERM_TRIPLE =>
+      val triple = t.tripleTerm
+      out.writeTag(4 + tagOffset, 2)
+      out.writeUInt32NoTag(triple.serializedSize)
+      triple.writeTo(out)
+    case _ => ()

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
@@ -116,6 +116,8 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
   override def isTriple: Boolean = true
 
   override def triple: RdfTriple = this
+
+  override def termNumber: Int = 4
 }
 
 object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple] {

--- a/project/Transform3.scala
+++ b/project/Transform3.scala
@@ -6,8 +6,8 @@ import scala.meta.*
  */
 object Transform3 {
   val transformer: Transformer = new Transformer {
-    def copyTemplate(templ: Template, traits: Seq[String], name: String, isName: String, number: Option[Int] = None):
-    Template = {
+    def copyTemplate(templ: Template, traits: Seq[String], name: String, isName: String,
+                     number: Option[(String, Int)] = None): Template = {
       templ.copy(
         inits = templ.inits ++ traits.map { tName =>
           Init.After_4_6_0(Type.Name(tName), Name.Anonymous(), Nil)
@@ -27,10 +27,10 @@ object Transform3 {
             None,
             Term.This(Name.Anonymous()),
           ),
-        ) ++ number.map { n =>
+        ) ++ number.map { case (name, n) =>
           Defn.Def.After_4_7_3(
             List(Mod.Override()),
-            Term.Name("streamRowValueNumber"),
+            Term.Name(name),
             Nil,
             None,
             Lit.Int(n),
@@ -43,16 +43,32 @@ object Transform3 {
       case Defn.Class.After_4_6_0(_, Type.Name(name), _, _, templ) =>
         val newTempl = name match {
           // RdfTerm
-          case "RdfIri" => Some(copyTemplate(templ, Seq("UniversalTerm"), "iri", "isIri"))
-          case "RdfLiteral" => Some(copyTemplate(templ, Seq("UniversalTerm"), "literal", "isLiteral"))
-          case "RdfDefaultGraph" => Some(copyTemplate(templ, Seq("GraphTerm"), "defaultGraph", "isDefaultGraph"))
+          case "RdfIri" => Some(copyTemplate(
+            templ, Seq("UniversalTerm"), "iri", "isIri", Some(("termNumber", 1))
+          ))
+          case "RdfLiteral" => Some(copyTemplate(
+            templ, Seq("UniversalTerm"), "literal", "isLiteral", Some(("termNumber", 3))
+          ))
+          case "RdfDefaultGraph" => Some(copyTemplate(
+            templ, Seq("GraphTerm"), "defaultGraph", "isDefaultGraph", Some(("termNumber", 5))
+          ))
 
           // RdfStreamRowValue
-          case "RdfStreamOptions" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "options", "isOptions", Some(1)))
-          case "RdfGraphEnd" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "graphEnd", "isGraphEnd", Some(5)))
-          case "RdfNameEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "name", "isName", Some(9)))
-          case "RdfPrefixEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "prefix", "isPrefix", Some(10)))
-          case "RdfDatatypeEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "datatype", "isDatatype", Some(11)))
+          case "RdfStreamOptions" => Some(copyTemplate(
+            templ, Seq("RdfStreamRowValue"), "options", "isOptions", Some(("streamRowValueNumber", 1))
+          ))
+          case "RdfGraphEnd" => Some(copyTemplate(
+            templ, Seq("RdfStreamRowValue"), "graphEnd", "isGraphEnd", Some(("streamRowValueNumber", 5))
+          ))
+          case "RdfNameEntry" => Some(copyTemplate(
+            templ, Seq("RdfStreamRowValue"), "name", "isName", Some(("streamRowValueNumber", 9))
+          ))
+          case "RdfPrefixEntry" => Some(copyTemplate(
+            templ, Seq("RdfStreamRowValue"), "prefix", "isPrefix", Some(("streamRowValueNumber", 10))
+          ))
+          case "RdfDatatypeEntry" => Some(copyTemplate(
+            templ, Seq("RdfStreamRowValue"), "datatype", "isDatatype", Some(("streamRowValueNumber", 11))
+          ))
           case _ => None
         }
         newTempl.map(templ => tree.asInstanceOf[Defn.Class].copy(templ = templ)).getOrElse(tree)


### PR DESCRIPTION
Same optimization as in #198 – instead of going through if-else-if chains with multiple virtual method calls to if* methods, do one virtual method call to `termNumber` and then use the tableswitch instruction.