### PR TITLE
Experiment: speed up noprefix IRI encoding

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -142,9 +142,13 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   // We assume by default that 32 rows should be enough to encode one statement.
   // If not, the buffer will grow.
   private val extraRowsBuffer = new ArrayBuffer[RdfStreamRow](32)
-  // Make the node cache size between 256 and 1024, depending on the user's maxNameTableSize.
-  private val nodeCacheSize = Math.max(Math.min(options.maxNameTableSize, 1024), 256)
-  private val nodeEncoder = new NodeEncoder[TNode](options, nodeCacheSize, nodeCacheSize)
+  private val nodeEncoder = new NodeEncoder[TNode](
+    options,
+    // Make the node cache size between 256 and 1024, depending on the user's maxNameTableSize.
+    Math.max(Math.min(options.maxNameTableSize, 1024), 256),
+    options.maxNameTableSize,
+    Math.max(Math.min(options.maxNameTableSize, 1024), 256),
+  )
   private var emittedOptions = false
 
   private val lastSubject: LastNodeHolder[TNode] = new LastNodeHolder()

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
@@ -18,7 +18,7 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
   private def getEncoder(prefixTableSize: Int = 8): (NodeEncoder[Mrl.Node], ArrayBuffer[RdfStreamRow]) =
     val buffer = new ArrayBuffer[RdfStreamRow]()
-    (NodeEncoder[Mrl.Node](smallOptions(prefixTableSize), 16, 16), buffer)
+    (NodeEncoder[Mrl.Node](smallOptions(prefixTableSize), 16, 16, 16), buffer)
 
   "A NodeEncoder" when {
     "encoding datatype literals" should {


### PR DESCRIPTION
Remove one layer of IRI caching if we are not using the prefix table. This should speed things up...