### PR TITLE
Improve row buffer handling in ProtoEncoder

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/NodeEncoder.java
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.core;
 
 import eu.ostrzyciel.jelly.core.proto.v1.*;
-import scala.collection.mutable.ArrayBuffer;
+import scala.collection.mutable.Buffer;
 
 import java.util.LinkedHashMap;
 import java.util.function.Function;
@@ -107,7 +107,7 @@ public final class NodeEncoder<TNode> {
      * @return The encoded literal
      */
     public UniversalTerm encodeDtLiteral(
-            TNode key, String lex, String datatypeName, ArrayBuffer<RdfStreamRow> rowsBuffer
+            TNode key, String lex, String datatypeName, Buffer<RdfStreamRow> rowsBuffer
     ) {
         var cachedNode = dtLiteralNodeCache.computeIfAbsent(key, k -> new DependentNode());
         // Check if the value is still valid
@@ -141,7 +141,7 @@ public final class NodeEncoder<TNode> {
      * @param rowsBuffer The buffer to which the new name and prefix lookup entries should be appended
      * @return The encoded IRI
      */
-    public UniversalTerm encodeIri(String iri, ArrayBuffer<RdfStreamRow> rowsBuffer) {
+    public UniversalTerm encodeIri(String iri, Buffer<RdfStreamRow> rowsBuffer) {
         if (maxPrefixTableSize == 0) {
             // Fast path for no prefixes
             var nameEntry = nameLookup.getOrAddEntry(iri);

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -128,14 +128,14 @@ trait ConverterFactory[
     new AnyStatementDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions), namespaceHandler)
 
   /**
-   * Create a new [[ProtoEncoder]] which manages a row buffer. Namespace declarations are disabled by default.
+   * Create a new [[ProtoEncoder]] which manages a row buffer on its own. Namespace declarations are disabled.
    * @param options Jelly serialization options.
    * @return encoder
    */
   def encoder(options: RdfStreamOptions): TEncoder = encoder(options, enableNamespaceDeclarations = false, None)
 
   /**
-   * Create a new [[ProtoEncoder]] which manages a row buffer.
+   * Create a new [[ProtoEncoder]] which manages a row buffer on its own.
    *
    * @param options Jelly serialization options.
    * @param enableNamespaceDeclarations whether to enable namespace declarations in the stream. 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -1,8 +1,9 @@
 package eu.ostrzyciel.jelly.core
 
 import ProtoDecoderImpl.*
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, RdfStreamRow}
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 object ConverterFactory:
@@ -127,14 +128,14 @@ trait ConverterFactory[
     new AnyStatementDecoder(decoderConverter, supportedOptions.getOrElse(defaultSupportedOptions), namespaceHandler)
 
   /**
-   * Create a new [[ProtoEncoder]]. Namespace declarations are disabled by default.
+   * Create a new [[ProtoEncoder]] which manages a row buffer. Namespace declarations are disabled by default.
    * @param options Jelly serialization options.
    * @return encoder
    */
-  def encoder(options: RdfStreamOptions): TEncoder = encoder(options, enableNamespaceDeclarations = false)
+  def encoder(options: RdfStreamOptions): TEncoder = encoder(options, enableNamespaceDeclarations = false, None)
 
   /**
-   * Create a new [[ProtoEncoder]].
+   * Create a new [[ProtoEncoder]] which manages a row buffer.
    *
    * @param options Jelly serialization options.
    * @param enableNamespaceDeclarations whether to enable namespace declarations in the stream. 
@@ -142,4 +143,23 @@ trait ConverterFactory[
    *                                    the stream version will be 1 (Jelly 1.0.0).
    * @return encoder
    */
-  def encoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean): TEncoder
+  def encoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean): TEncoder =
+    encoder(options, enableNamespaceDeclarations, None)
+
+  /**
+   * Create a new [[ProtoEncoder]].
+   *
+   * @param options                     Jelly serialization options.
+   * @param enableNamespaceDeclarations whether to enable namespace declarations in the stream.
+   *                                    If true, this will raise the stream version to 2 (Jelly 1.1.0). Otherwise,
+   *                                    the stream version will be 1 (Jelly 1.0.0).
+   * @param maybeRowBuffer              optional buffer for storing stream rows that should go into a stream frame.
+   *                                    If provided, the encoder will append the rows to this buffer instead of
+   *                                    returning them, so methods like `addTripleStatement` will return Seq().
+   * @return encoder
+   */
+  def encoder(
+    options: RdfStreamOptions,
+    enableNamespaceDeclarations: Boolean,
+    maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]]
+  ): TEncoder

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoderImpl.scala
@@ -3,7 +3,7 @@ package eu.ostrzyciel.jelly.core
 import eu.ostrzyciel.jelly.core.proto.v1.*
 
 import scala.annotation.switch
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
 
 /**
  * Fast implementation of the ProtoTranscoder interface.
@@ -48,7 +48,7 @@ private final class ProtoTranscoderImpl(
   private var inputUsesPrefixes = false
 
   // Current output stream state
-  private val rowBuffer = new ArrayBuffer[RdfStreamRow](128)
+  private val rowBuffer = new ListBuffer[RdfStreamRow]()
   private var changeInTerms = false
   private var emittedOptions = false
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/NodeEncoderSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
 class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
@@ -16,8 +16,8 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
     maxDatatypeTableSize = 8,
   )
 
-  private def getEncoder(prefixTableSize: Int = 8): (NodeEncoder[Mrl.Node], ArrayBuffer[RdfStreamRow]) =
-    val buffer = new ArrayBuffer[RdfStreamRow]()
+  private def getEncoder(prefixTableSize: Int = 8): (NodeEncoder[Mrl.Node], ListBuffer[RdfStreamRow]) =
+    val buffer = new ListBuffer[RdfStreamRow]()
     (NodeEncoder[Mrl.Node](smallOptions(prefixTableSize), 16, 16, 16), buffer)
 
   "A NodeEncoder" when {

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockConverterFactory.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockConverterFactory.scala
@@ -2,12 +2,18 @@ package eu.ostrzyciel.jelly.core.helpers
 
 import eu.ostrzyciel.jelly.core.ConverterFactory
 import eu.ostrzyciel.jelly.core.helpers.Mrl.*
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, RdfStreamRow}
+
+import scala.collection.mutable
 
 object MockConverterFactory extends ConverterFactory
   [MockProtoEncoder, MockProtoDecoderConverter, Node, Datatype, Triple, Quad]:
 
   override final def decoderConverter = new MockProtoDecoderConverter()
 
-  override final def encoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean) =
-    new MockProtoEncoder(options, enableNamespaceDeclarations)
+  override final def encoder(
+    options: RdfStreamOptions,
+    enableNamespaceDeclarations: Boolean,
+    maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]],
+  ) =
+    new MockProtoEncoder(options, enableNamespaceDeclarations, maybeRowBuffer)

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
@@ -2,15 +2,17 @@ package eu.ostrzyciel.jelly.core.helpers
 
 import eu.ostrzyciel.jelly.core.*
 import eu.ostrzyciel.jelly.core.helpers.Mrl.*
-import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, SpoTerm}
+import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, RdfStreamRow, SpoTerm}
+
+import scala.collection.mutable
 
 /**
  * Mock implementation of ProtoEncoder
  * @param options options for this stream
  * @param enableNamespaceDeclarations whether to enable namespace declarations
  */
-class MockProtoEncoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean = false)
-  extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations):
+class MockProtoEncoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean = false, maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = None)
+  extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations, maybeRowBuffer):
 
   protected inline def getTstS(triple: Triple) = triple.s
   protected inline def getTstP(triple: Triple) = triple.p

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/helpers/MockProtoEncoder.scala
@@ -10,9 +10,13 @@ import scala.collection.mutable
  * Mock implementation of ProtoEncoder
  * @param options options for this stream
  * @param enableNamespaceDeclarations whether to enable namespace declarations
