### PR TITLE
Jena/RDF4J stream options: enable all features by default

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
@@ -36,6 +36,14 @@ object JellyOptions:
     bigStrict.withRdfStar(true)
 
   /**
+   * "Big" preset suitable for high-volume streams and larger machines.
+   * Allows all protocol features (including generalized RDF statements and RDF-star statements).
+   * @return
+   */
+  def bigAllFeatures: RdfStreamOptions =
+    bigStrict.withGeneralizedStatements(true).withRdfStar(true)
+
+  /**
    * "Small" preset suitable for low-volume streams and smaller machines.
    * Does not allow generalized RDF statements.
    * @return
@@ -61,6 +69,14 @@ object JellyOptions:
     */
   def smallRdfStar: RdfStreamOptions =
     smallStrict.withRdfStar(true)
+
+  /**
+   * "Small" preset suitable for low-volume streams and smaller machines.
+   * Allows all protocol features (including generalized RDF statements and RDF-star statements).
+   * @return
+   */
+  def smallAllFeatures: RdfStreamOptions =
+    smallStrict.withGeneralizedStatements(true).withRdfStar(true)
 
   /**
    * Default maximum supported options for Jelly decoders.

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaSerDes.scala
@@ -49,11 +49,17 @@ object JenaSerDes extends NativeSerDes[Model, Dataset]:
     m
 
   def writeQuadsJelly
-  (os: OutputStream, dataset: Dataset, opt: RdfStreamOptions, frameSize: Int): Unit =
-    val format = new RDFFormat(JellyLanguage.JELLY, JellyFormatVariant(opt, frameSize))
+  (os: OutputStream, dataset: Dataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
+    var variant = JellyFormatVariant(frameSize = frameSize)
+    if opt.isDefined then
+      variant = variant.copy(opt = opt.get)
+    val format = new RDFFormat(JellyLanguage.JELLY, variant)
     RDFDataMgr.write(os, dataset, format)
 
   def writeTriplesJelly
-  (os: OutputStream, model: Model, opt: RdfStreamOptions, frameSize: Int): Unit =
-    val format = new RDFFormat(JellyLanguage.JELLY, JellyFormatVariant(opt, frameSize))
+  (os: OutputStream, model: Model, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
+    var variant = JellyFormatVariant(frameSize = frameSize)
+    if opt.isDefined then
+      variant = variant.copy(opt = opt.get)
+    val format = new RDFFormat(JellyLanguage.JELLY, variant)
     RDFDataMgr.write(os, model, format)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
@@ -54,22 +54,24 @@ object JenaStreamSerDes extends NativeSerDes[Seq[Triple], Seq[Quad]]:
       .parse(StreamRDFLib.sinkQuads(sink))
     sink.result
 
-  override def writeTriplesJelly(os: OutputStream, model: Seq[Triple], opt: RdfStreamOptions, frameSize: Int): Unit =
+  override def writeTriplesJelly(os: OutputStream, model: Seq[Triple], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val context = RIOT.getContext.copy()
+      .set(JellyLanguage.SYMBOL_FRAME_SIZE, frameSize)
+    if opt.isDefined then
       // Not setting the physical type, as it should be inferred from the data.
       // This emulates how RIOT initializes the stream writer in practice.
-      .set(JellyLanguage.SYMBOL_STREAM_OPTIONS, opt)
-      .set(JellyLanguage.SYMBOL_FRAME_SIZE, frameSize)
+      context.set(JellyLanguage.SYMBOL_STREAM_OPTIONS, opt.get)
 
     val writerStream = StreamRDFWriter.getWriterStream(os, JellyLanguage.JELLY, context)
     writerStream.start()
     model.foreach(writerStream.triple)
     writerStream.finish()
 
-  override def writeQuadsJelly(os: OutputStream, dataset: Seq[Quad], opt: RdfStreamOptions, frameSize: Int): Unit =
+  override def writeQuadsJelly(os: OutputStream, dataset: Seq[Quad], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val context = RIOT.getContext.copy()
-      .set(JellyLanguage.SYMBOL_STREAM_OPTIONS, opt)
       .set(JellyLanguage.SYMBOL_FRAME_SIZE, frameSize)
+    if opt.isDefined then
+      context.set(JellyLanguage.SYMBOL_STREAM_OPTIONS, opt.get)
 
     val writerStream = StreamRDFWriter.getWriterStream(os, JellyLanguage.JELLY, context)
     writerStream.start()

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/NativeSerDes.scala
@@ -17,5 +17,5 @@ trait NativeSerDes[TModel : Measure, TDataset : Measure]:
   def readQuadsW3C(is: InputStream): TDataset
   def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): TModel
   def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): TDataset
-  def writeTriplesJelly(os: OutputStream, model: TModel, opt: RdfStreamOptions, frameSize: Int): Unit
-  def writeQuadsJelly(os: OutputStream, dataset: TDataset, opt: RdfStreamOptions, frameSize: Int): Unit
+  def writeTriplesJelly(os: OutputStream, model: TModel, opt: Option[RdfStreamOptions], frameSize: Int): Unit
+  def writeQuadsJelly(os: OutputStream, dataset: TDataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
@@ -33,14 +33,14 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
   override def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): Seq[Statement] = 
     read(is, supportedOptions)
 
-  override def writeTriplesJelly(os: OutputStream, model: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
+  override def writeTriplesJelly(os: OutputStream, model: Seq[Statement], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val f = Source.fromIterator(() => model.iterator)
-      .via(EncoderFlow.flatTripleStream(StreamRowCountLimiter(frameSize), opt))
+      .via(EncoderFlow.flatTripleStream(StreamRowCountLimiter(frameSize), opt.getOrElse(JellyOptions.smallAllFeatures)))
       .runWith(JellyIo.toIoStream(os))
     Await.ready(f, 10.seconds)
 
-  override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: RdfStreamOptions, frameSize: Int): Unit =
+  override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val f = Source.fromIterator(() => dataset.iterator)
-      .via(EncoderFlow.flatQuadStream(StreamRowCountLimiter(frameSize), opt))
+      .via(EncoderFlow.flatQuadStream(StreamRowCountLimiter(frameSize), opt.getOrElse(JellyOptions.smallAllFeatures)))
       .runWith(JellyIo.toIoStream(os))
     Await.ready(f, 10.seconds)

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyFormat.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyFormat.scala
@@ -11,7 +11,7 @@ import org.apache.jena.riot.{RDFFormat, RDFFormatVariant}
  * @param frameSize size of each RdfStreamFrame, in rows
  */
 case class JellyFormatVariant(
-  opt: RdfStreamOptions = RdfStreamOptions.defaultInstance,
+  opt: RdfStreamOptions = JellyOptions.smallAllFeatures,
   frameSize: Int = 256
 ) extends RDFFormatVariant(opt.toString)
 
