### PR TITLE
Add Jelly stream transcoders

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             java: 17
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             java: 21
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             java: 23
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             java: 17
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             java: 21
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             java: 23
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             java: 17
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             java: 21
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             java: 23
     runs-on: ${{ matrix.os }}
 

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
@@ -1,5 +1,6 @@
 package eu.ostrzyciel.jelly.core;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 /**
@@ -157,5 +158,17 @@ final class EncoderLookup {
         }
         entryForReturns.getId = id;
         return entryForReturns;
+    }
+
+    public void clear() {
+        map.clear();
+        Arrays.fill(table, 0);
+        tail = 0;
+        used = 0;
+        lastSetId = -1000;
+        if (useSerials) {
+            Arrays.fill(serials, 0);
+            serials[0] = -1;
+        }
     }
 }

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
@@ -206,16 +206,4 @@ final class EncoderLookup {
         entryForReturns.getId = id;
         return entryForReturns;
     }
-
-    public void clear() {
-        map.clear();
-        Arrays.fill(table, 0);
-        tail = 0;
-        used = 0;
-        lastSetId = -1000;
-        if (useSerials) {
-            Arrays.fill(serials, 0);
-            serials[0] = -1;
-        }
-    }
 }

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/EncoderLookup.java
@@ -107,6 +107,42 @@ final class EncoderLookup {
     }
 
     /**
+     * One branch of the getOrAddEntry method. Should be inlined by the JIT.
+     * @param key
+     * @param id
+     */
+    private final void addEntrySequential(String key, int id) {
+        int base = id * 2;
+        // Set the left to the tail
+        table[base] = tail;
+        // Right is already 0
+        // table[base + 1] = 0;
+        // Set the tail's right to us
+        table[tail + 1] = base;
+        tail = base;
+        names[id] = key;
+        map.put(key, new LookupEntry(id, id));
+    }
+
+    /**
+     * Another branch of the getOrAddEntry method. Should be inlined by the JIT.
+     * @param key
+     * @param id
+     */
+    private final void addEntryEvicting(String key, int id) {
+        // Remove the entry from the map
+        LookupEntry oldEntry = map.remove(names[id]);
+        // Insert the new entry
+        names[id] = key;
+        map.put(key, oldEntry);
+        // Update the table
+        onAccess(id);
+        entryForReturns.setId = lastSetId + 1 == id ? 0 : id;
+        // We only update lastSetId in this case, because in the sequential case we don't check it anyway
+        lastSetId = id;
+    }
+
+    /**
      * Adds a new entry to the lookup table or retrieves it if it already exists.
      * @param key The key of the entry.
      * @return The entry.
@@ -118,37 +154,15 @@ final class EncoderLookup {
             onAccess(value.getId);
             return value;
         }
-
         int id;
         if (used < size) {
             // We still have space in the table, add a new entry to the end of the table.
             id = ++used;
-            int base = id * 2;
-            // Set the left to the tail
-            table[base] = tail;
-            // Right is already 0
-            // table[base + 1] = 0;
-            // Set the tail's right to us
-            table[tail + 1] = base;
-            tail = base;
-            names[id] = key;
-            map.put(key, new LookupEntry(id, id));
-            // setId is 0 because we are adding a new entry sequentially
-            // We don't need to set it because it's 0 by default
-            // entryForReturns.setId = 0;
+            addEntrySequential(key, id);
         } else {
             // The table is full, evict the least recently used entry.
             id = table[1] / 2;
-            // Remove the entry from the map
-            LookupEntry oldEntry = map.remove(names[id]);
-            // Insert the new entry
-            names[id] = key;
-            map.put(key, oldEntry);
-            // Update the table
-            onAccess(id);
-            entryForReturns.setId = lastSetId + 1 == id ? 0 : id;
-            // We only update lastSetId in this case, because in the sequential case we don't check it anyway
-            lastSetId = id;
+            addEntryEvicting(key, id);
         }
         if (this.useSerials) {
             // Increment the serial number
@@ -156,6 +170,39 @@ final class EncoderLookup {
             // The if should be very predictable and have no negative performance impact.
             ++serials[id];
         }
+        entryForReturns.getId = id;
+        return entryForReturns;
+    }
+
+    /**
+     * A variant of getOrAddEntry that is used for transcoders.
+     * This method does not update the serial number of the entry because serials are not used by transcoders.
+     * @param key The key of the entry.
+     * @param evictHint A hint for the entry to evict. If 0, the least recently used entry is evicted.
+     * @return The entry.
+     */
+    public LookupEntry getOrAddEntryTranscoder(String key, int evictHint) {
+        var value = map.get(key);
+        if (value != null) {
+            onAccess(value.getId);
+            return value;
+        }
+        int id;
+        if (used < size) {
+            id = ++used;
+            addEntrySequential(key, id);
+        } else {
+            // The table is full
+            if (evictHint != 0) {
+                // We have a hint for the entry to evict
+                id = evictHint;
+            } else {
+                // Evict the least recently used entry.
+                id = table[1] / 2;
+            }
+            addEntryEvicting(key, id);
+        }
+        // Serials are not used for transcoders
         entryForReturns.getId = id;
         return entryForReturns;
     }

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
@@ -1,0 +1,81 @@
+package eu.ostrzyciel.jelly.core;
+
+class TranscoderLookup {
+    private final int outputSize;
+    private int[] table;
+    private final EncoderLookup lookup;
+
+    // 0-compression:
+    //  - for prefixes and datatypes: no worries about splicing, because zeroes are not allowed at the start of the
+    //    stream. While splitting, we need to check for zeroes at the start of the stream and remap them.
+    //  - IRI names: remap all 0s forcefully
+    private final boolean isNameLookup;
+    private boolean isFirstElement = true;
+    private int lastSetId = 0;
+    private int lastInputGetId = 0;
+    private int lastOutputGetId = 0;
+
+    TranscoderLookup(boolean isNameLookup, int outputSize) {
+        this.isNameLookup = isNameLookup;
+        this.outputSize = outputSize;
+        this.lookup = new EncoderLookup(outputSize, false);
+    }
+
+    EncoderLookup.LookupEntry addEntry(int originalId, String value) {
+        if (originalId == 0) {
+            originalId = ++lastSetId;
+        } else {
+            lastSetId = originalId;
+        }
+        EncoderLookup.LookupEntry entry = lookup.getOrAddEntry(value);
+        table[originalId] = entry.getId;
+        return entry;
+    }
+
+    int remap(int id) {
+        if (isNameLookup) {
+            if (id == 0) {
+                if (isFirstElement) {
+                    lastInputGetId = id = 1;
+                } else {
+                    id = ++lastInputGetId;
+                }
+            } else {
+                lastInputGetId = id;
+            }
+            isFirstElement = false;
+            int outputId = table[id];
+            lookup.onAccess(outputId);
+            if (outputId == lastOutputGetId + 1) {
+                lastOutputGetId++;
+                return 0;
+            }
+            lastOutputGetId = outputId;
+            return outputId;
+        }
+        if (id == 0) {
+            // No need to do onAccess here, because this is the same as the last element
+            if (isFirstElement) {
+                // We are starting a new output stream, so we need to remap the first zero.
+                isFirstElement = false;
+                return lastInputGetId;
+            }
+            return 0;
+        }
+        lastInputGetId = id;
+        id = table[id];
+        lookup.onAccess(id);
+        isFirstElement = false;
+        return id;
+    }
+
+    void newInputStream(int size) {
+        if (size > outputSize) {
+            throw new IllegalArgumentException("Input lookup size cannot be greater than the output lookup size");
+        }
+        if (table == null || table.length < size + 1) {
+            table = new int[size + 1];
+        }
+        isFirstElement = true;
+    }
+}

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
@@ -22,6 +22,11 @@ class TranscoderLookup {
     private int lastInputGetId = 0;
     private int lastOutputGetId = 0;
 
+    /**
+     * Create a new TranscoderLookup.
+     * @param isNameLookup Whether this lookup is for IRI names.
+     * @param outputSize The size of the output lookup.
+     */
     TranscoderLookup(boolean isNameLookup, int outputSize) {
         this.isNameLookup = isNameLookup;
         this.outputSize = outputSize;

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
@@ -2,10 +2,15 @@ package eu.ostrzyciel.jelly.core;
 
 import java.util.Arrays;
 
+/**
+ * A wrapper around EncoderLookup that is used in proto transcoders to remap input stream IDs to output stream IDs.
+ */
 class TranscoderLookup {
+    // The size of the output lookup table
     private final int outputSize;
+    // Mapping input IDs to output IDs
     private int[] table;
-    private int[] evictTable;
+    // The actual lookup table (output)
     private final EncoderLookup lookup;
 
     // 0-compression:
@@ -23,6 +28,15 @@ class TranscoderLookup {
         this.lookup = new EncoderLookup(outputSize, false);
     }
 
+    /**
+     * Remap a lookup entry from the input stream to the output stream.
+     *
+     * This may result in us actually adding a new entry to the output lookup, or not, if it's already there.
+     *
+     * @param originalId The ID of the entry in the input stream.
+     * @param value The value of the entry.
+     * @return The lookup entry in the output stream.
+     */
     EncoderLookup.LookupEntry addEntry(int originalId, String value) {
         if (originalId == 0) {
             originalId = ++lastSetId;
@@ -42,6 +56,14 @@ class TranscoderLookup {
         return entry;
     }
 
+    /**
+     * Remap a reference to a lookup entry from the input stream ID space to the output stream ID space.
+     *
+     * This automatically handles 0-compression.
+     *
+     * @param id The ID to remap (input stream).
+     * @return The remapped ID (output stream).
+     */
     int remap(int id) {
         if (isNameLookup) {
             if (id == 0) {
@@ -67,6 +89,10 @@ class TranscoderLookup {
         return id;
     }
 
+    /**
+     * Signal that a new input stream is starting.
+     * @param size The size of the input lookup.
+     */
     void newInputStream(int size) {
         if (size > outputSize) {
             throw new IllegalArgumentException("Input lookup size cannot be greater than the output lookup size");

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/TranscoderLookup.java
@@ -10,7 +10,6 @@ class TranscoderLookup {
     //    stream. While splitting, we need to check for zeroes at the start of the stream and remap them.
     //  - IRI names: remap all 0s forcefully
     private final boolean isNameLookup;
-    private boolean isFirstElement = true;
     private int lastSetId = 0;
     private int lastInputGetId = 0;
     private int lastOutputGetId = 0;
@@ -35,15 +34,10 @@ class TranscoderLookup {
     int remap(int id) {
         if (isNameLookup) {
             if (id == 0) {
-                if (isFirstElement) {
-                    lastInputGetId = id = 1;
-                } else {
-                    id = ++lastInputGetId;
-                }
+                id = ++lastInputGetId;
             } else {
                 lastInputGetId = id;
             }
-            isFirstElement = false;
             int outputId = table[id];
             lookup.onAccess(outputId);
             if (outputId == lastOutputGetId + 1) {
@@ -55,17 +49,10 @@ class TranscoderLookup {
         }
         if (id == 0) {
             // No need to do onAccess here, because this is the same as the last element
-            if (isFirstElement) {
-                // We are starting a new output stream, so we need to remap the first zero.
-                isFirstElement = false;
-                return lastInputGetId;
-            }
             return 0;
         }
-        lastInputGetId = id;
         id = table[id];
         lookup.onAccess(id);
-        isFirstElement = false;
         return id;
     }
 
@@ -73,9 +60,13 @@ class TranscoderLookup {
         if (size > outputSize) {
             throw new IllegalArgumentException("Input lookup size cannot be greater than the output lookup size");
         }
+        if (table != null) {
+            // Only set this for streams 2 and above (counting from 1)
+            lastSetId = 0;
+            lastInputGetId = 0;
+        }
         if (table == null || table.length < size + 1) {
             table = new int[size + 1];
         }
-        isFirstElement = true;
     }
 }

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
@@ -1,9 +1,11 @@
 package eu.ostrzyciel.jelly.core
 
 private trait JellyExceptions:
-  sealed class RdfProtoDeserializationError(msg: String) extends Error(msg)
+  final class RdfProtoDeserializationError(msg: String) extends Error(msg)
 
   final class RdfProtoSerializationError(msg: String) extends Error(msg)
+
+  final class RdfProtoTranscodingError(msg: String) extends Error(msg)
   
 private object JellyExceptions extends JellyExceptions:
   /**

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -2,7 +2,7 @@ package eu.ostrzyciel.jelly.core
 
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ArrayBuffer
 
 object ProtoEncoder:
   private val graphEnd = Seq(RdfStreamRow(RdfGraphEnd.defaultInstance))
@@ -149,12 +149,12 @@ abstract class ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted](val options: RdfS
     options.maxNameTableSize,
     Math.max(Math.min(options.maxNameTableSize, 1024), 256),
   )
-  private var emittedOptions = false
+  private var emittedOptions: Boolean = false
 
   private val lastSubject: LastNodeHolder[TNode] = new LastNodeHolder()
   private val lastPredicate: LastNodeHolder[TNode] = new LastNodeHolder()
   private val lastObject: LastNodeHolder[TNode] = new LastNodeHolder()
-  private var lastGraph: TNode | LastNodeHolder.NoValue.type = LastNodeHolder.NoValue 
+  private var lastGraph: TNode | LastNodeHolder.NoValue.type = LastNodeHolder.NoValue
 
   private def nodeToProtoWrapped(node: TNode, lastNodeHolder: LastNodeHolder[TNode]): SpoTerm =
     if node.equals(lastNodeHolder.node) then null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
@@ -1,0 +1,17 @@
+package eu.ostrzyciel.jelly.core
+
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.*
+
+object ProtoTranscoder:
+  def fastMergingTranscoderUnsafe(outputOptions: RdfStreamOptions): ProtoTranscoder =
+    ProtoTranscoderImpl(None, outputOptions)
+
+  def fastMergingTranscoder(
+    supportedInputOptions: RdfStreamOptions, outputOptions: RdfStreamOptions
+  ): ProtoTranscoder = ProtoTranscoderImpl(Some(supportedInputOptions), outputOptions)
+
+trait ProtoTranscoder:
+  def ingestRow(row: RdfStreamRow): Iterable[RdfStreamRow]
+
+  def ingestFrame(frame: RdfStreamFrame): RdfStreamFrame

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
@@ -1,17 +1,52 @@
 package eu.ostrzyciel.jelly.core
 
-import eu.ostrzyciel.jelly.core.JellyOptions
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
+/**
+ * Factory for creating ProtoTranscoder instances.
+ */
 object ProtoTranscoder:
+  /**
+   * Fast transcoder suitable for merging multiple input streams into one.
+   * This variant DOES NOT check the input options of the consumed streams. This should be therefore only used
+   * when the input is fully trusted. Otherwise, an attacker could cause a DoS by sending a stream with large lookups.
+   *
+   * @param outputOptions options for the output stream. This MUST have the physical stream type set.
+   * @return ProtoTranscoder
+   */
   def fastMergingTranscoderUnsafe(outputOptions: RdfStreamOptions): ProtoTranscoder =
     ProtoTranscoderImpl(None, outputOptions)
 
+  /**
+   * Fast transcoder suitable for merging multiple input streams into one.
+   * This variant does check the input options of the consumed streams, so it is SAFE to use with untrusted input.
+   *
+   * @param supportedInputOptions maximum allowable options for the input streams
+   * @param outputOptions options for the output stream. This MUST have the physical stream type set.
+   * @return ProtoTranscoder
+   */
   def fastMergingTranscoder(
     supportedInputOptions: RdfStreamOptions, outputOptions: RdfStreamOptions
   ): ProtoTranscoder = ProtoTranscoderImpl(Some(supportedInputOptions), outputOptions)
 
+/**
+ * Transcoder for Jelly streams.
+ *
+ * It turns one or more input streams into one output stream.
+ */
 trait ProtoTranscoder:
+  /**
+   * Ingests a single row and returns zero or more rows.
+   *
+   * @param row the row to ingest
+   * @return zero or more rows
+   */
   def ingestRow(row: RdfStreamRow): Iterable[RdfStreamRow]
 
+  /**
+   * Ingests a frame and returns a frame.
+   *
+   * @param frame the frame to ingest
+   * @return the frame
+   */
   def ingestFrame(frame: RdfStreamFrame): RdfStreamFrame

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -48,6 +48,12 @@ private final class ProtoTranscoderImpl(
       case RdfStreamRow.TRIPLE_FIELD_NUMBER => handleTriple(row)
       case RdfStreamRow.QUAD_FIELD_NUMBER => handleQuad(row)
       case RdfStreamRow.GRAPH_START_FIELD_NUMBER =>
+        this.changeInTerms = false
+        val term = r.graphStart.graph
+        val g1 = handleGraphTerm(term)
+        if changeInTerms then
+          rowBuffer.append(RdfStreamRow(RdfGraphStart(g1)))
+        else rowBuffer.append(row)
       case RdfStreamRow.GRAPH_END_FIELD_NUMBER => rowBuffer.append(row)
       case RdfStreamRow.NAME_FIELD_NUMBER =>
         val name = r.name

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -1,0 +1,155 @@
+package eu.ostrzyciel.jelly.core
+
+import eu.ostrzyciel.jelly.core.JellyExceptions.RdfProtoDeserializationError
+import eu.ostrzyciel.jelly.core.proto.v1.*
+
+import scala.annotation.switch
+import scala.collection.mutable.ArrayBuffer
+
+// Note: the caller is responsible for setting a physical stream type in the output!
+
+private final class ProtoTranscoderImpl(
+  supportedInputOptions: Option[RdfStreamOptions],
+  outputOptions: RdfStreamOptions
+) extends ProtoTranscoder:
+  override def ingestRow(row: RdfStreamRow): Iterable[RdfStreamRow] =
+    rowBuffer.clear()
+    processRow(row)
+    rowBuffer.toSeq
+
+  override def ingestFrame(frame: RdfStreamFrame): RdfStreamFrame =
+    rowBuffer.clear()
+    for row <- frame.rows do
+      processRow(row)
+    val newFrame = RdfStreamFrame(rowBuffer.toSeq)
+    newFrame
+
+  // Transcoder state
+  private val checkInputOptions = supportedInputOptions.isDefined
+  private val prefixLookup: TranscoderLookup = new TranscoderLookup(false, outputOptions.maxPrefixTableSize)
+  private val nameLookup: TranscoderLookup = new TranscoderLookup(true, outputOptions.maxNameTableSize)
+  private val datatypeLookup: TranscoderLookup = new TranscoderLookup(false, outputOptions.maxDatatypeTableSize)
+
+  // Current input stream state
+  private var inputOptions: RdfStreamOptions = null
+  private var inputUsesPrefixes = false
+
+  // Current output stream state
+  private val rowBuffer = new ArrayBuffer[RdfStreamRow](128)
+  private var changeInTerms = false
+  private var emittedOptions = false
+
+  private def processRow(row: RdfStreamRow): Unit =
+    val r = row.row
+    if r == null then
+      throw new RdfProtoDeserializationError("Row kind is not set.")
+    (r.streamRowValueNumber: @switch) match
+      case RdfStreamRow.OPTIONS_FIELD_NUMBER => handleOptions(r.options)
+      case RdfStreamRow.TRIPLE_FIELD_NUMBER => handleTriple(row)
+      case RdfStreamRow.QUAD_FIELD_NUMBER => handleQuad(row)
+      case RdfStreamRow.GRAPH_START_FIELD_NUMBER =>
+      case RdfStreamRow.GRAPH_END_FIELD_NUMBER => rowBuffer.append(row)
+      case RdfStreamRow.NAME_FIELD_NUMBER =>
+        val name = r.name
+        val entry = nameLookup.addEntry(name.id, name.value)
+        if !entry.newEntry then ()
+        else if entry.setId == name.id then rowBuffer.append(row)
+        else rowBuffer.append(RdfStreamRow(RdfNameEntry(entry.setId, name.value)))
+      case RdfStreamRow.PREFIX_FIELD_NUMBER =>
+        val prefix = r.prefix
+        val entry = prefixLookup.addEntry(prefix.id, prefix.value)
+        if !entry.newEntry then ()
+        else if entry.setId == prefix.id then rowBuffer.append(row)
+        else rowBuffer.append(RdfStreamRow(RdfPrefixEntry(entry.setId, prefix.value)))
+      case RdfStreamRow.DATATYPE_FIELD_NUMBER =>
+        val datatype = r.datatype
+        val entry = datatypeLookup.addEntry(datatype.id, datatype.value)
+        if !entry.newEntry then ()
+        else if entry.setId == datatype.id then rowBuffer.append(row)
+        else rowBuffer.append(RdfStreamRow(RdfDatatypeEntry(entry.setId, datatype.value)))
+      case _ =>
+        // This case should never happen
+        throw new RdfProtoDeserializationError("Row kind is not set.")
+
+  private def handleTriple(row: RdfStreamRow): Unit =
+    this.changeInTerms = false
+    val triple = row.row.triple
+    val s1 = handleSpoTerm(triple.subject)
+    val p1 = handleSpoTerm(triple.predicate)
+    val o1 = handleSpoTerm(triple.`object`)
+    if changeInTerms then
+      rowBuffer.append(RdfStreamRow(RdfTriple(s1, p1, o1)))
+    else rowBuffer.append(row)
+
+  private def handleQuad(row: RdfStreamRow): Unit =
+    this.changeInTerms = false
+    val quad = row.row.quad
+    val s1 = handleSpoTerm(quad.subject)
+    val p1 = handleSpoTerm(quad.predicate)
+    val o1 = handleSpoTerm(quad.`object`)
+    val g1 = handleGraphTerm(quad.graph)
+    if changeInTerms then
+      rowBuffer.append(RdfStreamRow(RdfQuad(s1, p1, o1, g1)))
+    else rowBuffer.append(row)
+
+  private def handleSpoTerm(term: SpoTerm): SpoTerm =
+    if term == null then null
+    else if term.isIri then handleIri(term.iri)
+    else if term.isBnode then term
+    else if term.isLiteral then handleLiteral(term.literal)
+    else if term.isTripleTerm then handleTripleTerm(term.tripleTerm)
+    else throw new RdfProtoDeserializationError("Unknown term type.")
+
+  private def handleGraphTerm(term: GraphTerm): GraphTerm =
+    if term == null then null
+    else if term.isIri then handleIri(term.iri)
+    else if term.isDefaultGraph then term
+    else if term.isBnode then term
+    else if term.isLiteral then handleLiteral(term.literal)
+    else throw new RdfProtoDeserializationError("Unknown term type.")
+
+  private def handleIri(iri: RdfIri): RdfIri =
+    val prefix = iri.prefixId
+    val name = iri.nameId
+    val prefix1 = if inputUsesPrefixes then prefixLookup.remap(prefix) else 0
+    val name1 = nameLookup.remap(name)
+    if prefix1 != prefix || name1 != name then
+      changeInTerms = true
+      RdfIri(prefix1, name1)
+    else iri
+
+  private def handleLiteral(literal: RdfLiteral): RdfLiteral =
+    if !literal.literalKind.isDatatype then literal
+    else
+      val dt = literal.literalKind.datatype
+      val dt1 = datatypeLookup.remap(dt)
+      if dt1 != dt then
+        changeInTerms = true
+        RdfLiteral(literal.lex, RdfLiteral.LiteralKind.Datatype(dt1))
+      else literal
+
+  private def handleTripleTerm(triple: RdfTriple): RdfTriple =
+    val s1 = handleSpoTerm(triple.subject)
+    val p1 = handleSpoTerm(triple.predicate)
+    val o1 = handleSpoTerm(triple.`object`)
+    if s1 != triple.subject || p1 != triple.predicate || o1 != triple.`object` then
+      changeInTerms = true
+      RdfTriple(s1, p1, o1)
+    else triple
+
+  private def handleOptions(options: RdfStreamOptions): Unit =
+    if checkInputOptions then
+      // TODO: check if this is the same physical stream type...
+      JellyOptions.checkCompatibility(options, supportedInputOptions.get)
+    this.inputUsesPrefixes = options.maxPrefixTableSize > 0
+    if inputUsesPrefixes then
+      prefixLookup.newInputStream(options.maxPrefixTableSize)
+    nameLookup.newInputStream(options.maxNameTableSize)
+    datatypeLookup.newInputStream(options.maxDatatypeTableSize)
+    // Update the input options
+    inputOptions = options
+    if !emittedOptions then
+      emittedOptions = true
+      rowBuffer.append(RdfStreamRow(outputOptions.copy(
+        version = Constants.protoVersion
+      )))

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -7,15 +7,31 @@ import scala.collection.mutable.ArrayBuffer
 
 // Note: the caller is responsible for setting a physical stream type in the output!
 
+/**
+ * Fast implementation of the ProtoTranscoder interface.
+ *
+ * It does not in perfect compression (like you would get with full decoding and re-encoding), but it should be
+ * good enough for the vast majority of cases.
+ *
+ * @param supportedInputOptions maximum allowable options for the input streams (optional)
+ * @param outputOptions options for the output stream. This MUST have the physical stream type set.
+ */
 private final class ProtoTranscoderImpl(
   supportedInputOptions: Option[RdfStreamOptions],
   outputOptions: RdfStreamOptions
 ) extends ProtoTranscoder:
+
+  /**
+   * @inheritdoc
+   */
   override def ingestRow(row: RdfStreamRow): Iterable[RdfStreamRow] =
     rowBuffer.clear()
     processRow(row)
     rowBuffer.toSeq
 
+  /**
+   * @inheritdoc
+   */
   override def ingestFrame(frame: RdfStreamFrame): RdfStreamFrame =
     rowBuffer.clear()
     for row <- frame.rows do

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -5,8 +5,6 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
 import scala.annotation.switch
 import scala.collection.mutable.ArrayBuffer
 
-// Note: the caller is responsible for setting a physical stream type in the output!
-
 /**
  * Fast implementation of the ProtoTranscoder interface.
  *

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -1,6 +1,5 @@
 package eu.ostrzyciel.jelly.core
 
-import eu.ostrzyciel.jelly.core.JellyExceptions.RdfProtoDeserializationError
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 import scala.annotation.switch
@@ -152,6 +151,8 @@ private final class ProtoTranscoderImpl(
     this.inputUsesPrefixes = options.maxPrefixTableSize > 0
     if inputUsesPrefixes then
       prefixLookup.newInputStream(options.maxPrefixTableSize)
+    else if outputOptions.maxPrefixTableSize > 0 then
+      throw new RdfProtoTranscodingError("Output stream uses prefixes, but the input stream does not.")
     nameLookup.newInputStream(options.maxNameTableSize)
     datatypeLookup.newInputStream(options.maxDatatypeTableSize)
     // Update the input options

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTestCases.scala
@@ -16,7 +16,7 @@ object ProtoTestCases:
   def wrapEncodedFull(rows: Seq[RdfStreamRowValue]): Seq[RdfStreamRow] =
     wrapEncoded(rows).map(row => RdfStreamRow(row))
 
-  trait TestCase[TStatement]:
+  trait TestCase[+TStatement]:
     def mrl: Seq[TStatement]
     def encoded(opt: RdfStreamOptions): Seq[RdfStreamRowValue]
     def encodedFull(opt: RdfStreamOptions, groupByN: Int) =

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
@@ -1,0 +1,67 @@
+package eu.ostrzyciel.jelly.core
+
+import eu.ostrzyciel.jelly.core.ProtoTestCases.*
+import eu.ostrzyciel.jelly.core.helpers.{MockConverterFactory, Mrl}
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ProtoTranscoderSpec extends AnyWordSpec, Inspectors, Matchers:
+  def smallOptions(prefixTableSize: Int) = RdfStreamOptions(
+    maxNameTableSize = 4,
+    maxPrefixTableSize = prefixTableSize,
+    maxDatatypeTableSize = 8,
+  )
+
+  "ProtoTranscoder" should {
+    "splice two identical streams" when {
+      "input is Triples1" in {
+        // TODO: more cases
+        val options: RdfStreamOptions = JellyOptions.smallAllFeatures.withPhysicalType(PhysicalStreamType.TRIPLES)
+        val input: RdfStreamFrame = Triples1.encodedFull(options, 100).head
+        val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+        // First frame should be returned as is
+        val out1 = transcoder.ingestFrame(input)
+        out1 shouldBe input
+        // What's more, the rows should be the exact same objects (except the options)
+        forAll(input.rows.zip(out1.rows).drop(1)) { case (in, out) =>
+          in eq out shouldBe true // reference equality
+        }
+
+        val out2 = transcoder.ingestFrame(input)
+        out2.rows.size shouldBe < (input.rows.size)
+        // No row in out2 should be an options row or a lookup entry row
+        forAll(out2.rows) { (row: RdfStreamRow) =>
+          row.row.isOptions shouldBe false
+          row.row.isPrefix shouldBe false
+          row.row.isName shouldBe false
+          row.row.isDatatype shouldBe false
+        }
+
+        // If there is a row in out2 with same content as in input, it should be the same object
+        var identicalRows = 0
+        forAll(input.rows) { (row: RdfStreamRow) =>
+          val sameRow = out2.rows.find(_.row == row.row)
+          if (sameRow.isDefined) {
+            sameRow.get eq row shouldBe true
+            identicalRows += 1
+          }
+        }
+        // Something should be identical
+        identicalRows shouldBe > (0)
+
+        // Decode the output
+        val decoder = MockConverterFactory.anyStatementDecoder(None)
+        val statements1 = out1.rows.flatMap(decoder.ingestRow)
+        val statements2 = out2.rows.flatMap(decoder.ingestRow)
+        statements1 shouldBe statements2
+      }
+    }
+
+    // TODO: same, with more repetitions
+
+    // TODO: splicing multiple different streams in various orders
+
+    // TODO: exception handling
+  }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
@@ -241,11 +241,24 @@ class ProtoTranscoderSpec extends AnyWordSpec, Inspectors, Matchers:
       ex.getMessage should include ("larger than the maximum supported size")
     }
 
+    "throw an exception if the input does not use prefixes but the output does" in {
+      val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(
+        JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.TRIPLES)
+      )
+      val ex = intercept[RdfProtoTranscodingError] {
+        transcoder.ingestRow(RdfStreamRow(
+          JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.TRIPLES)
+            .withMaxPrefixTableSize(0)
+        ))
+      }
+      ex.getMessage should include ("Output stream uses prefixes, but the input stream does not")
+    }
+
     "accept an input stream with valid options if checking is enabled" in {
       val transcoder = ProtoTranscoder.fastMergingTranscoder(
         // Mark the prefix table as disabled
         JellyOptions.defaultSupportedOptions.withMaxPrefixTableSize(0),
-        JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.TRIPLES)
+        JellyOptions.smallStrict.withPhysicalType(PhysicalStreamType.TRIPLES).withMaxPrefixTableSize(0),
       )
       val inputOptions = JellyOptions.smallStrict
         .withPhysicalType(PhysicalStreamType.TRIPLES)

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
@@ -9,6 +9,10 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Random
 
+/**
+ * Unit tests for the ProtoTranscoder class.
+ * See also integration tests: [[eu.ostrzyciel.jelly.integration_tests.CrossTranscodingSpec]]
+ */
 class ProtoTranscoderSpec extends AnyWordSpec, Inspectors, Matchers:
   def smallOptions(prefixTableSize: Int) = RdfStreamOptions(
     maxNameTableSize = 4,

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderSpec.scala
@@ -7,6 +7,8 @@ import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.util.Random
+
 class ProtoTranscoderSpec extends AnyWordSpec, Inspectors, Matchers:
   def smallOptions(prefixTableSize: Int) = RdfStreamOptions(
     maxNameTableSize = 4,
@@ -14,54 +16,184 @@ class ProtoTranscoderSpec extends AnyWordSpec, Inspectors, Matchers:
     maxDatatypeTableSize = 8,
   )
 
+  val testCases: Seq[(String, PhysicalStreamType, TestCase[Mrl.Triple | Mrl.Quad | (Mrl.Node, Iterable[Mrl.Triple])])] = Seq(
+    ("Triples1", PhysicalStreamType.TRIPLES, Triples1),
+    ("Quads1", PhysicalStreamType.QUADS, Quads1),
+    ("Quads2RepeatDefault", PhysicalStreamType.QUADS, Quads2RepeatDefault),
+    ("Graphs1", PhysicalStreamType.GRAPHS, Graphs1),
+  )
+
   "ProtoTranscoder" should {
     "splice two identical streams" when {
-      "input is Triples1" in {
-        // TODO: more cases
-        val options: RdfStreamOptions = JellyOptions.smallAllFeatures.withPhysicalType(PhysicalStreamType.TRIPLES)
-        val input: RdfStreamFrame = Triples1.encodedFull(options, 100).head
-        val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
-        // First frame should be returned as is
-        val out1 = transcoder.ingestFrame(input)
-        out1 shouldBe input
-        // What's more, the rows should be the exact same objects (except the options)
-        forAll(input.rows.zip(out1.rows).drop(1)) { case (in, out) =>
-          in eq out shouldBe true // reference equality
-        }
-
-        val out2 = transcoder.ingestFrame(input)
-        out2.rows.size shouldBe < (input.rows.size)
-        // No row in out2 should be an options row or a lookup entry row
-        forAll(out2.rows) { (row: RdfStreamRow) =>
-          row.row.isOptions shouldBe false
-          row.row.isPrefix shouldBe false
-          row.row.isName shouldBe false
-          row.row.isDatatype shouldBe false
-        }
-
-        // If there is a row in out2 with same content as in input, it should be the same object
-        var identicalRows = 0
-        forAll(input.rows) { (row: RdfStreamRow) =>
-          val sameRow = out2.rows.find(_.row == row.row)
-          if (sameRow.isDefined) {
-            sameRow.get eq row shouldBe true
-            identicalRows += 1
+      for (caseName, streamType, testCase) <- testCases do
+        s"input is $caseName" in {
+          val options: RdfStreamOptions = JellyOptions.smallAllFeatures.withPhysicalType(streamType)
+          val input: RdfStreamFrame = testCase.encodedFull(options, 100).head
+          val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+          // First frame should be returned as is
+          val out1 = transcoder.ingestFrame(input)
+          out1 shouldBe input
+          // What's more, the rows should be the exact same objects (except the options)
+          forAll(input.rows.zip(out1.rows).drop(1)) { case (in, out) =>
+            in eq out shouldBe true // reference equality
           }
-        }
-        // Something should be identical
-        identicalRows shouldBe > (0)
 
-        // Decode the output
-        val decoder = MockConverterFactory.anyStatementDecoder(None)
-        val statements1 = out1.rows.flatMap(decoder.ingestRow)
-        val statements2 = out2.rows.flatMap(decoder.ingestRow)
-        statements1 shouldBe statements2
-      }
+          val out2 = transcoder.ingestFrame(input)
+          out2.rows.size shouldBe < (input.rows.size)
+          // No row in out2 should be an options row or a lookup entry row
+          forAll(out2.rows) { (row: RdfStreamRow) =>
+            row.row.isOptions shouldBe false
+            row.row.isPrefix shouldBe false
+            row.row.isName shouldBe false
+            row.row.isDatatype shouldBe false
+          }
+
+          // If there is a row in out2 with same content as in input, it should be the same object
+          var identicalRows = 0
+          forAll(input.rows) { (row: RdfStreamRow) =>
+            val sameRows = out2.rows.filter(_.row == row.row)
+            if !sameRows.isEmpty then
+              forAtLeast(1, sameRows) { (sameRow: RdfStreamRow) =>
+                sameRow eq row shouldBe true
+                identicalRows += 1
+              }
+          }
+          // Something should be identical
+          identicalRows shouldBe > (0)
+
+          // Decode the output
+          val decoder = MockConverterFactory.anyStatementDecoder(None)
+          val statements1 = out1.rows.flatMap(decoder.ingestRow)
+          val statements2 = out2.rows.flatMap(decoder.ingestRow)
+          statements1 shouldBe statements2
+        }
     }
 
-    // TODO: same, with more repetitions
+    "splice multiple identical streams" when {
+      for (caseName, streamType, testCase) <- testCases do
+        s"input is $caseName" in {
+          val options: RdfStreamOptions = JellyOptions.smallAllFeatures.withPhysicalType(streamType)
+          val input: RdfStreamFrame = testCase.encodedFull(options, 100).head
+          val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+          val out1 = transcoder.ingestFrame(input)
+          var lastOut = out1
+          for i <- 1 to 100 do
+            val outN = transcoder.ingestFrame(input)
+            outN.rows.size shouldBe < (input.rows.size)
+            // No row in out should be an options row or a lookup entry row
+            forAll(outN.rows) { (row: RdfStreamRow) =>
+              row.row.isOptions shouldBe false
+              row.row.isPrefix shouldBe false
+              row.row.isName shouldBe false
+              row.row.isDatatype shouldBe false
+            }
+            if i != 1 then
+              outN shouldBe lastOut
+            lastOut = outN
+        }
+    }
 
-    // TODO: splicing multiple different streams in various orders
+    "splice multiple different streams" when {
+      for seed <- 1 to 20 do
+        f"random seed is $seed" in {
+          val decoder = MockConverterFactory.quadsDecoder(None)
+          val options = JellyOptions.smallAllFeatures.withPhysicalType(PhysicalStreamType.QUADS)
+          val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+          val possibleCases = Seq(Quads1, Quads2RepeatDefault)
+          val random = Random(seed)
+          val usedIndices = Array.ofDim[Int](possibleCases.size)
+          for i <- 1 to 100 do
+            val index = random.nextInt(possibleCases.size)
+            usedIndices(index) += 1
+            val testCase = possibleCases(index)
+            val out = transcoder.ingestFrame(testCase.encodedFull(options, 100).head)
+
+            if usedIndices(index) > 1 then
+              // No row in out should be an options row or a lookup entry row
+              forAll(out.rows) { (row: RdfStreamRow) =>
+                row.row.isOptions shouldBe false
+                row.row.isPrefix shouldBe false
+                row.row.isName shouldBe false
+                row.row.isDatatype shouldBe false
+              }
+
+            val decoded = out.rows.flatMap(decoder.ingestRow)
+            decoded shouldBe testCase.mrl
+        }
+    }
+
+    "handle named graphs" in {
+      val options = JellyOptions.smallStrict
+        .withMaxPrefixTableSize(0)
+        .withPhysicalType(PhysicalStreamType.GRAPHS)
+        .withVersion(Constants.protoVersion)
+      val input = Seq(
+        RdfStreamRow(options),
+        RdfStreamRow(RdfNameEntry(0, "some IRI")),
+        RdfStreamRow(RdfNameEntry(4, "some IRI 2")),
+        RdfStreamRow(RdfGraphStart(RdfIri(0, 0))),
+        RdfStreamRow(RdfGraphStart(RdfIri(0, 4))),
+      )
+      val expectedOutput = Seq(
+        RdfStreamRow(options),
+        RdfStreamRow(RdfNameEntry(0, "some IRI")),
+        // ID 4 should be remapped to 2
+        RdfStreamRow(RdfNameEntry(0, "some IRI 2")),
+        RdfStreamRow(RdfGraphStart(RdfIri(0, 0))),
+        RdfStreamRow(RdfGraphStart(RdfIri(0, 0))),
+      )
+      val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+      input.flatMap(transcoder.ingestRow) shouldBe expectedOutput
+    }
+
+    "remap prefix, name, and datatype IDs" in {
+      val options = JellyOptions.smallStrict.withVersion(Constants.protoVersion)
+      val input = Seq(
+        RdfStreamRow(options),
+        RdfStreamRow(RdfNameEntry(4, "some name")),
+        RdfStreamRow(RdfPrefixEntry(4, "some prefix")),
+        RdfStreamRow(RdfDatatypeEntry(4, "some IRI")),
+        RdfStreamRow(RdfTriple(
+          RdfTriple(
+            RdfIri(4, 4),
+            RdfIri(0, 4),
+            RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(4)),
+          ),
+          RdfIri(0, 4),
+          RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(0)),
+        )),
+        RdfStreamRow(RdfTriple(
+          RdfTriple(RdfTerm.Bnode(""), RdfTerm.Bnode(""), RdfTerm.Bnode("")),
+          RdfIri(0, 4),
+          RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(0)),
+        )),
+      )
+      val expectedOutput = Seq(
+        RdfStreamRow(options),
+        RdfStreamRow(RdfNameEntry(0, "some name")),
+        RdfStreamRow(RdfPrefixEntry(0, "some prefix")),
+        RdfStreamRow(RdfDatatypeEntry(0, "some IRI")),
+        RdfStreamRow(RdfTriple(
+          RdfTriple(
+            RdfIri(1, 0),
+            RdfIri(0, 1),
+            RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(1)),
+          ),
+          RdfIri(0, 1),
+          RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(0)),
+        )),
+        RdfStreamRow(RdfTriple(
+          RdfTriple(RdfTerm.Bnode(""), RdfTerm.Bnode(""), RdfTerm.Bnode("")),
+          RdfIri(0, 1),
+          RdfLiteral("some literal", RdfLiteral.LiteralKind.Datatype(0)),
+        )),
+      )
+      val transcoder = ProtoTranscoder.fastMergingTranscoderUnsafe(options)
+      val output = input.flatMap(transcoder.ingestRow)
+      output.size shouldBe expectedOutput.size
+      for (i <- input.indices) do
+        output(i) shouldBe expectedOutput(i)
+    }
 
     // TODO: exception handling
   }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
@@ -3,8 +3,10 @@ package eu.ostrzyciel.jelly.core
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+/**
+ * Unit tests for the TranscoderLookup class.
+ */
 class TranscoderLookupSpec extends AnyWordSpec, Matchers:
-  import EncoderLookup.LookupEntry
 
   "TranscoderLookup" should {
     "throw an exception when trying to set input lookup size greater than the output" in {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
@@ -117,6 +117,78 @@ class TranscoderLookupSpec extends AnyWordSpec, Matchers:
       }
     }
 
-    // TODO: cases for isFirstElement
+    "handle multiple input streams" when {
+      "it's a prefix lookup" in {
+        val tl = TranscoderLookup(false, 10)
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_1")
+        tl.addEntry(0, "s3_1")
+        tl.remap(2) shouldBe 2
+
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_2")
+        tl.addEntry(0, "s2_2")
+        tl.addEntry(0, "s3_2")
+        tl.remap(1) shouldBe 4
+        tl.remap(2) shouldBe 5
+        tl.remap(3) shouldBe 6
+
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_3")
+        tl.addEntry(0, "s2_3")
+        tl.addEntry(0, "s3_3")
+        tl.remap(1) shouldBe 7
+        tl.remap(2) shouldBe 8
+        tl.remap(3) shouldBe 9
+
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_2")
+        tl.addEntry(0, "s3_3")
+        tl.remap(1) shouldBe 1
+        tl.remap(2) shouldBe 5
+        tl.remap(3) shouldBe 9
+      }
+
+      "it's a name lookup" in {
+        val tl = TranscoderLookup(true, 10)
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_1")
+        tl.addEntry(0, "s3_1")
+        tl.remap(2) shouldBe 2
+        tl.remap(0) shouldBe 0
+
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_1")
+        tl.addEntry(0, "s3_1")
+        tl.remap(0) shouldBe 1
+        tl.remap(0) shouldBe 0
+        tl.remap(0) shouldBe 0
+
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_2")
+        tl.addEntry(0, "s2_2")
+        tl.addEntry(0, "s3_2")
+        tl.remap(0) shouldBe 0 // last was 3, this is 4, so it's 0
+        tl.remap(3) shouldBe 6
+        tl.remap(1) shouldBe 4
+        tl.remap(0) shouldBe 0
+        tl.remap(0) shouldBe 0
+      }
+    }
+
+    "resize the internal remapping table" in {
+      val tl = TranscoderLookup(false, 100)
+
+      for i <- 1 to 10 do
+        val size = i * 4
+        tl.newInputStream(size)
+        for j <- 1 to size do
+          tl.addEntry(j, s"s$j").getId shouldBe j
+          tl.remap(j)
+    }
   }
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/TranscoderLookupSpec.scala
@@ -1,0 +1,122 @@
+package eu.ostrzyciel.jelly.core
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TranscoderLookupSpec extends AnyWordSpec, Matchers:
+  import EncoderLookup.LookupEntry
+
+  "TranscoderLookup" should {
+    "throw an exception when trying to set input lookup size greater than the output" in {
+      val tl = TranscoderLookup(false, 100)
+      val ex = intercept[IllegalArgumentException] {
+        tl.newInputStream(120)
+      }
+      ex.getMessage should include ("Input lookup size cannot be greater than the output lookup size")
+    }
+
+    "remap IDs" when {
+      "it's a prefix lookup" in {
+        val tl = TranscoderLookup(false, 120)
+        tl.newInputStream(100)
+        tl.addEntry(80, "s80").getId shouldBe 1
+        tl.addEntry(81, "s81").getId shouldBe 2
+
+        tl.remap(80) shouldBe 1
+        tl.remap(0) shouldBe 0
+        tl.remap(0) shouldBe 0
+        tl.remap(81) shouldBe 2
+        tl.remap(80) shouldBe 1
+        tl.remap(81) shouldBe 2
+        tl.remap(0) shouldBe 0
+      }
+
+      "it's a name lookup" in {
+        val tl = TranscoderLookup(true, 100)
+        tl.newInputStream(100)
+        tl.addEntry(80, "s80").getId shouldBe 1
+        tl.addEntry(81, "s81").getId shouldBe 2
+        tl.addEntry(82, "s82").getId shouldBe 3
+        tl.addEntry(83, "s83").getId shouldBe 4
+
+        tl.remap(80) shouldBe 0
+        tl.remap(80) shouldBe 1
+        tl.remap(80) shouldBe 1
+        tl.remap(81) shouldBe 0
+        tl.remap(82) shouldBe 0
+        tl.remap(82) shouldBe 3
+        tl.remap(83) shouldBe 0
+
+        // and with 0 in the input
+        tl.remap(80) shouldBe 1
+        tl.remap(0) shouldBe 0
+        tl.remap(0) shouldBe 0
+        tl.remap(80) shouldBe 1
+      }
+    }
+
+    "remap IDs evicting old entries" when {
+      "it's a prefix lookup" in {
+        val tl = TranscoderLookup(false, 10)
+        tl.newInputStream(5)
+        for i <- 0 to 50 do
+          tl.addEntry((i % 5) + 1, s"s$i").getId shouldBe (i % 10) + 1
+          tl.remap((i % 5) + 1) shouldBe (i % 10) + 1
+      }
+
+      "it's a name lookup" in {
+        val tl = TranscoderLookup(true, 10)
+        tl.newInputStream(5)
+        for i <- 0 to 50 do
+          tl.addEntry((i % 5) + 1, s"s$i").getId shouldBe (i % 10) + 1
+          if (i % 10) != 0 || i == 0 then
+            tl.remap((i % 5) + 1) shouldBe 0
+          else
+            tl.remap((i % 5) + 1) shouldBe (i % 10) + 1
+      }
+    }
+
+    "decode 0-encoding in lookup entries in the input stream" when {
+      "it's a prefix lookup" in {
+        val tl = TranscoderLookup(false, 10)
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_1")
+        tl.addEntry(0, "s3_1")
+        tl.remap(1) shouldBe 1
+
+        tl.addEntry(1, "s1_2")
+        tl.remap(1) shouldBe 4
+        tl.remap(2) shouldBe 2
+        tl.remap(3) shouldBe 3
+        tl.remap(0) shouldBe 0
+
+        // Recover an entry
+        tl.addEntry(5, "s1_1")
+        tl.remap(5) shouldBe 1
+        tl.remap(0) shouldBe 0
+      }
+
+      "it's a name lookup" in {
+        val tl = TranscoderLookup(true, 10)
+        tl.newInputStream(5)
+        tl.addEntry(0, "s1_1")
+        tl.addEntry(0, "s2_1")
+        tl.addEntry(0, "s3_1")
+        tl.remap(1) shouldBe 0
+
+        tl.addEntry(1, "s1_2")
+        tl.remap(1) shouldBe 4
+        tl.remap(0) shouldBe 2
+        tl.remap(0) shouldBe 0
+
+        // Recover an entry
+        tl.addEntry(5, "s1_1")
+        tl.remap(5) shouldBe 1
+        tl.remap(2) shouldBe 0
+      }
+    }
+
+    // TODO: cases for isFirstElement
+  }
+

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
@@ -183,7 +183,7 @@ class CrossTranscodingSpec extends AnyWordSpec, Matchers, ScalaFutures:
           val outputOpt2 = addStreamTypeToOptions(outputOpt, tc.physicalType)
           val transcoder = transFactory(Some(sInputOpt2), outputOpt2)
           val decoder = getFrameDecoder
-          for inputIx <- 1 to 25 do
+          for inputIx <- 1 to 20 do
             val result: Seq[RdfStreamFrame] = tc.frames.map(transcoder.ingestFrame)
             val decoded = result.flatMap(decoder)
             decoded.size should be(tc.statements.size)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
@@ -1,0 +1,10 @@
+package eu.ostrzyciel.jelly.integration_tests
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * TODO
+ */
+class CrossTranscodingSpec extends AnyWordSpec, Matchers:
+  ???

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
@@ -1,20 +1,57 @@
 package eu.ostrzyciel.jelly.integration_tests
 
-import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTranscoder}
+import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory
+import eu.ostrzyciel.jelly.core.*
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import eu.ostrzyciel.jelly.stream.*
 import org.apache.jena.graph.Graph
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.sparql.core.DatasetGraph
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
+import org.eclipse.rdf4j.model.Statement
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.io.File
+import java.io.{ByteArrayOutputStream, File, FileInputStream}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
 
 /**
  * TODO
  */
-class CrossTranscodingSpec extends AnyWordSpec, Matchers:
+class CrossTranscodingSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  given actorSystem: ActorSystem = ActorSystem()
+  given ExecutionContext = actorSystem.getDispatcher
+  given PatienceConfig = PatienceConfig(timeout = 5.seconds, interval = 50.millis)
+
+  // 0. Helper functions
+
+  def checkCompat(requestedO: RdfStreamOptions, supportedO: RdfStreamOptions): Boolean =
+    try {
+      JellyOptions.checkCompatibility(requestedO, supportedO)
+      true
+    } catch {
+      case _: RdfProtoDeserializationError => false
+    }
+
+  def decodeToStatements(frames: Seq[RdfStreamFrame]): Seq[Statement] =
+    val dec = getFrameDecoder
+    frames.flatMap(dec)
+
+  def getFrameDecoder: RdfStreamFrame => Seq[Statement] =
+    val decoder = Rdf4jConverterFactory.anyStatementDecoder()
+    (frame: RdfStreamFrame) => frame.rows.flatMap(decoder.ingestRow)
+
+  def addStreamTypeToOptions(opt: RdfStreamOptions, t: String): RdfStreamOptions =
+    if t == "triples" then
+      opt.withPhysicalType(PhysicalStreamType.TRIPLES).withLogicalType(LogicalStreamType.FLAT_TRIPLES)
+    else
+      opt.withPhysicalType(PhysicalStreamType.QUADS).withLogicalType(LogicalStreamType.FLAT_QUADS)
+
+  // 1. Define the test data
+
   private val encoderImpls: Seq[(String, TestStream)] = Seq(
     ("Jena", JenaTestStream),
     ("RDF4J", Rdf4jTestStream),
@@ -23,11 +60,13 @@ class CrossTranscodingSpec extends AnyWordSpec, Matchers:
   private val transcoderImpls: Seq[(String, (Option[RdfStreamOptions], RdfStreamOptions) => ProtoTranscoder)] = Seq(
     (
       "fastMergingTranscoder",
-      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) => ProtoTranscoder.fastMergingTranscoder(suppInput.get, output)
+      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) =>
+        ProtoTranscoder.fastMergingTranscoder(suppInput.get, output)
     ),
     (
       "fastMergingTranscoderUnsafe",
-      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) => ProtoTranscoder.fastMergingTranscoderUnsafe(output)
+      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) =>
+        ProtoTranscoder.fastMergingTranscoderUnsafe(output)
     ),
   )
 
@@ -44,60 +83,115 @@ class CrossTranscodingSpec extends AnyWordSpec, Matchers:
     )
 
   private val jellyOptions: Seq[(String, RdfStreamOptions)] = Seq(
-    ("small default", JellyOptions.smallGeneralized),
-    ("small, no prefix table", JellyOptions.smallGeneralized.withMaxPrefixTableSize(0)),
+    ("small default", JellyOptions.smallAllFeatures),
+    ("small, no prefix table", JellyOptions.smallAllFeatures.withMaxPrefixTableSize(0)),
     (
-      "tiny name table, no prefix table",
-      JellyOptions.smallGeneralized.withMaxPrefixTableSize(0).withMaxNameTableSize(16)
+      "tiny name table, tiny prefix table",
+      JellyOptions.smallAllFeatures.withMaxPrefixTableSize(8).withMaxNameTableSize(16)
     ),
-    ("big default", JellyOptions.bigGeneralized),
+    ("big default", JellyOptions.bigAllFeatures),
   )
 
   private val sizeLimiters: Seq[(String, SizeLimiter)] = Seq(
     ("message byte size: 32_000", ByteSizeLimiter(32_000)),
-    ("message byte size: 500", ByteSizeLimiter(500)),
-    ("message byte size: 2_000_000", ByteSizeLimiter(2_000_000)),
-    ("stream row count: 5", StreamRowCountLimiter(5)),
+    ("message byte size: 300", ByteSizeLimiter(300)),
+    ("stream row count: 4", StreamRowCountLimiter(4)),
     ("stream row count: 200", StreamRowCountLimiter(200)),
   )
 
-  {
-    for (caseName, sourceFile) <- TripleTests.files do
-    val sourceGraph = TripleTests.graphs(caseName)
-    val is = new FileInputStream(sourceFile)
-    val os = new ByteArrayOutputStream()
-    var encSize = 0
-    encFlow.tripleSource(is, limiter, jOpt)
-      .wireTap(f => encSize += f.serializedSize)
-      .toMat(decFlow.tripleSink(os))(Keep.right)
-      .run()
-      .futureValue
+  // 2. Construct the test cases
 
-    val ck = CaseKey("triples", encName, jOptName, limiterName, caseName)
-    encodedSizes(ck) = encSize
-    val resultGraph = RDFParser.source(new ByteArrayInputStream(os.toByteArray))
-      .lang(Lang.TURTLE)
-      .toGraph
+  final case class TestCase(
+    physicalType: String, encoder: String, jOpt: String, limiter: String, caseName: String,
+    options: RdfStreamOptions, frames: Seq[RdfStreamFrame], statements: Seq[Statement]
+  ):
+    override def toString: String = s"[$physicalType, $encoder, $jOpt, $limiter, $caseName]"
 
-    sourceGraph.size() should be(resultGraph.size())
-    if caseName == "rdf-star-blanks.nt" then
-      // For blank nodes in quoted triples, we need to use a slower isomorphism algorithm
-      IsoMatcher.isomorphic(sourceGraph, resultGraph) should be(true)
-    else
-      sourceGraph.isIsomorphicWith(resultGraph) should be(true)
+  val testCases: Seq[TestCase] = {
+    for
+      (caseName, sourceFile) <- TripleTests.files
+      (encName, encFlow) <- encoderImpls
+      (jOptName, jOpt) <- jellyOptions
+      (limiterName, limiter) <- sizeLimiters
+    yield
+      val sourceGraph = TripleTests.graphs(caseName)
+      val is = new FileInputStream(sourceFile)
+      val os = new ByteArrayOutputStream()
+      val frames: Seq[RdfStreamFrame] = encFlow.tripleSource(is, limiter, jOpt)
+        .runWith(Sink.seq)
+        .futureValue
+      val statements = decodeToStatements(frames)
+      TestCase("triples", encName, jOptName, limiterName, caseName, jOpt, frames, statements)
+  } ++ {
+    for
+      (caseName, sourceFile) <- QuadTests.files
+      (encName, encFlow) <- encoderImpls
+      (jOptName, jOpt) <- jellyOptions
+      (limiterName, limiter) <- sizeLimiters
+    yield
+      val sourceDataset = QuadTests.datasets(caseName)
+      val is = new FileInputStream(sourceFile)
+      val os = new ByteArrayOutputStream()
+      val frames: Seq[RdfStreamFrame] = encFlow.quadSource(is, limiter, jOpt)
+        .runWith(Sink.seq)
+        .futureValue
+      val statements = decodeToStatements(frames)
+      TestCase("quads", encName, jOptName, limiterName, caseName, jOpt, frames, statements)
   }
+
+  // 3. Run the tests
 
   for (transName, transFactory) <- transcoderImpls do
     f"$transName" when {
-      for (jOptName, jOpt) <- jellyOptions do
-      for (limiterName, limiter) <- sizeLimiters do
-        s"processing input data $jOptName, $limiterName; demanded output $jOptName" should {
-          "do nothing" in {
+      for
+        (outputOptName, outputOpt) <- jellyOptions
+        (sInputOptName, sInputOpt) <- jellyOptions
+          .filter((_, o) => o == outputOpt || (checkCompat(o, outputOpt) && !transName.contains("Unsafe")))
+      do s"demanded output is $outputOptName, supported input is $sInputOptName" should {
+        val compatibleCases = testCases.filter(tc => checkCompat(tc.options, sInputOpt))
+        val sInputOpt2 = sInputOpt.withVersion(Constants.protoVersion)
 
-          }
+        "transcode an empty stream" in {
+          val transcoder = transFactory(Some(sInputOpt2), outputOpt)
+          val emptyFrame = RdfStreamFrame(Seq.empty)
+          val emptyResult = transcoder.ingestFrame(emptyFrame)
+          emptyResult.rows should be (emptyFrame.rows)
         }
+
+        for tc <- compatibleCases do s"frame-transcode a single input stream $tc" in {
+          val outputOpt2 = addStreamTypeToOptions(outputOpt, tc.physicalType)
+          val transcoder = transFactory(Some(sInputOpt2), outputOpt2)
+          val result: Seq[RdfStreamFrame] = tc.frames.map(transcoder.ingestFrame)
+          if tc.options == outputOpt then
+            for
+              (frame, frameI) <- result.zipWithIndex
+              (r, i) <- frame.rows.zipWithIndex
+            do
+              withClue(s"at frame $frameI row $i ") {
+                r should be (tc.frames(frameI).rows(i))
+              }
+          val decoded = decodeToStatements(result)
+          decoded.size should be (tc.statements.size)
+          for (s, i) <- tc.statements.zip(decoded).zipWithIndex do
+            val (expected, observed) = s
+            withClue("at index " + i) {
+              observed should be (expected)
+            }
+        }
+
+        for tc <- compatibleCases do s"frame-transcode a single input repeated many times $tc" in {
+          val outputOpt2 = addStreamTypeToOptions(outputOpt, tc.physicalType)
+          val transcoder = transFactory(Some(sInputOpt2), outputOpt2)
+          val decoder = getFrameDecoder
+          for inputIx <- 1 to 25 do
+            val result: Seq[RdfStreamFrame] = tc.frames.map(transcoder.ingestFrame)
+            val decoded = result.flatMap(decoder)
+            decoded.size should be(tc.statements.size)
+            for (s, i) <- tc.statements.zip(decoded).zipWithIndex do
+              val (expected, observed) = s
+              withClue(s"at input stream $inputIx index $i") {
+                observed should be(expected)
+              }
+        }
+      }
     }
-
-
-
-

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
@@ -20,7 +20,12 @@ import scala.concurrent.duration.*
 import scala.util.Random
 
 /**
- * TODO
+ * Integration tests for ProtoTranscoder.
+ * We check it here against a number of different encoders, stream option sets, and test cases.
+ * This is meant to catch rare or obscure bugs in the transcoder.
+ *
+ * More detailed test cases, testing specific behaviors are in the core module: ProtoTranscoderSpec and
+ * TranscoderLookupSpec.
  */
 class CrossTranscodingSpec extends AnyWordSpec, Matchers, ScalaFutures:
   given actorSystem: ActorSystem = ActorSystem()

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/CrossTranscodingSpec.scala
@@ -1,10 +1,103 @@
 package eu.ostrzyciel.jelly.integration_tests
 
+import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTranscoder}
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import eu.ostrzyciel.jelly.stream.*
+import org.apache.jena.graph.Graph
+import org.apache.jena.riot.RDFDataMgr
+import org.apache.jena.sparql.core.DatasetGraph
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
 
 /**
  * TODO
  */
 class CrossTranscodingSpec extends AnyWordSpec, Matchers:
-  ???
+  private val encoderImpls: Seq[(String, TestStream)] = Seq(
+    ("Jena", JenaTestStream),
+    ("RDF4J", Rdf4jTestStream),
+  )
+
+  private val transcoderImpls: Seq[(String, (Option[RdfStreamOptions], RdfStreamOptions) => ProtoTranscoder)] = Seq(
+    (
+      "fastMergingTranscoder",
+      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) => ProtoTranscoder.fastMergingTranscoder(suppInput.get, output)
+    ),
+    (
+      "fastMergingTranscoderUnsafe",
+      (suppInput: Option[RdfStreamOptions], output: RdfStreamOptions) => ProtoTranscoder.fastMergingTranscoderUnsafe(output)
+    ),
+  )
+
+  private object TripleTests:
+    val files: Seq[(String, File)] = TestCases.triples
+    val graphs: Map[String, Graph] = Map.from(
+      files.map((name, f) => (name, RDFDataMgr.loadGraph(f.toURI.toString)))
+    )
+
+  private object QuadTests:
+    val files: Seq[(String, File)] = TestCases.quads
+    val datasets: Map[String, DatasetGraph] = Map.from(
+      files.map((name, f) => (name, RDFDataMgr.loadDatasetGraph(f.toURI.toString)))
+    )
+
+  private val jellyOptions: Seq[(String, RdfStreamOptions)] = Seq(
+    ("small default", JellyOptions.smallGeneralized),
+    ("small, no prefix table", JellyOptions.smallGeneralized.withMaxPrefixTableSize(0)),
+    (
+      "tiny name table, no prefix table",
+      JellyOptions.smallGeneralized.withMaxPrefixTableSize(0).withMaxNameTableSize(16)
+    ),
+    ("big default", JellyOptions.bigGeneralized),
+  )
+
+  private val sizeLimiters: Seq[(String, SizeLimiter)] = Seq(
+    ("message byte size: 32_000", ByteSizeLimiter(32_000)),
+    ("message byte size: 500", ByteSizeLimiter(500)),
+    ("message byte size: 2_000_000", ByteSizeLimiter(2_000_000)),
+    ("stream row count: 5", StreamRowCountLimiter(5)),
+    ("stream row count: 200", StreamRowCountLimiter(200)),
+  )
+
+  {
+    for (caseName, sourceFile) <- TripleTests.files do
+    val sourceGraph = TripleTests.graphs(caseName)
+    val is = new FileInputStream(sourceFile)
+    val os = new ByteArrayOutputStream()
+    var encSize = 0
+    encFlow.tripleSource(is, limiter, jOpt)
+      .wireTap(f => encSize += f.serializedSize)
+      .toMat(decFlow.tripleSink(os))(Keep.right)
+      .run()
+      .futureValue
+
+    val ck = CaseKey("triples", encName, jOptName, limiterName, caseName)
+    encodedSizes(ck) = encSize
+    val resultGraph = RDFParser.source(new ByteArrayInputStream(os.toByteArray))
+      .lang(Lang.TURTLE)
+      .toGraph
+
+    sourceGraph.size() should be(resultGraph.size())
+    if caseName == "rdf-star-blanks.nt" then
+      // For blank nodes in quoted triples, we need to use a slower isomorphism algorithm
+      IsoMatcher.isomorphic(sourceGraph, resultGraph) should be(true)
+    else
+      sourceGraph.isIsomorphicWith(resultGraph) should be(true)
+  }
+
+  for (transName, transFactory) <- transcoderImpls do
+    f"$transName" when {
+      for (jOptName, jOpt) <- jellyOptions do
+      for (limiterName, limiter) <- sizeLimiters do
+        s"processing input data $jOptName, $limiterName; demanded output $jOptName" should {
+          "do nothing" in {
+
+          }
+        }
+    }
+
+
+
+

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
@@ -1,0 +1,25 @@
+package eu.ostrzyciel.jelly.stream
+
+import eu.ostrzyciel.jelly.core.ProtoTranscoder
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.*
+
+object TranscoderFlow:
+  final def fastMergingUnsafe(outputOptions: RdfStreamOptions): TranscoderFlowOps =
+    TranscoderFlowOps(ProtoTranscoder.fastMergingTranscoderUnsafe(outputOptions))
+
+  final def fastMerging(supportedInputOptions: RdfStreamOptions, outputOptions: RdfStreamOptions): TranscoderFlowOps =
+    TranscoderFlowOps(ProtoTranscoder.fastMergingTranscoder(supportedInputOptions, outputOptions))
+
+  final class TranscoderFlowOps(transcoder: ProtoTranscoder):
+    def frameToFrame: Flow[RdfStreamFrame, RdfStreamFrame, NotUsed] =
+      Flow[RdfStreamFrame].map(transcoder.ingestFrame)
+
+    def rowToRow: Flow[RdfStreamRow, RdfStreamRow, NotUsed] =
+      Flow[RdfStreamRow].mapConcat(transcoder.ingestRow)
+
+    def rowToFrame(limiter: SizeLimiter): Flow[RdfStreamRow, RdfStreamFrame, NotUsed] =
+      rowToRow
+        .via(limiter.flow)
+        .map(rows => RdfStreamFrame(rows))

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
@@ -5,20 +5,64 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.apache.pekko.NotUsed
 import org.apache.pekko.stream.scaladsl.*
 
+/**
+ * Factory of transcoder flows for Jelly streams. See: [[eu.ostrzyciel.jelly.core.ProtoTranscoder]].
+ *
+ * These methods are simple wrappers on the transcoder and make the exact same assumptions as the transcoder itself.
+ */
 object TranscoderFlow:
+  /**
+   * Fast transcoder suitable for merging multiple input streams into one.
+   * This variant DOES NOT check the input options of the consumed streams. This should be therefore only used
+   * when the input is fully trusted. Otherwise, an attacker could cause a DoS by sending a stream with large lookups.
+   *
+   * @param outputOptions options for the output stream
+   * @return intermediate object for creating a Pekko Streams flow
+   */
   final def fastMergingUnsafe(outputOptions: RdfStreamOptions): TranscoderFlowOps =
     TranscoderFlowOps(ProtoTranscoder.fastMergingTranscoderUnsafe(outputOptions))
 
+  /**
+   * Fast transcoder suitable for merging multiple input streams into one.
+   * This variant does check the input options of the consumed streams, so it is SAFE to use with untrusted input.
+   *
+   * @param supportedInputOptions maximum allowable options for the input streams
+   * @param outputOptions options for the output stream
+   * @return intermediate object for creating a Pekko Streams flow
+   */
   final def fastMerging(supportedInputOptions: RdfStreamOptions, outputOptions: RdfStreamOptions): TranscoderFlowOps =
     TranscoderFlowOps(ProtoTranscoder.fastMergingTranscoder(supportedInputOptions, outputOptions))
 
   final class TranscoderFlowOps(transcoder: ProtoTranscoder):
+    /**
+     * Do the transcoding on a 1:1, frame-by-frame basis.
+     *
+     * 1 frame in -> 1 frame out.
+     *
+     * @return Pekko Streams flow
+     */
     def frameToFrame: Flow[RdfStreamFrame, RdfStreamFrame, NotUsed] =
       Flow[RdfStreamFrame].map(transcoder.ingestFrame)
 
+    /**
+     * Do the transcoding on a row-by-row basis.
+     *
+     * 1 row in -> 0 or more rows out.
+     *
+     * @return Pekko Streams flow
+     */
     def rowToRow: Flow[RdfStreamRow, RdfStreamRow, NotUsed] =
       Flow[RdfStreamRow].mapConcat(transcoder.ingestRow)
 
+    /**
+     * Do the transcoding on a row-by-row basis and then group the rows into frames.
+     * The size of the frames is limited by the provided limiter.
+     *
+     * N rows in -> 1 frame out.
+     *
+     * @param limiter size limiter for the stream frames
+     * @return Pekko Streams flow
+     */
     def rowToFrame(limiter: SizeLimiter): Flow[RdfStreamRow, RdfStreamFrame, NotUsed] =
       rowToRow
         .via(limiter.flow)

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/TranscoderFlow.scala
@@ -16,7 +16,7 @@ object TranscoderFlow:
    * This variant DOES NOT check the input options of the consumed streams. This should be therefore only used
    * when the input is fully trusted. Otherwise, an attacker could cause a DoS by sending a stream with large lookups.
    *
-   * @param outputOptions options for the output stream
+   * @param outputOptions options for the output stream. This MUST have the physical stream type set.
    * @return intermediate object for creating a Pekko Streams flow
    */
   final def fastMergingUnsafe(outputOptions: RdfStreamOptions): TranscoderFlowOps =
@@ -27,7 +27,7 @@ object TranscoderFlow:
    * This variant does check the input options of the consumed streams, so it is SAFE to use with untrusted input.
    *
    * @param supportedInputOptions maximum allowable options for the input streams
-   * @param outputOptions options for the output stream
+   * @param outputOptions options for the output stream. This MUST have the physical stream type set.
    * @return intermediate object for creating a Pekko Streams flow
    */
   final def fastMerging(supportedInputOptions: RdfStreamOptions, outputOptions: RdfStreamOptions): TranscoderFlowOps =

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
@@ -1,0 +1,5 @@
+package eu.ostrzyciel.jelly.stream
+
+class TranscoderFlowSpec {
+  //TODO
+}

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
@@ -1,5 +1,68 @@
 package eu.ostrzyciel.jelly.stream
 
-class TranscoderFlowSpec {
-  //TODO
-}
+import eu.ostrzyciel.jelly.core.helpers.MockConverterFactory
+import eu.ostrzyciel.jelly.core.{JellyOptions, ProtoTestCases}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.*
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration.*
+
+class TranscoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
+  import ProtoTestCases.*
+
+  given PatienceConfig = PatienceConfig(5.seconds, 100.millis)
+  given MockConverterFactory.type = MockConverterFactory
+  given ActorSystem = ActorSystem()
+
+  "fastMergingUnsafe" should {
+    "transcode triples" when {
+      "frameToFrame" in {
+        Source(Triples1.encodedFull(JellyOptions.smallAllFeatures, 4))
+          .via(TranscoderFlow.fastMergingUnsafe(JellyOptions.smallAllFeatures).frameToFrame)
+          .runWith(Sink.seq)
+          .futureValue should be(Triples1.encodedFull(JellyOptions.smallAllFeatures, 4))
+      }
+
+      "rowToRow" in {
+        Source(Triples1.encodedFull(JellyOptions.smallAllFeatures, 4).flatMap(_.rows))
+          .via(TranscoderFlow.fastMergingUnsafe(JellyOptions.smallAllFeatures).rowToRow)
+          .runWith(Sink.seq)
+          .futureValue should be (Triples1.encodedFull(JellyOptions.smallAllFeatures, 4).flatMap(_.rows))
+      }
+
+      "rowToFrame" in {
+        Source(Triples1.encodedFull(JellyOptions.smallAllFeatures, 4).flatMap(_.rows))
+          .via(TranscoderFlow.fastMergingUnsafe(JellyOptions.smallAllFeatures).rowToFrame(StreamRowCountLimiter(4)))
+          .runWith(Sink.seq)
+          .futureValue should be (Triples1.encodedFull(JellyOptions.smallAllFeatures, 4))
+      }
+    }
+  }
+
+  "fastMerging" should {
+    "transcode quads" when {
+      "frameToFrame" in {
+        Source(Quads1.encodedFull(JellyOptions.smallAllFeatures, 5))
+          .via(TranscoderFlow.fastMerging(JellyOptions.defaultSupportedOptions, JellyOptions.smallAllFeatures).frameToFrame)
+          .runWith(Sink.seq)
+          .futureValue should be (Quads1.encodedFull(JellyOptions.smallAllFeatures, 5))
+      }
+
+      "rowToRow" in {
+        Source(Quads1.encodedFull(JellyOptions.smallAllFeatures, 5).flatMap(_.rows))
+          .via(TranscoderFlow.fastMerging(JellyOptions.defaultSupportedOptions, JellyOptions.smallAllFeatures).rowToRow)
+          .runWith(Sink.seq)
+          .futureValue should be (Quads1.encodedFull(JellyOptions.smallAllFeatures, 5).flatMap(_.rows))
+      }
+
+      "rowToFrame" in {
+        Source(Quads1.encodedFull(JellyOptions.smallAllFeatures, 5).flatMap(_.rows))
+          .via(TranscoderFlow.fastMerging(JellyOptions.defaultSupportedOptions, JellyOptions.smallAllFeatures).rowToFrame(StreamRowCountLimiter(5)))
+          .runWith(Sink.seq)
+          .futureValue should be (Quads1.encodedFull(JellyOptions.smallAllFeatures, 5))
+      }
+    }
+  }

--- a/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
+++ b/stream/src/test/scala/eu/ostrzyciel/jelly/stream/TranscoderFlowSpec.scala
@@ -10,6 +10,11 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration.*
 
+/**
+ * Basic functionality tests for the TranscoderFlow class.
+ * This really only tests if the flows are working as intended, not the transcoder itself.
+ * For that, see tests in the core and integration-tests modules.
+ */
 class TranscoderFlowSpec extends AnyWordSpec, Matchers, ScalaFutures:
   import ProtoTestCases.*
 


### PR DESCRIPTION
Issue: #225 

This implements the `core` API, along with streaming wrappers in `stream`. Oh, and of course a lot of tests.