+ * @param maybeRowBuffer optional buffer for storing stream rows that should go into a stream frame
  */
-class MockProtoEncoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean = false, maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = None)
-  extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations, maybeRowBuffer):
+class MockProtoEncoder(
+  options: RdfStreamOptions,
+  enableNamespaceDeclarations: Boolean = false,
+  maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = None
+) extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations, maybeRowBuffer):
 
   protected inline def getTstS(triple: Triple) = triple.s
   protected inline def getTstP(triple: Triple) = triple.p

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaConverterFactory.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaConverterFactory.scala
@@ -10,8 +10,15 @@ import scala.collection.mutable
 
 object JenaConverterFactory
   extends ConverterFactory[JenaProtoEncoder, JenaDecoderConverter, Node, RDFDatatype, Triple, Quad]:
+
+  /**
+   * @inheritdoc
+   */
   override final def decoderConverter: JenaDecoderConverter = new JenaDecoderConverter()
 
+  /**
+   * @inheritdoc
+   */
   override final def encoder(
     options: RdfStreamOptions, 
     enableNamespaceDeclarations: Boolean, 

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaConverterFactory.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaConverterFactory.scala
@@ -1,14 +1,20 @@
 package eu.ostrzyciel.jelly.convert.jena
 
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, RdfStreamRow}
 import eu.ostrzyciel.jelly.core.ConverterFactory
 import org.apache.jena.datatypes.RDFDatatype
 import org.apache.jena.graph.{Node, Triple}
 import org.apache.jena.sparql.core.Quad
 
