### PR TITLE
core: refactor ProtoEncoder for Jelly-Patch

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoderImpl.scala
@@ -2,6 +2,7 @@ package eu.ostrzyciel.jelly.core
 
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import eu.ostrzyciel.jelly.core.ConverterFactory.NamespaceHandler
+import eu.ostrzyciel.jelly.core.internal.{DecoderLookup, LastNodeHolder}
 
 import scala.annotation.switch
 import scala.collection.mutable.ListBuffer

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/DecoderLookup.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/DecoderLookup.scala
@@ -1,4 +1,4 @@
-package eu.ostrzyciel.jelly.core
+package eu.ostrzyciel.jelly.core.internal
 
 import scala.reflect.ClassTag
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/LastNodeHolder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/LastNodeHolder.scala
@@ -1,4 +1,4 @@
-package eu.ostrzyciel.jelly.core
+package eu.ostrzyciel.jelly.core.internal
 
 private[core] object LastNodeHolder:
   /**

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/RowBufferAppender.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/RowBufferAppender.scala
@@ -1,0 +1,9 @@
+package eu.ostrzyciel.jelly.core.internal
+
+import eu.ostrzyciel.jelly.core.proto.v1.RdfLookupEntryRowValue
+
+/**
+ * Internal trait for appending lookup entries to the row buffer.
+ */
+private[core] trait RowBufferAppender:
+  private[core] def appendLookupEntry(entry: RdfLookupEntryRowValue): Unit

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/RdfStreamRowValue.scala
@@ -23,3 +23,5 @@ private[core] trait RdfStreamRowValue:
   def name: RdfNameEntry = null
   def prefix: RdfPrefixEntry = null
   def datatype: RdfDatatypeEntry = null
+
+private[core] trait RdfLookupEntryRowValue extends RdfStreamRowValue

--- a/project/Transform3.scala
+++ b/project/Transform3.scala
@@ -50,9 +50,9 @@ object Transform3 {
           // RdfStreamRowValue
           case "RdfStreamOptions" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "options", "isOptions", Some(1)))
           case "RdfGraphEnd" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "graphEnd", "isGraphEnd", Some(5)))
-          case "RdfNameEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "name", "isName", Some(9)))
-          case "RdfPrefixEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "prefix", "isPrefix", Some(10)))
-          case "RdfDatatypeEntry" => Some(copyTemplate(templ, Seq("RdfStreamRowValue"), "datatype", "isDatatype", Some(11)))
+          case "RdfNameEntry" => Some(copyTemplate(templ, Seq("RdfLookupEntryRowValue"), "name", "isName", Some(9)))
+          case "RdfPrefixEntry" => Some(copyTemplate(templ, Seq("RdfLookupEntryRowValue"), "prefix", "isPrefix", Some(10)))
+          case "RdfDatatypeEntry" => Some(copyTemplate(templ, Seq("RdfLookupEntryRowValue"), "datatype", "isDatatype", Some(11)))
           case _ => None
         }
         newTempl.map(templ => tree.asInstanceOf[Defn.Class].copy(templ = templ)).getOrElse(tree)


### PR DESCRIPTION
Related to: https://github.com/Jelly-RDF/jelly-protobuf/issues/11

This introduces a few refactors around the ProtoEncoder to allow us to reuse its code in the core-patch module later. This includes:

- Allowing NodeEncoder to append to anything that can consume lookup entries, via a dedicated interface
- De-inlining protected methods in ProtoEncoder. I don't think it was working anyway. The JVM is smart enough to do inlining by itself, and the inlines were messing with public/private code guarantees.
- Create the core.internal package to group the messier internal classes together and keep the top-level package clean.