### PR TITLE
CI: setup SBT manually due to breaking change in ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           java-version: '17'
           cache: 'sbt'
 
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -38,6 +41,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'sbt'
+
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
 
       - name: 'Build plugins'
         run: |

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -35,6 +35,9 @@ jobs:
         distribution: temurin
         java-version: ${{ matrix.java }}
 
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
     - name: Build and test
       shell: bash
       run: sbt -v +test


### PR DESCRIPTION
It seems we will have to be setting up sbt manually after Java, because sbt was removed from the Ubuntu 24 image for GH Actions. See: https://github.com/actions/runner-images/issues/10636

Also see: https://github.com/scala-steward-org/scala-steward-action/pull/644