+import scala.collection.mutable
+
 object JenaConverterFactory
   extends ConverterFactory[JenaProtoEncoder, JenaDecoderConverter, Node, RDFDatatype, Triple, Quad]:
   override final def decoderConverter: JenaDecoderConverter = new JenaDecoderConverter()
 
-  override final def encoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean): JenaProtoEncoder = 
-    JenaProtoEncoder(options, enableNamespaceDeclarations)
+  override final def encoder(
+    options: RdfStreamOptions, 
+    enableNamespaceDeclarations: Boolean, 
+    maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]],
+  ): JenaProtoEncoder =
+    JenaProtoEncoder(options, enableNamespaceDeclarations, maybeRowBuffer)

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
@@ -1,15 +1,18 @@
 package eu.ostrzyciel.jelly.convert.jena
 
 import eu.ostrzyciel.jelly.core.*
-import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, SpoTerm}
+import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, RdfStreamRow, SpoTerm}
 import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.graph.*
 import org.apache.jena.sparql.core.Quad
 
+import scala.collection.mutable
+
 final class JenaProtoEncoder(
   options: RdfStreamOptions,
   enableNamespaceDeclarations: Boolean,
-) extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations):
+  maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = None,
+) extends ProtoEncoder[Node, Triple, Quad, Triple](options, enableNamespaceDeclarations, maybeRowBuffer):
 
   protected inline def getTstS(triple: Triple) = triple.getSubject
   protected inline def getTstP(triple: Triple) = triple.getPredicate

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
@@ -10,7 +10,7 @@ import org.apache.jena.sparql.core.{DatasetGraph, Quad}
 import org.apache.jena.sparql.util.Context
 
 import java.io.{OutputStream, Writer}
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.*
 
 

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
@@ -184,21 +184,21 @@ final class JellyStreamWriterAutodetectType(opt: JellyFormatVariant, out: Output
  * It will output the statements as in a TRIPLES/QUADS stream.
  */
 final class JellyStreamWriter(opt: JellyFormatVariant, out: OutputStream) extends StreamRDF:
+  private val buffer: ListBuffer[RdfStreamRow] = new ListBuffer[RdfStreamRow]()
   // We don't set any options here – it is the responsibility of the caller to set
   // a valid stream type here.
-  private val encoder = JenaConverterFactory.encoder(opt.opt, opt.enableNamespaceDeclarations)
-  private val buffer: ArrayBuffer[RdfStreamRow] = new ArrayBuffer[RdfStreamRow]()
+  private val encoder = JenaConverterFactory.encoder(opt.opt, opt.enableNamespaceDeclarations, Some(buffer))
 
   // No need to handle this, the encoder will emit the header automatically anyway
   override def start(): Unit = ()
 
   override def triple(triple: Triple): Unit =
-    buffer ++= encoder.addTripleStatement(triple)
+    encoder.addTripleStatement(triple)
     if buffer.size >= opt.frameSize then
       flushBuffer()
 
   override def quad(quad: Quad): Unit =
-    buffer ++= encoder.addQuadStatement(quad)
+    encoder.addQuadStatement(quad)
     if buffer.size >= opt.frameSize then
       flushBuffer()
 
@@ -207,7 +207,7 @@ final class JellyStreamWriter(opt: JellyFormatVariant, out: OutputStream) extend
 
   override def prefix(prefix: String, iri: String): Unit =
     if opt.enableNamespaceDeclarations then
-      buffer ++= encoder.declareNamespace(prefix, iri)
+      encoder.declareNamespace(prefix, iri)
       if buffer.size >= opt.frameSize then
         flushBuffer()
 
@@ -217,6 +217,6 @@ final class JellyStreamWriter(opt: JellyFormatVariant, out: OutputStream) extend
       flushBuffer()
 
   private def flushBuffer(): Unit =
-    val frame = RdfStreamFrame(rows = buffer.toSeq)
+    val frame = RdfStreamFrame(rows = buffer.toList)
     frame.writeDelimitedTo(out)
     buffer.clear()

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jConverterFactory.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jConverterFactory.scala
@@ -1,13 +1,19 @@
 package eu.ostrzyciel.jelly.convert.rdf4j
 
 import eu.ostrzyciel.jelly.core.ConverterFactory
-import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamOptions, RdfStreamRow}
 import org.eclipse.rdf4j.model.{Statement, Value}
