### PR TITLE
Fix missing phys. stream type in RDF4J writer

### DIFF
--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
@@ -45,12 +45,10 @@ object Rdf4jSerDes extends NativeSerDes[Seq[Statement], Seq[Statement]]:
     writer.endRDF()
 
   override def writeTriplesJelly(os: OutputStream, model: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
+    // We set the physical type to TRIPLES, because the writer has no way of telling triples from
+    // quads in RDF4J. Thus, the writer will default to QUADS.
     write(os, model, opt.withPhysicalType(PhysicalStreamType.TRIPLES), frameSize)
 
   override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
-    write(os, dataset, opt.withPhysicalType(PhysicalStreamType.QUADS), frameSize)
-
-
-
-
-
+    // No need to set the physical type, because the writer will default to QUADS.
+    write(os, dataset, opt, frameSize)


### PR DESCRIPTION
Issue: #218

We cannot fix this one in the same way as in Jena, because in RDF4J there is no way to tell apart a triple and a quad in the default graph. Because of that, the RDF4J writer will now default to writing a QUADS stream, unless it's told otherwise.

I've updated the tests and scaladocs accordingly to reflect this.