### PR TITLE
Fix serializing to the Text Format

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/CompanionHelper.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/CompanionHelper.scala
@@ -1,0 +1,11 @@
+package eu.ostrzyciel.jelly.core.proto.v1
+
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+trait CompanionHelper[T <: GeneratedMessage](name: String) extends GeneratedMessageCompanion[T]:
+  override final lazy val javaDescriptor: com.google.protobuf.Descriptors.Descriptor =
+    val jd: com.google.protobuf.Descriptors.FileDescriptor = RdfProto.javaDescriptor
+    jd.findMessageTypeByName(name)
+  override final lazy val scalaDescriptor: scalapb.descriptors.Descriptor =
+    val sd: scalapb.descriptors.FileDescriptor = RdfProto.scalaDescriptor
+    sd.messages.find(_.name == name).get

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfGraphStart.scala
@@ -68,7 +68,7 @@ final case class RdfGraphStart(graph: GraphTerm = null) extends scalapb.Generate
   override def graphStart: RdfGraphStart = this
 }
 
-object RdfGraphStart extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart] {
+object RdfGraphStart extends CompanionHelper[RdfGraphStart]("RdfGraphStart") {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart] = this
 
   def parseFrom(_input__ : _root_.com.google.protobuf.CodedInputStream): eu.ostrzyciel.jelly.core.proto.v1.RdfGraphStart = {
@@ -104,10 +104,6 @@ object RdfGraphStart extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jel
     case _ =>
       throw new RuntimeException("Expected PMessage")
   }
-
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(5)
-
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(5)
 
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfNamespaceDeclaration.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfNamespaceDeclaration.scala
@@ -97,7 +97,7 @@ final case class RdfNamespaceDeclaration(
   override def namespace: RdfNamespaceDeclaration = this
 }
 
-object RdfNamespaceDeclaration extends scalapb.GeneratedMessageCompanion[RdfNamespaceDeclaration] {
+object RdfNamespaceDeclaration extends CompanionHelper[RdfNamespaceDeclaration]("RdfNamespaceDeclaration") {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[RdfNamespaceDeclaration] = this
 
   def parseFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): RdfNamespaceDeclaration = {
@@ -130,10 +130,6 @@ object RdfNamespaceDeclaration extends scalapb.GeneratedMessageCompanion[RdfName
       )
     case _ => throw new RuntimeException("Expected PMessage")
   }
-
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(7)
-
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(7)
 
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -129,7 +129,7 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
   override def quad: RdfQuad = this
 }
 
-object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfQuad] {
+object RdfQuad extends CompanionHelper[RdfQuad]("RdfQuad") {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfQuad] = this
 
   def parseFrom(_input__ : _root_.com.google.protobuf.CodedInputStream): eu.ostrzyciel.jelly.core.proto.v1.RdfQuad = {
@@ -210,10 +210,6 @@ object RdfQuad extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.cor
     case _ =>
       throw new RuntimeException("Expected PMessage")
   }
-
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(4)
-
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(4)
 
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfQuad.scala
@@ -84,37 +84,37 @@ final case class RdfQuad(subject: SpoTerm = null, predicate: SpoTerm = null, `ob
     _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
     (__field.number: @_root_.scala.unchecked) match {
       case 1 =>
-        if (subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 2 =>
-        if (subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
       case 3 =>
-        if (subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 4 =>
-        if (subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 5 =>
-        if (predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 6 =>
-        if (predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
       case 7 =>
-        if (predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 8 =>
-        if (predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 9 =>
-        if (`object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 10 =>
-        if (`object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
       case 11 =>
-        if (`object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 12 =>
-        if (`object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 13 =>
-        if (graph.isIri) graph.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph != null && graph.isIri) graph.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 14 =>
-        if (graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (graph != null && graph.isBnode) _root_.scalapb.descriptors.PString(graph.bnode) else _root_.scalapb.descriptors.PEmpty
       case 15 =>
-        if (graph.isDefaultGraph) graph.defaultGraph.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph != null && graph.isDefaultGraph) graph.defaultGraph.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 16 =>
-        if (graph.isLiteral) graph.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (graph != null && graph.isLiteral) graph.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
     }
   }
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
@@ -138,7 +138,7 @@ import scala.annotation.switch
   def companion: eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow.type = eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow
 }
 
-object RdfStreamRow extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow] {
+object RdfStreamRow extends CompanionHelper[RdfStreamRow]("RdfStreamRow") {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow] = this
   def parseFrom(_input__ : _root_.com.google.protobuf.CodedInputStream): eu.ostrzyciel.jelly.core.proto.v1.RdfStreamRow = {
     var __row: RdfStreamRowValue = null
@@ -191,10 +191,6 @@ object RdfStreamRow extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jell
     case _ =>
       throw new RuntimeException("Expected PMessage")
   }
-  
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(12)
-  
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(12)
   
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[?] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[?] = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRow.scala
@@ -192,9 +192,9 @@ object RdfStreamRow extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jell
       throw new RuntimeException("Expected PMessage")
   }
   
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(11)
+  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(12)
   
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(11)
+  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(12)
   
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[?] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[?] = null

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
@@ -77,29 +77,29 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
     _root_.scala.Predef.require(__field.containingMessage eq companion.scalaDescriptor)
     (__field.number: @_root_.scala.unchecked) match {
       case 1 =>
-        if (subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isIri) subject.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 2 =>
-        if (subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isBnode) _root_.scalapb.descriptors.PString(subject.bnode) else _root_.scalapb.descriptors.PEmpty
       case 3 =>
-        if (subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isLiteral) subject.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 4 =>
-        if (subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (subject != null && subject.isTripleTerm) subject.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 5 =>
-        if (predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isIri) predicate.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 6 =>
-        if (predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isBnode) _root_.scalapb.descriptors.PString(predicate.bnode) else _root_.scalapb.descriptors.PEmpty
       case 7 =>
-        if (predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isLiteral) predicate.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 8 =>
-        if (predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (predicate != null && predicate.isTripleTerm) predicate.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 9 =>
-        if (`object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isIri) `object`.iri.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 10 =>
-        if (`object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isBnode) _root_.scalapb.descriptors.PString(`object`.bnode) else _root_.scalapb.descriptors.PEmpty
       case 11 =>
-        if (`object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isLiteral) `object`.literal.toPMessage else _root_.scalapb.descriptors.PEmpty
       case 12 =>
-        if (`object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
+        if (`object` != null && `object`.isTripleTerm) `object`.tripleTerm.toPMessage else _root_.scalapb.descriptors.PEmpty
     }
   }
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfTriple.scala
@@ -118,7 +118,7 @@ final case class RdfTriple(subject: SpoTerm = null, predicate: SpoTerm = null, `
   override def triple: RdfTriple = this
 }
 
-object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple] {
+object RdfTriple extends CompanionHelper[RdfTriple]("RdfTriple") {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.core.proto.v1.RdfTriple] = this
 
   def parseFrom(_input__ : _root_.com.google.protobuf.CodedInputStream): eu.ostrzyciel.jelly.core.proto.v1.RdfTriple = {
@@ -185,10 +185,6 @@ object RdfTriple extends scalapb.GeneratedMessageCompanion[eu.ostrzyciel.jelly.c
     case _ =>
       throw new RuntimeException("Expected PMessage")
   }
-
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = RdfProto.javaDescriptor.getMessageTypes().get(3)
-
-  def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = RdfProto.scalaDescriptor.messages(3)
 
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = {
     var __out: _root_.scalapb.GeneratedMessageCompanion[_] = null

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoAuxiliarySpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoAuxiliarySpec.scala
@@ -1,0 +1,51 @@
+package eu.ostrzyciel.jelly.core
+
+import eu.ostrzyciel.jelly.core.proto.v1.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Tests for some auxiliary methods (e.g., Text Format serialization) of the generated Protobuf messages.
+ */
+class ProtoAuxiliarySpec extends AnyWordSpec, Matchers:
+  import ProtoTestCases.*
+
+  val opt = JellyOptions.smallGeneralized
+  val testCases = Seq(
+    ("Triples1", Triples1),
+    ("Triples2NsDecl", Triples2NsDecl),
+    ("Quads1", Quads1),
+    ("Quads2RepeatDefault", Quads2RepeatDefault),
+    ("Graphs1", Graphs1),
+  ).map((name, tc) => (name, tc.encodedFull(opt, 1000).head))
+
+  val companions: Seq[scalapb.GeneratedMessageCompanion[? <: scalapb.GeneratedMessage]] = RdfProto.messagesCompanions
+
+  for (companion <- companions) do
+    val name = companion.getClass.getName.split('.').last.replace("$", "")
+    s"message companion $name" should {
+      "return the correct Java descriptor" in {
+        companion.javaDescriptor.getName should be (name)
+      }
+
+      "return the correct Scala descriptor" in {
+        companion.scalaDescriptor.name should be (name)
+      }
+  }
+
+  "RdfStreamFrame" should {
+    "serialize to string with toProtoString" when {
+      for ((name, tc) <- testCases) do s"test case $name" in {
+        val str = tc.toProtoString
+        str should not be empty
+      }
+    }
+
+    "deserialize from string with fromAscii" when {
+      for ((name, tc) <- testCases) do s"test case $name" in {
+        val str = tc.toProtoString
+        val frame = RdfStreamFrame.fromAscii(str)
+        frame should be (tc)
+      }
+    }
+  }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoAuxiliarySpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoAuxiliarySpec.scala
@@ -3,6 +3,7 @@ package eu.ostrzyciel.jelly.core
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import scalapb.descriptors.{Descriptor, FileDescriptor}
 
 /**
  * Tests for some auxiliary methods (e.g., Text Format serialization) of the generated Protobuf messages.


### PR DESCRIPTION
There were some mis-implemented auxiliary methods in the manually written proto code that made it impossible to serialize Jelly frames in the Text Format, for debugging. This commit fixes that, along with adding some tests that should catch similar problems in the future.