### PR TITLE
Experiment: again try a lighter impl for encoder node cache

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCache.java
@@ -1,0 +1,27 @@
+package eu.ostrzyciel.jelly.core;
+
+/**
+ * A terrifyingly simple cache.
+ */
+abstract class EncoderNodeCache<V> {
+
+    protected final Object[] keys;
+
+    protected final int sizeMinusOne;
+
+    protected EncoderNodeCache(int minimumSize) {
+        var size = Integer.highestOneBit(minimumSize);
+        if (size < minimumSize) {
+            size <<= 1;
+        }
+        this.sizeMinusOne = size - 1;
+        keys = new Object[size];
+    }
+
+    protected int calcIndex(Object key) {
+        int h = key.hashCode();
+        // Spread bits to avoid collisions for hashes that differ only in the upper bits.
+        // Trick from HashMap.hash()
+        return (h ^ h >>> 16) & sizeMinusOne;
+    }
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCacheDependent.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCacheDependent.java
@@ -1,0 +1,47 @@
+package eu.ostrzyciel.jelly.core;
+
+import eu.ostrzyciel.jelly.core.proto.v1.UniversalTerm;
+
+/**
+ * A cached node that depends on other lookups (RdfIri and RdfLiteral in the datatype variant).
+ */
+final class DependentNode {
+    // The actual cached node
+    UniversalTerm encoded;
+    // 1: datatypes and IRI names
+    // The pointer is the index in the lookup table, the serial is the serial number of the entry.
+    // The serial in the lookup table must be equal to the serial here for the entry to be valid.
+    int lookupPointer1;
+    int lookupSerial1;
+    // 2: IRI prefixes
+    int lookupPointer2;
+    int lookupSerial2;
+}
+
+class EncoderNodeCacheDependent extends EncoderNodeCache<DependentNode> {
+    private final DependentNode[] values;
+
+    EncoderNodeCacheDependent(int minimumSize) {
+        super(minimumSize);
+        DependentNode[] x = new DependentNode[sizeMinusOne + 1];
+        values = x;
+        for (int i = 0; i < values.length; i++) {
+            values[i] = new DependentNode();
+        }
+    }
+
+    DependentNode getOrClearIfAbsent(Object key) {
+        final int idx = calcIndex(key);
+        final Object storedKey = keys[idx];
+        final DependentNode node = values[idx];
+        if (storedKey != null && (storedKey == key || storedKey.equals(key))) {
+            return node;
+        } else {
+            node.encoded = null;
+            node.lookupPointer1 = 0;
+            node.lookupPointer2 = 0;
+            keys[idx] = key;
+            return node;
+        }
+    }
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCacheSimple.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderNodeCacheSimple.java
@@ -1,0 +1,28 @@
+package eu.ostrzyciel.jelly.core;
+
+import eu.ostrzyciel.jelly.core.proto.v1.UniversalTerm;
+
+import java.util.function.Function;
+
+class EncoderNodeCacheSimple extends EncoderNodeCache<UniversalTerm> {
+    private final UniversalTerm[] values;
+
+    EncoderNodeCacheSimple(int minimumSize) {
+        super(minimumSize);
+        UniversalTerm[] x = new UniversalTerm[sizeMinusOne + 1];
+        values = x;
+    }
+
+    UniversalTerm getOrComputeIfAbsent(Object key, Function<Object, UniversalTerm> f) {
+        final int idx = calcIndex(key);
+        final Object storedKey = keys[idx];
+        if (storedKey != null && (storedKey == key || storedKey.equals(key))) {
+            return values[idx];
+        } else {
+            keys[idx] = key;
+            UniversalTerm newTerm = f.apply(key);
+            values[idx] = newTerm;
+            return newTerm;
+        }
+    }
+}

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -144,10 +144,11 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
   private val extraRowsBuffer = new ArrayBuffer[RdfStreamRow](32)
   private val nodeEncoder = new NodeEncoder[TNode](
     options,
-    // Make the node cache size between 256 and 1024, depending on the user's maxNameTableSize.
-    Math.max(Math.min(options.maxNameTableSize, 1024), 256),
-    options.maxNameTableSize,
-    Math.max(Math.min(options.maxNameTableSize, 1024), 256),
+    // Make the node cache size between 256 and 2048, depending on the user's maxNameTableSize.
+    Math.max(Math.min(options.maxNameTableSize, 2048), 512),
+    // IRI cache can be the largest...
+    Math.max(Math.min((options.maxNameTableSize * 1.5).toInt, 8192), 512),
+    Math.max(Math.min(options.maxNameTableSize, 2048), 512),
   )
   private var emittedOptions = false
 


### PR DESCRIPTION
This is a re-try of #194, for the most part.

This time we have larger caches, keys split among multiple caches by category to avoid collisions, so it should go better. I've also improved the hashing algorithm to also take into account the higher bits. Let's see if this works.