### PR TITLE
Remove dependency on full Netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,6 @@ lazy val protobufCompilerDeps = Seq(
   "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbV % "protobuf",
   "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapbV,
   "com.google.protobuf" % "protobuf-java" % protobufV,
-  "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion,
 )
 
 lazy val commonSettings = Seq(
@@ -63,7 +62,6 @@ lazy val commonSettings = Seq(
   assemblyJarName := s"${name.value}.jar",
   assemblyMergeStrategy := {
     case x if x.endsWith("module-info.class") => MergeStrategy.concat
-    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
     case x => assemblyMergeStrategy.value(x)
   },
   crossVersion := CrossVersion.binary,


### PR DESCRIPTION
The dependency was not needed, because grpc-netty-shaded already provides what we need: https://github.com/grpc/grpc-java/issues/10931

This also helps avoid any future vulnerabilities, because Netty is quite prone to these.

Note that this is not a breaking change, because we weren't distributing any "real" packages with this dependency.