### PR TITLE
Jena CLI: allow changing writer settings with presets

### DIFF
--- a/docs/docs/getting-started-plugins.md
+++ b/docs/docs/getting-started-plugins.md
@@ -23,6 +23,10 @@ You can simply add Jelly format support to [Apache Jena](https://jena.apache.org
 !!! warning "Content negotiation in Fuseki"
 
     Content negotiation using the `application/x-jelly-rdf` media type in the `Accept` header works in Fuseki since Apache Jena version 5.2.0. Previous versions of Fuseki did not support media type registration.
+
+!!! tip "How to use Jelly with Jena's CLI tools?"
+
+    Jelly-JVM fully supports Apache Jena's command-line interface (CLI) utilities. See the **[dedicated guide](user/jena-cli.md)** for more information.
     
 
 ### Eclipse RDF4J

--- a/docs/docs/user/jena-cli.md
+++ b/docs/docs/user/jena-cli.md
@@ -1,0 +1,56 @@
+Jelly-JVM fully supports Apache Jena's command-line interface (CLI) utilities.
+
+## Parsing
+
+Jena will automatically detect Jelly files based on their extension (`.jelly`, `.jelly.gz`) and parse them. You can also manually set the `--syntax` option to `jelly`.
+
+## Writing
+
+You can use Jelly as an output format for Jena's CLI utilities by specifying the `--output` or `--stream` options with the `jelly` format. We recommend using the `--stream` option for better performance. 
+
+!!! example "Example: converting a Turtle file to Jelly"
+
+    ```shell
+    ./riot --stream=jelly data.ttl > data.jelly
+    ```
+
+By default Jena will use the "small, all features" Jelly preset (name table: 128 entries, prefix table: 16, datatype table: 16, RDF-star enabled, generalized RDF enabled). There are a few reasons why you might want to change these serialization options:
+
+- **Performance** – for larger files, the small preset does not offer the best performance or compression ratio. It's better to use larger lookup tables.
+- **Compatibility** – if your data does not include RDF-star or generalized RDF, you can mark these features as disabled. Later, parsers will know accurately what to expect in your data.
+
+The following presets are available:
+
+- Small: 128 name table entries, 16 prefix table entries, 16 datatype table entries
+    - `SMALL_STRICT` – RDF-star and generalized RDF disabled
+    - `SMALL_GENERALIZED` – RDF-star disabled, generalized RDF enabled
+    - `SMALL_RDF_STAR` – RDF-star enabled, generalized RDF disabled
+    - `SMALL_ALL_FEATURES` – RDF-star and generalized RDF enabled **(default)**
+- Big: 4000 name table entries, 150 prefix table entries, 32 datatype table entries **(recommended for larger files)**
+    - `BIG_STRICT`
+    - `BIG_GENERALIZED`
+    - `BIG_RDF_STAR`
+    - `BIG_ALL_FEATURES`
+
+To use one of these presets, use the `--set` CLI option with the `https://ostrzyciel.eu/jelly/riot/symbols#preset` symbol:
+
+!!! example "Example: converting a Turtle file to Jelly with a big preset (strict)"
+
+    ```shell
+    ./riot --stream=jelly \
+        --set="https://ostrzyciel.eu/jelly/riot/symbols#preset=BIG_STRICT" \
+        data.ttl > data.jelly
+    ```
+
+!!! example "Example: dumping a TDB2 database to Jelly with a big preset (all features)"
+
+    ```shell
+    ./tdb2.tdbdump --tdb=path/to/assembler.ttl \
+        --set="https://ostrzyciel.eu/jelly/riot/symbols#preset=BIG_ALL_FEATURES" \
+        --stream=jelly > mydb.jelly
+    ```
+
+## See also
+
+- [Installing Jelly with Jena](../getting-started-plugins.md#apache-jena-apache-jena-fuseki)
+- [Jena CLI documentation](https://jena.apache.org/documentation/tools/index.html)

--- a/docs/docs/user/jena.md
+++ b/docs/docs/user/jena.md
@@ -32,3 +32,4 @@ Usage notes:
 
 - [Useful utilities](utilities.md)
 - [Reactive streaming with Jelly-JVM](reactive.md)
+- [Using Jelly with Jena's CLI tools](jena-cli.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
   - Getting started (application developers): 'getting-started-devs.md'
   - User guide:
     - Apache Jena integration: 'user/jena.md'
+    - Apache Jena CLI tools: 'user/jena-cli.md'
     - RDF4J integration: 'user/rdf4j.md'
     - Reactive streaming: 'user/reactive.md'
     - gRPC: 'user/grpc.md'

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/JenaStreamSerDes.scala
@@ -2,7 +2,7 @@ package eu.ostrzyciel.jelly.integration_tests.io
 
 import eu.ostrzyciel.jelly.convert.jena.riot.JellyLanguage
 import eu.ostrzyciel.jelly.core.JellyOptions
-import eu.ostrzyciel.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamOptions}
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
 import org.apache.jena.graph.Triple
 import org.apache.jena.riot.system.{StreamRDFLib, StreamRDFWriter}
 import org.apache.jena.riot.{RDFLanguages, RDFParser, RIOT}

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
@@ -2,6 +2,8 @@ package eu.ostrzyciel.jelly.convert.jena.riot
 
 import eu.ostrzyciel.jelly.convert.jena.riot.JellyFormat.*
 import eu.ostrzyciel.jelly.core.Constants.*
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
 import org.apache.jena.riot.*
 import org.apache.jena.riot.system.StreamRDFWriter
 import org.apache.jena.sparql.util
@@ -27,6 +29,20 @@ object JellyLanguage:
   private val SYMBOL_NS: String = "https://ostrzyciel.eu/jelly/riot/symbols#"
 
   /**
+   * Pre-defined serialization format variants for Jelly.
+   */
+  private[riot] val presets: Map[String, RdfStreamOptions] = Map(
+    "SMALL_STRICT" -> JellyOptions.smallStrict,
+    "SMALL_GENERALIZED" -> JellyOptions.smallGeneralized,
+    "SMALL_RDF_STAR" -> JellyOptions.smallRdfStar,
+    "SMALL_ALL_FEATURES" -> JellyOptions.smallAllFeatures,
+    "BIG_STRICT" -> JellyOptions.bigStrict,
+    "BIG_GENERALIZED" -> JellyOptions.bigGeneralized,
+    "BIG_RDF_STAR" -> JellyOptions.bigRdfStar,
+    "BIG_ALL_FEATURES" -> JellyOptions.bigAllFeatures,
+  )
+
+  /**
    * Symbol for the stream options to be used when writing RDF data.
    *
    * Set this in Jena's Context to instances of [[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions]].
@@ -34,12 +50,23 @@ object JellyLanguage:
   val SYMBOL_STREAM_OPTIONS: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "streamOptions")
 
   /**
+   * Alternative to setting the stream options directly, you specify a name of the present to use.
+   *
+   * For example: "BIG_STRICT" or "SMALL_ALL_FEATURES".
+   *
+   * This is useful for example in the RIOT command line tool, where you can't set complex objects in the context.
+   *
+   * See the [[presets]] map for available presets.
+   */
+  val SYMBOL_PRESET: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "preset")
+
+  /**
    * Symbol for the maximum supported options of the Jelly parser. Use this to for example allow for decoding Jelly
    * files with very large lookup tables or to disable RDF-star support.
-   * 
+   *
    * Set this in Jena's Context to instances of [[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions]].
-   * 
-   * You should always first obtain the default supported options from 
+   *
+   * You should always first obtain the default supported options from
    * [[eu.ostrzyciel.jelly.core.JellyOptions.defaultSupportedOptions]] and then modify them as needed.
    */
   val SYMBOL_SUPPORTED_OPTIONS: util.Symbol = org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "supportedOptions")

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriterFactorySpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriterFactorySpec.scala
@@ -1,0 +1,96 @@
+package eu.ostrzyciel.jelly.convert.jena.riot
+
+import eu.ostrzyciel.jelly.convert.jena.traits.JenaTest
+import eu.ostrzyciel.jelly.core.Constants
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import org.apache.jena.graph.{NodeFactory, Triple}
+import org.apache.jena.riot.RDFFormat
+import org.apache.jena.sparql.core.{DatasetGraphFactory, Quad}
+import org.apache.jena.sparql.graph.GraphFactory
+import org.apache.jena.sparql.util.Context
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
+
+/**
+ * Tests for the Jelly writer factories.
+ *
+ * Currently, this only checks if the options specified in the Context are correctly passed to the writer,
+ * especially the preset.
+ */
+class JellyWriterFactorySpec extends AnyWordSpec, Matchers, JenaTest:
+  private val triple = Triple.create(NodeFactory.createBlankNode(), NodeFactory.createBlankNode(), NodeFactory.createBlankNode())
+  private val factories: Seq[(String, String, (RDFFormat, Context, OutputStream) => Unit)] = Seq(
+    (
+      "JellyGraphWriterFactory",
+      "triples",
+      (f: RDFFormat, ctx: Context, out: OutputStream) => {
+        val w = JellyGraphWriterFactory.create(f)
+        val g = GraphFactory.createDefaultGraph()
+        g.add(triple)
+        w.write(out, g, null, null, ctx)
+      }
+    ),
+    (
+      "JellyDatasetWriterFactory",
+      "quads",
+      (f: RDFFormat, ctx: Context, out: OutputStream) => {
+        val w = JellyDatasetWriterFactory.create(f)
+        val ds = DatasetGraphFactory.create()
+        ds.getDefaultGraph.add(triple)
+        w.write(out, ds, null, null, ctx)
+      }
+    ),
+    (
+      "JellyStreamWriterFactory",
+      "triples",
+      (f: RDFFormat, ctx: Context, out: OutputStream) => {
+        val w = JellyStreamWriterFactory.create(out, f, ctx)
+        w.triple(triple)
+        w.finish()
+      }
+    ),
+    (
+      "JellyStreamWriterFactory",
+      "quads",
+      (f: RDFFormat, ctx: Context, out: OutputStream) => {
+        val w = JellyStreamWriterFactory.create(out, f, ctx)
+        w.quad(Quad.create(null, triple))
+        w.finish()
+      }
+    ),
+  )
+
+  for (factoryName, streamType, factory) <- factories do
+    f"$factoryName ($streamType)" should {
+      for (presetName <- JellyLanguage.presets.keys) do
+        f"write a header with the $presetName preset set in the context" in {
+          val os = new ByteArrayOutputStream()
+          val format = RDFFormat(JellyLanguage.JELLY)
+          val ctx = new Context()
+          ctx.set(JellyLanguage.SYMBOL_PRESET, presetName)
+          factory(format, ctx, os)
+          val bytes = os.toByteArray
+          bytes should not be empty
+          val is = new ByteArrayInputStream(bytes)
+
+          val frame: RdfStreamFrame = RdfStreamFrame.parseDelimitedFrom(is).get
+          frame.rows.size should be > 0
+          frame.rows.head.row.isOptions should be(true)
+          val options = frame.rows.head.row.options
+          val expOpt = JellyLanguage.presets(presetName)
+          if streamType == "triples" then
+            options.physicalType should be(PhysicalStreamType.TRIPLES)
+            options.logicalType should be(LogicalStreamType.FLAT_TRIPLES)
+          else if streamType == "quads" then
+            options.physicalType should be(PhysicalStreamType.QUADS)
+            options.logicalType should be(LogicalStreamType.FLAT_QUADS)
+          options.generalizedStatements should be(expOpt.generalizedStatements)
+          options.rdfStar should be(expOpt.rdfStar)
+          options.maxNameTableSize should be(expOpt.maxNameTableSize)
+          options.maxPrefixTableSize should be(expOpt.maxPrefixTableSize)
+          options.maxDatatypeTableSize should be(expOpt.maxDatatypeTableSize)
+          options.version should be(Constants.protoVersion)
+        }
+    }


### PR DESCRIPTION
Previously it was not really possible to change the Jelly writer options when using the Jena CLI utilities. There is a CLI option to modify the Jena context, but our context would have to be set to a Java object... which I honestly hope is not possible, because that would be RCE or something.

So, to get around this, this commit introduces "presets" based on the default setting presets available in JellyOptions. The user can simply choose one of these by setting a symbol to the name of the preset.

I've added a test that checks if this works across all writers.

I've also added a doc page documenting this, because honestly, it's a neat and useful feature.