### PR TITLE
Jena RIOT writer: improve buffer handling

### DIFF
--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
@@ -41,7 +41,8 @@ object JellyLanguage:
   val SYMBOL_SUPPORTED_OPTIONS: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "supportedOptions")
 
   /**
-   * Symbol for the frame size to be used when writing RDF data.
+   * Symbol for the target stream frame size to be used when writing RDF data.
+   * Frame size may be slightly larger than this value, to fit the entire statement and its lookup entries in one frame.
    *
    * Set this in Jena's Context to an integer (not long!) value.
    */

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
@@ -77,7 +77,8 @@ final class JellyWriter(out: OutputStream) extends AbstractRDFWriter:
 
   override def endRDF(): Unit =
     checkWritingStarted()
-    flushBuffer()
+    if buffer.nonEmpty then
+      flushBuffer()
     out.flush()
 
   override def handleComment(comment: String): Unit =

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
@@ -19,7 +19,8 @@ object JellyWriterSettings:
   
   val FRAME_SIZE = new LongRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.frameSize",
-    "Target RDF frame size",
+    "Target RDF stream frame size. Frame size may be slightly larger than this value, " +
+      "to fit the entire statement and its lookup entries in one frame.",
     256L
   )
 


### PR DESCRIPTION
For some reason the Jena writer had completely different logic for handling RDF stream frame sizes than RDF4J. Instead of the simple check if the size of the row buffer is at least the target size, we had some complicated shenaninigans to make the frames exactly the same. This is great, but there was no technical reason to do that (nobody really cares) and the extra logic was unnecessary burden.

This PR unifies this behavior. The regular (non-streaming) Jena writers also got a revamp -- now they are just a wrapper over the streaming writer. I've also fixed a small bug (?) where an empty stream frame would be emitted at the end of the stream for no reason.