### PR TITLE
Reduce the number of branches in NodeEncoder

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
@@ -16,18 +16,10 @@ final class EncoderLookup {
         public int getId;
         /** The ID of the entry used for adding the lookup entry to the RDF stream. */
         public int setId;
-        /** Whether this entry is a new entry. */
-        public boolean newEntry;
 
         public LookupEntry(int getId, int setId) {
             this.getId = getId;
             this.setId = setId;
-        }
-
-        public LookupEntry(int getId, int setId, boolean newEntry) {
-            this.getId = getId;
-            this.setId = setId;
-            this.newEntry = newEntry;
         }
     }
 
@@ -58,16 +50,17 @@ final class EncoderLookup {
     // This will monotonically increase until it reaches the maximum size.
     private int used;
     // The last id that was set in the table.
-    private int lastSetId = -1000;
+    private int lastSetId;
     // Names of the entries. Entry 0 is always null.
     private final String[] names;
     // Whether to maintain serial numbers for the entries.
     private final boolean useSerials;
 
-    private final LookupEntry entryForReturns = new LookupEntry(0, 0, true);
+    private final LookupEntry entryForReturns = new LookupEntry(0, 0);
 
     public EncoderLookup(int size, boolean useSerials) {
         this.size = size;
+        this.lastSetId = size;
         table = new int[(size + 1) * 2];
         names = new String[size + 1];
         this.useSerials = useSerials;
@@ -83,7 +76,7 @@ final class EncoderLookup {
 
     /**
      * To be called after an entry is accessed (used).
-     * This moves the entry to the front of the list to prevent it from being evicted.
+     * This moves the entry to the end (tail) of the list to prevent it from being evicted.
      * @param id The ID of the entry that was accessed.
      */
     public void onAccess(int id) {
@@ -105,19 +98,11 @@ final class EncoderLookup {
         tail = base;
     }
 
-    /**
-     * Adds a new entry to the lookup table or retrieves it if it already exists.
-     * @param key The key of the entry.
-     * @return The entry.
-     */
-    public LookupEntry getOrAddEntry(String key) {
-        var value = map.get(key);
-        if (value != null) {
-            // The entry is already in the table, just update the access order
-            onAccess(value.getId);
-            return value;
-        }
+    public LookupEntry getEntry(String key) {
+        return map.get(key);
+    }
 
+    public LookupEntry addEntry(String key) {
         int id;
         if (used < size) {
             // We still have space in the table, add a new entry to the end of the table.
@@ -145,7 +130,9 @@ final class EncoderLookup {
             map.put(key, oldEntry);
             // Update the table
             onAccess(id);
-            entryForReturns.setId = lastSetId + 1 == id ? 0 : id;
+            // Branchless version of:
+            // entryForReturns.setId = lastSetId + 1 == id ? 0 : id;
+            entryForReturns.setId = ((-((lastSetId + 1) ^ id)) >> 31) & id;
             // We only update lastSetId in this case, because in the sequential case we don't check it anyway
             lastSetId = id;
         }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/EncoderLookupSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/EncoderLookupSpec.scala
@@ -9,95 +9,107 @@ import scala.util.Random
 class EncoderLookupSpec extends AnyWordSpec, Matchers:
   Random.setSeed(123)
 
+  /**
+   * Get or add an entry to the lookup.
+   * @return (entry, isNew)
+   */
+  def getOrAdd(lookup: EncoderLookup, key: String): (EncoderLookup.LookupEntry, Boolean) =
+    val entry = lookup.getEntry(key)
+    if entry != null then
+      lookup.onAccess(entry.getId)
+      (entry, false)
+    else
+      (lookup.addEntry(key), true)
+
   "encoder lookup" should {
     "add new entries up to capacity" in {
       val lookup = EncoderLookup(4, true)
       for i <- 1 to 4 do
-        val v = lookup.getOrAddEntry(s"v$i")
+        val (v, isNew) = getOrAdd(lookup, s"v$i")
         v.getId should be (i)
         v.setId should be (0)
-        v.newEntry should be (true)
+        isNew should be (true)
         lookup.serials(v.getId) should be (1)
     }
 
     "retrieve entries" in {
       val lookup = EncoderLookup(4, true)
       for i <- 1 to 4 do
-        lookup.getOrAddEntry(s"v$i")
+        getOrAdd(lookup, s"v$i")
       for i <- 1 to 4 do
-        val v = lookup.getOrAddEntry(s"v$i")
+        val (v, isNew) = getOrAdd(lookup, s"v$i")
         v.getId should be (i)
         v.setId should be (i)
-        v.newEntry should be (false)
+        isNew should be (false)
         lookup.serials(v.getId) should be (1)
     }
 
     "retrieve entries many times, in random order" in {
       val lookup = EncoderLookup(50, true)
       for i <- 1 to 50 do
-        lookup.getOrAddEntry(s"v$i")
+        getOrAdd(lookup, s"v$i")
       for _ <- 1 to 20 do
         for i <- Random.shuffle(1 to 50) do
-          val v = lookup.getOrAddEntry(s"v$i")
+          val (v, isNew) = getOrAdd(lookup, s"v$i")
           v.getId should be (i)
           v.setId should be (i)
-          v.newEntry should be (false)
+          isNew should be (false)
           lookup.serials(v.getId) should be (1)
     }
 
     "overwrite existing entries, from oldest to newest" in {
       val lookup = EncoderLookup(4, true)
       for i <- 1 to 4 do
-        lookup.getOrAddEntry(s"v$i")
+        getOrAdd(lookup, s"v$i")
 
-      val v = lookup.getOrAddEntry("v5")
+      val (v, isNew) = getOrAdd(lookup, "v5")
       v.getId should be (1)
       v.setId should be (1)
-      v.newEntry should be (true)
+      isNew should be (true)
       lookup.serials(v.getId) should be (2)
 
       for i <- 6 to 8 do
-        val v = lookup.getOrAddEntry(s"v$i")
+        val (v, isNew) = getOrAdd(lookup, s"v$i")
         v.getId should be (i - 4)
         v.setId should be (0)
-        v.newEntry should be (true)
+        isNew should be (true)
         lookup.serials(v.getId) should be (2)
     }
 
     "overwrite existing entries in order, many times" in {
       val lookup = EncoderLookup(17, true)
       for i <- 1 to 17 do
-        lookup.getOrAddEntry(s"v$i")
+        getOrAdd(lookup, s"v$i")
 
       for k <- 2 to 23 do
-        val v = lookup.getOrAddEntry(s"v1 $k")
+        val (v, isNew) = getOrAdd(lookup, s"v1 $k")
         v.getId should be (1)
         v.setId should be (1)
-        v.newEntry should be (true)
+        isNew should be (true)
         lookup.serials(v.getId) should be (k)
         for i <- 2 to 17 do
-          val v = lookup.getOrAddEntry(s"v$i $k")
+          val (v, isNew) = getOrAdd(lookup, s"v$i $k")
           v.getId should be (i)
           v.setId should be (0)
-          v.newEntry should be (true)
+          isNew should be (true)
           lookup.serials(v.getId) should be (k)
     }
 
     "pass random stress test (1)" in {
       val lookup = EncoderLookup(100, true)
       val frequentSet = (1 to 10).map(i => s"v$i")
-      frequentSet.foreach(lookup.getOrAddEntry)
+      frequentSet.foreach(getOrAdd(lookup, _))
 
       for i <- 1 to 50 do
         for fIndex <- 1 to 10 do
-          val v = lookup.getOrAddEntry(frequentSet(fIndex - 1))
+          val (v, isNew) = getOrAdd(lookup, frequentSet(fIndex - 1))
           v.getId should be (fIndex)
           v.setId should be (fIndex)
-          v.newEntry should be (false)
+          isNew should be (false)
           lookup.serials(v.getId) should be (1)
 
         for _ <- 1 to 80 do
-          val v = lookup.getOrAddEntry(s"r${Random.nextInt(200) + 1}")
+          val (v, isNew) = getOrAdd(lookup, s"r${Random.nextInt(200) + 1}")
           v.getId should be > 10
           if v.setId != 0 then
             v.setId should be > 10
@@ -106,30 +118,30 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
     "pass random stress test (2)" in {
       val lookup = EncoderLookup(113, true)
       for i <- 1 to 20 do
-        lookup.getOrAddEntry(s"v$i")
+        getOrAdd(lookup, s"v$i")
       for _ <- 1 to 1000 do
         val id = Random.nextInt(20) + 1
-        val v = lookup.getOrAddEntry(s"v$id")
+        val (v, isNew) = getOrAdd(lookup, s"v$id")
         v.getId should be (id)
         if v.setId != 0 then
           v.setId should be (id)
-          v.newEntry should be (false)
+          isNew should be (false)
         else
-          v.newEntry should be (true)
+          isNew should be (true)
         lookup.serials(v.getId) should be (1)
     }
 
     "pass random stress test (3)" in {
       val lookup = EncoderLookup(1023, true)
       for _ <- 1 to 100_000 do
-        val v = lookup.getOrAddEntry(s"v${Random.nextInt(10_000) + 1}")
+        val (v, isNew) = getOrAdd(lookup, s"v${Random.nextInt(10_000) + 1}")
         v.getId should be > 0
     }
 
     "not use the serials table if not needed" in {
       val lookup = EncoderLookup(16, false)
       for _ <- 1 to 2000 do
-        val v = lookup.getOrAddEntry(s"v${Random.nextInt(1000) + 1}")
+        val (v, isNew) = getOrAdd(lookup, s"v${Random.nextInt(1000) + 1}")
         v.getId should be > 0
       lookup.serials should be (null)
     }


### PR DESCRIPTION
Yet another experiment in the NodeEncoder which *could* improve performance.

This focuses on removing as many branches from the code as possible through 2 optimizations:
- Remove the `newEntry` field in lookup entries and instead of `getOrAddEntry` use the split `getEntry` and `addEntry`. This API, although less elegant, does reduce the number of branches by 1, because we have to check if the entry is new or not only once, instead of twice. This also removes one field from lookup entries, making them slightly easier to stomach for the memory.
- More crazy: use branchless code instead of snippets like `lastId + 1 == id ? 0 : id`. It *should* help, especially because these branches were close to returns.