@@ -22,6 +22,8 @@ object JellyFormat:
   val JELLY_SMALL_STRICT = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.smallStrict))
   val JELLY_SMALL_GENERALIZED = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.smallGeneralized))
   val JELLY_SMALL_RDF_STAR = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.smallRdfStar))
+  val JELLY_SMALL_ALL_FEATURES = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.smallAllFeatures))
   val JELLY_BIG_STRICT = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.bigStrict))
   val JELLY_BIG_GENERALIZED = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.bigGeneralized))
   val JELLY_BIG_RDF_STAR = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.bigRdfStar))
+  val JELLY_BIG_ALL_FEATURES = new RDFFormat(JELLY, JellyFormatVariant(JellyOptions.bigAllFeatures))

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
@@ -13,7 +13,11 @@ object JellyLanguage:
   /**
    * The Jelly language constant for use in Apache Jena RIOT.
    *
-   * This uses by default [[JellyFormat.JELLY_SMALL_STRICT]] for serialization.
+   * This uses by default [[JellyFormat.JELLY_SMALL_ALL_FEATURES]] for serialization, assuming pessimistically
+   * that the user may want to use all features of the protocol.
+   *
+   * If you are not intending to use generalized RDF or RDF-star, you may want to use
+   * [[JellyFormat.JELLY_SMALL_STRICT]].
    */
   val JELLY: Lang = LangBuilder.create(jellyName, jellyContentType)
     .addAltNames("JELLY")
@@ -66,18 +70,20 @@ object JellyLanguage:
       RDFLanguages.register(JELLY)
 
       // Default serialization format
-      RDFWriterRegistry.register(JELLY, JellyFormat.JELLY_SMALL_STRICT)
+      RDFWriterRegistry.register(JELLY, JellyFormat.JELLY_SMALL_ALL_FEATURES)
       // Register also the streaming writer
-      StreamRDFWriter.register(JELLY, JellyFormat.JELLY_SMALL_STRICT)
+      StreamRDFWriter.register(JELLY, JellyFormat.JELLY_SMALL_ALL_FEATURES)
 
       // Register the writers
       val allFormats = List(
         JELLY_SMALL_STRICT,
         JELLY_SMALL_GENERALIZED,
         JELLY_SMALL_RDF_STAR,
+        JELLY_SMALL_ALL_FEATURES,
         JELLY_BIG_STRICT,
         JELLY_BIG_GENERALIZED,
-        JELLY_BIG_RDF_STAR
+        JELLY_BIG_RDF_STAR,
+        JELLY_BIG_ALL_FEATURES,
       )
 
       for format <- allFormats do

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
@@ -5,6 +5,11 @@ import org.eclipse.rdf4j.rio.WriterConfig
 import org.eclipse.rdf4j.rio.helpers.*
 
 object JellyWriterSettings:
+  def configFromOptions(frameSize: Long): WriterConfig =
+    val c = new WriterConfig()
+    c.set(FRAME_SIZE, frameSize)
+    c
+
   def configFromOptions(opt: RdfStreamOptions, frameSize: Long = 256L): WriterConfig =
     val c = new WriterConfig()
     c.set(FRAME_SIZE, frameSize)
@@ -33,19 +38,21 @@ object JellyWriterSettings:
   val PHYSICAL_TYPE = new ClassRioSetting[PhysicalStreamType](
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.physicalType",
     "Physical stream type",
-    PhysicalStreamType.TRIPLES
+    PhysicalStreamType.QUADS
   )
 
   val ALLOW_GENERALIZED_STATEMENTS = new BooleanRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.allowGeneralizedStatements",
-    "Allow generalized statements",
-    false
+    "Allow generalized statements. Enabled by default, because we cannot know this in advance. " +
+      "If your data does not contain generalized statements, it is recommended that you set this to false.",
+    true
   )
   
   val ALLOW_RDF_STAR = new BooleanRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.allowRdfStar",
-    "Allow RDF-star statements",
-    false
+    "Allow RDF-star statements. Enabled by default, because we cannot know this in advance. " +
+      "If your data does not contain RDF-star statements, it is recommended that you set this to false.",
+    true
   )
 
   val MAX_NAME_TABLE_SIZE = new LongRioSetting(


### PR DESCRIPTION
Issue: #221

This PR introduces a new preset in JellyOptions (allFeatures) which enables generalized statements and RDF-star. This preset will now be used as the default in Jena RIOT and RDF4J Rio, because it's better to break a SHOULD requirement than a MUST (see the issue for details).