### PR TITLE
Add IoUtils.writeFrameAsDelimited

### DIFF
--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/IoUtilsSpec.scala
@@ -119,4 +119,15 @@ class IoUtilsSpec extends AnyWordSpec, Matchers:
         newIn.readAllBytes() shouldBe Array[Byte](0x12, 0x34)
       }
     }
+    
+    "writeFrameAsDelimited" in {
+      val os = ByteArrayOutputStream()
+      IoUtils.writeFrameAsDelimited(frameLarge.toByteArray, os)
+      val bytes = os.toByteArray
+      
+      val in = new ByteArrayInputStream(bytes)
+      val (isDelimited, newIn) = IoUtils.autodetectDelimiting(in)
+      isDelimited shouldBe true
+      RdfStreamFrame.parseDelimitedFrom(newIn).get shouldBe frameLarge
+    }
   }


### PR DESCRIPTION
The utility will be useful in nanopub-registry to quickly return the nanopub from the DB, just by prepending a delimiter.