### PR TITLE
Update Jena to 5.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 lazy val pekkoV = "1.1.3"
 lazy val pekkoGrpcV = "1.1.1"
-lazy val jenaV = "5.2.0"
+lazy val jenaV = "5.3.0"
 lazy val rdf4jV = "5.1.0"
 // !! When updating ScalaPB also change the version of the plugin in plugins.sbt
 lazy val scalapbV = "0.11.17"


### PR DESCRIPTION
Jena 5.3.0 has faster parsing thanks to some slimming-down in datatype handling.

This should also fix the flaky tests that were caused by a race condition in Jena initialization.