### PR TITLE
Revert breaking signature change: ProtoEncoder

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ConverterFactory.scala
@@ -43,7 +43,7 @@ trait ConverterFactory[
 ]:
   import ConverterFactory.*
 
-  final type TEncoder = ProtoEncoder[TNode, TTriple, TQuad]
+  final type TEncoder = ProtoEncoder[TNode, TTriple, TQuad, ?]
   final type NsHandler = NamespaceHandler[TNode]
   final val defaultNsHandler: NsHandler = (_, _) => ()
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -26,7 +26,14 @@ object ProtoEncoder:
     maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = None,
   )
 
-trait ProtoEncoder[TNode, -TTriple, -TQuad]
+/**
+ * Base trait for RDF stream encoders.
+ * @tparam TNode type of RDF nodes in the library
+ * @tparam TTriple type of triple statements in the library
+ * @tparam TQuad type of quad statements in the library
+ * @tparam TQuoted Unused since 2.7.0. Can be set to `Nothing` or `?`.
+ */
+trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
   extends ProtoEncoderBase[TNode, TTriple, TQuad] with RowBufferAppender:
 
   /**

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
@@ -23,7 +23,7 @@ private[core] object ProtoEncoderImpl:
 private[core] final class ProtoEncoderImpl[TNode, -TTriple, -TQuad](
   protected val converter: ProtoEncoderConverter[TNode, TTriple, TQuad],
   params: ProtoEncoder.Params,
-) extends ProtoEncoder[TNode, TTriple, TQuad]:
+) extends ProtoEncoder[TNode, TTriple, TQuad, ?]:
 
   import ProtoEncoderImpl.*
 

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/JenaProtoEncoder.scala
@@ -7,4 +7,4 @@ import org.apache.jena.sparql.core.Quad
 /**
  * Type alias for Jena-specific proto encoder, for convenience and backward compatibility.
  */
-type JenaProtoEncoder = ProtoEncoder[Node, Triple, Quad]
+type JenaProtoEncoder = ProtoEncoder[Node, Triple, Quad, ?]

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jProtoEncoder.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jProtoEncoder.scala
@@ -6,4 +6,4 @@ import org.eclipse.rdf4j.model.{Statement, Value}
 /**
  * Type alias for RDF4J-specific proto encoder, for convenience and backward compatibility.
  */
-type Rdf4jProtoEncoder = ProtoEncoder[Value, Statement, Statement]
+type Rdf4jProtoEncoder = ProtoEncoder[Value, Statement, Statement, ?]

--- a/stream/src/main/scala/eu/ostrzyciel/jelly/stream/impl/EncoderFlowBuilder.scala
+++ b/stream/src/main/scala/eu/ostrzyciel/jelly/stream/impl/EncoderFlowBuilder.scala
@@ -49,7 +49,7 @@ final class EncoderFlowBuilderImpl[TNode, TTriple, TQuad]
 (using factory: ConverterFactory[?, ?, TNode, ?, TTriple, TQuad]):
   import ProtoEncoder.Params
   
-  private type TEncoder = ProtoEncoder[TNode, TTriple, TQuad]
+  private type TEncoder = ProtoEncoder[TNode, TTriple, TQuad, ?]
 
   private val emptyParams = Params(null)
 
@@ -394,7 +394,7 @@ final class EncoderFlowBuilderImpl[TNode, TTriple, TQuad]
       logicalType = if opt.logicalType.isUnspecified then lst else opt.logicalType
     )
 
-  private def graphAsIterable[TEncoder <: ProtoEncoder[TNode, TTriple, ?]](encoder: TEncoder):
+  private def graphAsIterable[TEncoder <: ProtoEncoder[TNode, TTriple, ?, ?]](encoder: TEncoder):
   ((TNode, Iterable[TTriple])) => Iterable[RdfStreamRow] =
     (graphName: TNode, triples: Iterable[TTriple]) =>
       encoder.startGraph(graphName)


### PR DESCRIPTION
In #278 I overeagerly changed the type signature of ProtoEncoder from 4 type parameters to 3. Turns out, this can break existing code. Having an unused type param is no big deal, so I'm fine with reintroducing it just for back-compat.