### PR TITLE
Fix crash when detecting delimiting on short streams

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/IoUtils.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/IoUtils.scala
@@ -24,7 +24,7 @@ object IoUtils:
     // A case like "0A 0A 0A 0A" in the delimited variant is impossible. It would mean that the whole message
     // is 10 bytes long, while stream options alone are 10 bytes long.
     // Yeah, it's magic. But it works.
-    val isDelimited = (
+    val isDelimited = scout.length == 3 && (
       scout(0) != 0x0A || scout(1) == 0x0A && scout(2) != 0x0A
     )
     (isDelimited, newInput)

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
@@ -24,7 +24,7 @@ class IoUtilsSpec extends AnyWordSpec, Matchers:
   ))
 
   "IoUtils" should {
-    "guessDelimiting" when {
+    "autodetectDelimiting" when {
       "input stream is a non-delimited Jelly message (size >10)" in {
         val bytes = frameLarge.toByteArray
         bytes(0) shouldBe 0x0A
@@ -103,6 +103,20 @@ class IoUtilsSpec extends AnyWordSpec, Matchers:
         isDelimited shouldBe true
         newIn.readAllBytes() shouldBe bytes
       }
+
+      "input stream is empty" in {
+        val in = new ByteArrayInputStream(Array.emptyByteArray)
+        val (isDelimited, newIn) = IoUtils.autodetectDelimiting(in)
+        isDelimited shouldBe false
+        newIn.readAllBytes() shouldBe Array.emptyByteArray
+      }
+
+      "input stream has only 2 bytes" in {
+        // some messed-up data
+        val in = new ByteArrayInputStream(Array[Byte](0x12, 0x34))
+        val (isDelimited, newIn) = IoUtils.autodetectDelimiting(in)
+        isDelimited shouldBe false
+        newIn.readAllBytes() shouldBe Array[Byte](0x12, 0x34)
+      }
     }
   }
-


### PR DESCRIPTION
When the input stream is empty or very short (<3 bytes), the delimiting autodetection procedure will fail with an unhelpful exception. This change should make the failure occur later, in the parser, where it belongs.