### PR TITLE
Experiment: speed up prefixed IRI encoding

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
@@ -1,9 +1,6 @@
 package eu.ostrzyciel.jelly.core;
 
-import jdk.dynalink.linker.support.Lookup;
-
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 
 /**
  * A lookup table for NodeEncoder, used for indexing datatypes, IRI prefixes, and IRI names.

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/EncoderLookupSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/EncoderLookupSpec.scala
@@ -13,91 +13,83 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
     "add new entries up to capacity" in {
       val lookup = EncoderLookup(4)
       for i <- 1 to 4 do
-        val v = lookup.addEntry(s"v$i")
+        val v = lookup.getOrAddEntry(s"v$i")
         v.getId should be (i)
         v.setId should be (0)
         v.newEntry should be (true)
-        v.serial should be (1)
     }
 
     "retrieve entries" in {
       val lookup = EncoderLookup(4)
       for i <- 1 to 4 do
-        lookup.addEntry(s"v$i")
+        lookup.getOrAddEntry(s"v$i")
       for i <- 1 to 4 do
-        val v = lookup.addEntry(s"v$i")
+        val v = lookup.getOrAddEntry(s"v$i")
         v.getId should be (i)
         v.setId should be (i)
         v.newEntry should be (false)
-        v.serial should be (1)
     }
 
     "retrieve entries many times, in random order" in {
       val lookup = EncoderLookup(50)
       for i <- 1 to 50 do
-        lookup.addEntry(s"v$i")
+        lookup.getOrAddEntry(s"v$i")
       for _ <- 1 to 20 do
         for i <- Random.shuffle(1 to 50) do
-          val v = lookup.addEntry(s"v$i")
+          val v = lookup.getOrAddEntry(s"v$i")
           v.getId should be (i)
           v.setId should be (i)
           v.newEntry should be (false)
-          v.serial should be (1)
     }
 
     "overwrite existing entries, from oldest to newest" in {
       val lookup = EncoderLookup(4)
       for i <- 1 to 4 do
-        lookup.addEntry(s"v$i")
+        lookup.getOrAddEntry(s"v$i")
 
-      val v = lookup.addEntry("v5")
+      val v = lookup.getOrAddEntry("v5")
       v.getId should be (1)
       v.setId should be (1)
       v.newEntry should be (true)
-      v.serial should be (2)
 
       for i <- 6 to 8 do
-        val v = lookup.addEntry(s"v$i")
+        val v = lookup.getOrAddEntry(s"v$i")
         v.getId should be (i - 4)
         v.setId should be (0)
         v.newEntry should be (true)
-        v.serial should be (2)
     }
 
     "overwrite existing entries in order, many times" in {
       val lookup = EncoderLookup(17)
       for i <- 1 to 17 do
-        lookup.addEntry(s"v$i")
+        lookup.getOrAddEntry(s"v$i")
 
       for k <- 2 to 23 do
-        val v = lookup.addEntry(s"v1 $k")
+        val v = lookup.getOrAddEntry(s"v1 $k")
         v.getId should be (1)
         v.setId should be (1)
         v.newEntry should be (true)
-        v.serial should be (k)
         for i <- 2 to 17 do
-          val v = lookup.addEntry(s"v$i $k")
+          val v = lookup.getOrAddEntry(s"v$i $k")
           v.getId should be (i)
           v.setId should be (0)
           v.newEntry should be (true)
-          v.serial should be (k)
     }
 
     "pass random stress test (1)" in {
       val lookup = EncoderLookup(100)
       val frequentSet = (1 to 10).map(i => s"v$i")
-      frequentSet.foreach(lookup.addEntry)
+      frequentSet.foreach(lookup.getOrAddEntry)
 
       for i <- 1 to 50 do
         for fIndex <- 1 to 10 do
-          val v = lookup.addEntry(frequentSet(fIndex - 1))
+          val v = lookup.getOrAddEntry(frequentSet(fIndex - 1))
           v.getId should be (fIndex)
           v.setId should be (fIndex)
           v.newEntry should be (false)
-          v.serial should be (1)
 
         for _ <- 1 to 80 do
-          val v = lookup.addEntry(s"r${Random.nextInt(200) + 1}")
+          val v = lookup.getOrAddEntry(s"r${Random.nextInt(200) + 1}")
           v.getId should be > 10
           if v.setId != 0 then
             v.setId should be > 10
@@ -106,23 +98,22 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
     "pass random stress test (2)" in {
       val lookup = EncoderLookup(113)
       for i <- 1 to 20 do
-        lookup.addEntry(s"v$i")
+        lookup.getOrAddEntry(s"v$i")
       for _ <- 1 to 1000 do
         val id = Random.nextInt(20) + 1
-        val v = lookup.addEntry(s"v$id")
+        val v = lookup.getOrAddEntry(s"v$id")
         v.getId should be (id)
         if v.setId != 0 then
           v.setId should be (id)
           v.newEntry should be (false)
         else
           v.newEntry should be (true)
-        v.serial should be (1)
     }
 
     "pass random stress test (3)" in {
       val lookup = EncoderLookup(1023)
       for _ <- 1 to 100_000 do
-        val v = lookup.addEntry(s"v${Random.nextInt(10_000) + 1}")
+        val v = lookup.getOrAddEntry(s"v${Random.nextInt(10_000) + 1}")
         v.getId should be > 0
     }
   }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
@@ -72,6 +72,33 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
         )
       }
 
+      "not evict datatype IRIs used recently" in {
+        val (encoder, buffer) = getEncoder()
+        for i <- 1 to 8 do
+          val node = encoder.encodeDtLiteral(
+            Mrl.DtLiteral(s"v$i", Mrl.Datatype(s"dt$i")),
+            s"v$i", s"dt$i", buffer,
+          )
+          node.literal.lex should be (s"v$i")
+          node.literal.literalKind.datatype should be (i)
+
+        // use literal 1 again
+        val node = encoder.encodeDtLiteral(
+          Mrl.DtLiteral("v1", Mrl.Datatype("dt1")),
+          "v1", "dt1", buffer,
+        )
+        node.literal.lex should be ("v1")
+        node.literal.literalKind.datatype should be (1)
+
+        // now add a new DT and see which DT is evicted
+        val node2 = encoder.encodeDtLiteral(
+          Mrl.DtLiteral("v9", Mrl.Datatype("dt9")),
+          "v9", "dt9", buffer,
+        )
+        node2.literal.lex should be ("v9")
+        node2.literal.literalKind.datatype should be (2)
+      }
+
       "encode datatype literals while evicting old datatypes" in {
         val (encoder, buffer) = getEncoder()
         for i <- 1 to 12 do
@@ -93,10 +120,11 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
         for i <- 5 to 8 do
           val node = encoder.encodeDtLiteral(
-            Mrl.DtLiteral(s"v$i", Mrl.Datatype(s"dt$i")),
-            s"v$i", s"dt$i", buffer,
+            // Use different values to avoid reusing the same literal
+            Mrl.DtLiteral(s"v1_$i", Mrl.Datatype(s"dt$i")),
+            s"v1_$i", s"dt$i", buffer,
           )
-          node.literal.lex should be (s"v$i")
+          node.literal.lex should be (s"v1_$i")
           node.literal.literalKind.datatype should be (i)
 
         // 5–8 were used last, so they should be evicted last
@@ -256,20 +284,22 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           ("https://test.org/test/Cake1", 3, 1),
           ("https://test.org/Cake2", 1, 0),
           ("https://test.org#Cake2", 2, 2),
-          ("https://test.org/other/Cake1", 3, 1),
-          ("https://test.org/other/Cake2", 0, 0),
-          ("https://test.org/other/Cake3", 0, 0),
+          // new nameId because naive name deduplication fails
+          ("https://test.org/other/Cake1", 3, 0), // 3 3
+          ("https://test.org/other/Cake2", 0, 0), // 3 4
+          ("https://test.org/other/Cake3", 0, 1),
           ("https://test.org/other/Cake4", 0, 0),
-          ("https://test.org/other/Cake1", 0, 1),
+          ("https://test.org/other/Cake1", 0, 0),
           ("https://test.org/other/Cake2", 0, 0),
-          ("https://test.org/other/Cake3", 0, 0),
+          ("https://test.org/other/Cake3", 0, 1),
           ("https://test.org/other/Cake4", 0, 0),
-          ("https://test.org/other/Cake5", 0, 1),
-          ("https://test.org/other/Cake5", 0, 1),
-          ("https://test.org#Cake2", 2, 0),
-          ("https://test.org#Cake5", 0, 1),
+          ("https://test.org/other/Cake5", 0, 0), // 3 3
+          ("https://test.org/other/Cake5", 0, 3), // 3 3
+          ("https://test.org#Cake2", 2, 0), // 2 4
+          // naive deduplication fails again
+          ("https://test.org#Cake5", 0, 1), // 2 1
           // prefix "" evicts the previous number #1
-          ("Cake2", 1, 0),
+          ("Cake5", 1, 1),
         )
 
         for (sIri, ePrefix, eName) <- data do
@@ -279,14 +309,18 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
 
         val expectedBuffer = Seq(
           // Prefix? (name otherwise), ID, value
-          (true, 0, "https://test.org/"),
           (false, 0, "Cake1"),
+          (true, 0, "https://test.org/"),
           (true, 0, "https://test.org#"),
           (true, 0, "https://test.org/test/"),
           (false, 0, "Cake2"),
+          (false, 0, "Cake1"),
           (true, 3, "https://test.org/other/"),
-          (false, 0, "Cake3"),
+          (false, 0, "Cake2"),
+          (false, 1, "Cake3"),
           (false, 0, "Cake4"),
+          (false, 0, "Cake5"),
+          (false, 0, "Cake2"),
           (false, 1, "Cake5"),
           (true, 1, ""),
         )
@@ -303,6 +337,71 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
             val name = row.row.name
             name.id should be (eId)
             name.value should be (eVal)
+      }
+
+      "add IRIs while evicting old ones (2: detecting invalidated prefix entries)" in {
+        val (encoder, buffer) = getEncoder(3)
+        val data = Seq(
+          // IRI, expected prefix ID, expected name ID
+          ("https://test.org/1/Cake1", 1, 0),
+          ("https://test.org/2/Cake1", 2, 1),
+          ("https://test.org/3/Cake1", 3, 1),
+          ("https://test.org/3/Cake2", 0, 0),
+          // Evict the /1/ prefix
+          ("https://test.org/4/Cake2", 1, 2),
+          // Try to get the first IRI
+          ("https://test.org/1/Cake1", 2, 1),
+        )
+
+        for (sIri, ePrefix, eName) <- data do
+          val iri = encoder.encodeIri(sIri, buffer).asInstanceOf[RdfIri]
+          iri.prefixId should be(ePrefix)
+          iri.nameId should be(eName)
+
+        val expectedBuffer = Seq(
+          // Prefix? (name otherwise), ID, value
+          (false, 0, "Cake1"),
+          (true, 0, "https://test.org/1/"),
+          (true, 0, "https://test.org/2/"),
+          (true, 0, "https://test.org/3/"),
+          (false, 0, "Cake2"),
+          (true, 1, "https://test.org/4/"),
+          (true, 0, "https://test.org/1/"),
+        )
+
+        buffer.size should be(expectedBuffer.size)
+        for ((isPrefix, eId, eVal), row) <- expectedBuffer.zip(buffer) do
+          if isPrefix then
+            row.row.isPrefix should be(true)
+            val prefix = row.row.prefix
+            prefix.id should be(eId)
+            prefix.value should be(eVal)
+          else
+            row.row.isName should be(true)
+            val name = row.row.name
+            name.id should be(eId)
+            name.value should be(eVal)
+      }
+
+      "not evict IRI prefixes used recently" in {
+        val (encoder, buffer) = getEncoder(3)
+        val data = Seq(
+          // IRI, expected prefix ID, expected name ID
+          ("https://test.org/1/Cake1", 1, 0),
+          ("https://test.org/2/Cake2", 2, 0),
+          ("https://test.org/3/Cake3", 3, 0),
+          ("https://test.org/3/Cake3", 0, 3),
+          ("https://test.org/2/Cake2", 2, 2),
+          ("https://test.org/1/Cake1", 1, 1),
+          // Evict something -- this must not be /1/ because it was used last
+          // this tests if .onAccess() is called correctly
+          ("https://test.org/4/Cake4", 3, 4),
+        )
+
+        for (sIri, ePrefix, eName) <- data do
+          val iri = encoder.encodeIri(sIri, buffer).asInstanceOf[RdfIri]
+          iri.prefixId should be(ePrefix)
+          iri.nameId should be(eName)
       }
 
       "add IRIs while evicting old ones, without a prefix table" in {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -52,11 +52,11 @@ object ProtoTestCases:
 
     def encoded(opt: RdfStreamOptions) = wrapEncoded(Seq(
       opt,
-      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "subject"),
+      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "predicate"),
-      RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfNameEntry(0, "object"),
+      RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfTriple(
         RdfIri(1, 0),
         RdfIri(0, 0),
@@ -68,8 +68,8 @@ object ProtoTestCases:
         null,
         RdfLiteral("123", RdfLiteral.LiteralKind.Datatype(1)),
       ),
-      RdfPrefixEntry(0, ""),
       RdfNameEntry(0, "b"),
+      RdfPrefixEntry(0, ""),
       RdfNameEntry(0, "c"),
       RdfTriple(
         null,
@@ -118,11 +118,11 @@ object ProtoTestCases:
 
     def encoded(opt: RdfStreamOptions) = wrapEncoded(Seq(
       opt,
-      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "subject"),
+      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "predicate"),
-      RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfNameEntry(0, "graph"),
+      RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfQuad(
         RdfIri(1, 0),
         RdfIri(0, 0),
@@ -171,8 +171,8 @@ object ProtoTestCases:
 
     def encoded(opt: RdfStreamOptions) = wrapEncoded(Seq(
       opt,
-      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "subject"),
+      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "predicate"),
       RdfQuad(
         RdfIri(1, 0),
@@ -243,11 +243,11 @@ object ProtoTestCases:
       RdfGraphStart(
         RdfDefaultGraph()
       ),
-      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "subject"),
+      RdfPrefixEntry(0, "https://test.org/test/"),
       RdfNameEntry(0, "predicate"),
-      RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfNameEntry(0, "object"),
+      RdfPrefixEntry(0, "https://test.org/ns2/"),
       RdfTriple(
         RdfIri(1, 0),
         RdfIri(0, 0),
@@ -260,8 +260,8 @@ object ProtoTestCases:
         RdfLiteral("123", RdfLiteral.LiteralKind.Datatype(1)),
       ),
       RdfGraphEnd(),
-      RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfNameEntry(0, "graph"),
+      RdfPrefixEntry(0, "https://test.org/ns3/"),
       RdfGraphStart(
         RdfIri(3, 0)
       ),

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
@@ -104,8 +104,9 @@ class CrossStreamingSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
               val is = new FileInputStream(sourceFile)
               val os = new ByteArrayOutputStream()
               var encSize = 0
+              var frames = new mutable.ArrayBuffer[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame]()
               encFlow.tripleSource(is, limiter, jOpt)
-                .wireTap(f => encSize += f.serializedSize)
+                .wireTap(f => { encSize += f.serializedSize ; frames += f })
                 .toMat(decFlow.tripleSink(os))(Keep.right)
                 .run()
                 .futureValue

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossStreamingSpec.scala
@@ -104,9 +104,8 @@ class CrossStreamingSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
               val is = new FileInputStream(sourceFile)
               val os = new ByteArrayOutputStream()
               var encSize = 0
-              var frames = new mutable.ArrayBuffer[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame]()
               encFlow.tripleSource(is, limiter, jOpt)
-                .wireTap(f => { encSize += f.serializedSize ; frames += f })
+                .wireTap(f => encSize += f.serializedSize)
                 .toMat(decFlow.tripleSink(os))(Keep.right)
                 .run()
                 .futureValue


### PR DESCRIPTION
This is an experimental rewrite of prefixed IRI encoding that aims to reduce the number of hashmap calls by merging the complete IRI map with the name lookup table. The name lookup table is now keyed by IRIs (not names), which is based on the assumption that names are often associated with only one prefix. Of course, this assumption can be broken. The code has a path to detect this if two such names occur one after another and deduplicates them. However, if the two IRIs are separated by another IRI, a duplicated name entry will be added.

It's an open question as to what would be exactly the performance and the representation size impact of this change. It's certain that the compression factors for datasets like `assist-iot-weather` will be hurt, but I'm not sure by how much. As usual, if it turns out to not be worth it, I will revert the change.