### PR TITLE
Fix missing capability in RDF4J format registration

### DIFF
--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/package.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/package.scala
@@ -12,7 +12,7 @@ package object rio:
     jellyContentType,
     null,
     jellyFileExtension,
-    supportsNamespaces = false,
-    supportsContexts = true,
-    supportsRDFStar = true
+    false,
+    true,
+    true
   )

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/package.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/package.scala
@@ -12,7 +12,7 @@ package object rio:
     jellyContentType,
     null,
     jellyFileExtension,
-    false,
-    false,
-    true
+    supportsNamespaces = false,
+    supportsContexts = true,
+    supportsRDFStar = true
   )


### PR DESCRIPTION
We registered Jelly as not supporting named graphs, which is not true. This PR fixes the issue.