+
+import scala.collection.mutable
 
 object Rdf4jConverterFactory
   extends ConverterFactory[Rdf4jProtoEncoder, Rdf4jDecoderConverter, Value, Rdf4jDatatype, Statement, Statement]:
 
   override final def decoderConverter: Rdf4jDecoderConverter = new Rdf4jDecoderConverter()
 
-  override final def encoder(options: RdfStreamOptions, enableNamespaceDeclarations: Boolean): Rdf4jProtoEncoder =
-    Rdf4jProtoEncoder(options, enableNamespaceDeclarations)
+  override final def encoder(
+    options: RdfStreamOptions,
+    enableNamespaceDeclarations: Boolean,
+    maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]],
+  ): Rdf4jProtoEncoder =
+    Rdf4jProtoEncoder(options, enableNamespaceDeclarations, maybeRowBuffer)

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jConverterFactory.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jConverterFactory.scala
@@ -9,8 +9,14 @@ import scala.collection.mutable
 object Rdf4jConverterFactory
   extends ConverterFactory[Rdf4jProtoEncoder, Rdf4jDecoderConverter, Value, Rdf4jDatatype, Statement, Statement]:
 
+  /**
+   * @inheritdoc
+   */
   override final def decoderConverter: Rdf4jDecoderConverter = new Rdf4jDecoderConverter()
 
+  /**
+   * @inheritdoc
+   */
   override final def encoder(
     options: RdfStreamOptions,
     enableNamespaceDeclarations: Boolean,

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jProtoEncoder.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jProtoEncoder.scala
@@ -1,14 +1,17 @@
 package eu.ostrzyciel.jelly.convert.rdf4j
 
 import eu.ostrzyciel.jelly.core.*
-import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, SpoTerm}
+import eu.ostrzyciel.jelly.core.proto.v1.{GraphTerm, RdfStreamOptions, RdfStreamRow, SpoTerm}
 import org.eclipse.rdf4j.model.*
 import org.eclipse.rdf4j.model.vocabulary.XSD
+
+import scala.collection.mutable
 
 final class Rdf4jProtoEncoder(
   options: RdfStreamOptions,
   enableNamespaceDeclarations: Boolean,
-) extends ProtoEncoder[Value, Statement, Statement, Triple](options, enableNamespaceDeclarations):
+  maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]],
+) extends ProtoEncoder[Value, Statement, Statement, Triple](options, enableNamespaceDeclarations, maybeRowBuffer):
 
   protected inline def getTstS(triple: Statement) = triple.getSubject
   protected inline def getTstP(triple: Statement) = triple.getPredicate

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
@@ -8,7 +8,7 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter
 
 import java.io.OutputStream
 import java.util
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.mutable.ListBuffer
 
 /**
  * RDF4J Rio writer for Jelly RDF format.


### PR DESCRIPTION
It turns out that previously when encoding a Jelly stream, we were doing a very weird and elaborate dance... First, the ProtoEncoder gathered stream rows in an array buffer. Then, it converted it to a Seq (linked list), which was then sometimes again inserted into an array buffer and again converted to a Seq.

Of course, this doesn't make much sense and adds memory allocation overhead.

I've replaced the ArrayBuffer in ProtoEncoder in favor of a ListBuffer, which can be turned into an immutable Seq with a zero-copy operation. Additionally, I've also added an option for the ProtoEncoder callers to pass their own `Buffer` which is managed externally, by the caller, to further reduce the overhead. This approach is now employed in the Jena/RDF4J writers, and it did result in a ~5% speedup. The `jelly-stream` module doesn't use this, because it unwinds the lists into iterators anyway.