### PR TITLE
Add ProtoDecoder.ingestRowFlat

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoDecoder.scala
@@ -7,9 +7,33 @@ import eu.ostrzyciel.jelly.core.proto.v1.*
  * 
  * See the implementation in [[eu.ostrzyciel.jelly.core.internal.ProtoDecoderImpl]].
  * 
- * @tparam TOut Type of the output of the decoder.
+ * @tparam TOut Type of the output of the decoder. Must be nullable.
  */
 trait ProtoDecoder[+TOut]:
+  /**
+   * Options for this stream.
+   * @return Some(options) if the decoder has encountered the stream options, None otherwise.
+   */
   def getStreamOpt: Option[RdfStreamOptions]
-  
-  def ingestRow(row: RdfStreamRow): Option[TOut]
+
+  /**
+   * Ingest a row from the stream.
+   *
+   * @param row row to ingest
+   * @return Some(output) if the row corresponds to an RDF statement, None otherwise.
+   */
+  final def ingestRow(row: RdfStreamRow): Option[TOut] =
+    val flat = ingestRowFlat(row)
+    if flat == null then None
+    else Some(flat.asInstanceOf[TOut])
+
+  /**
+   * Ingest a row from the stream, using a flat output.
+   *
+   * This method will be more efficient than `ingestRow` because it avoids the overhead of creating an `Option`.
+   * But, be careful, it does return nulls.
+   *
+   * @param row row to ingest
+   * @return non-null if the row corresponds to an RDF statement, null otherwise.
+   */
+  def ingestRowFlat(row: RdfStreamRow): TOut | Null

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyReader.scala
@@ -37,10 +37,11 @@ object JellyReader extends ReaderRIOT:
     )
     inline def processFrame(f: RdfStreamFrame): Unit =
       for row <- f.rows do
-        decoder.ingestRow(row) match
-          case Some(st: Triple) => output.triple(st)
-          case Some(st: Quad) => output.quad(st)
-          case None => ()
+        // Use the flat interface to skip the Option creation overhead
+        decoder.ingestRowFlat(row) match
+          case null => ()
+          case st: Triple => output.triple(st)
+          case st: Quad => output.quad(st)
 
     output.start()
     try {

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyParser.scala
@@ -45,9 +45,10 @@ final class JellyParser extends AbstractRDFParser:
     )
     inline def processFrame(f: RdfStreamFrame): Unit =
       for row <- f.rows do
-        decoder.ingestRow(row) match
-          case Some(st) => rdfHandler.handleStatement(st)
-          case None => ()
+        // Use the flat interface to skip the Option creation overhead
+        decoder.ingestRowFlat(row) match
+          case null => ()
+          case st => rdfHandler.handleStatement(st)
 
     rdfHandler.startRDF()
     try {


### PR DESCRIPTION
This method avoids the overhead of allocating Some[Statement] during parsing. The old .ingestRow method is kept both for back-compat and just because it's still useful.

You may want to use ingestRowFlat if you are working with Java code or want to squeeze out an extra bit of performance.