### PR TITLE
Add forward-compat test for Jelly-RDF 1.1.1

### DIFF
--- a/integration-tests/src/main/protobuf/rdf.proto
+++ b/integration-tests/src/main/protobuf/rdf.proto
@@ -388,4 +388,9 @@ message RdfStreamRow {
 message RdfStreamFrame {
   // Stream rows
   repeated RdfStreamRow rows = 1;
+
+  // !!! ADDED FOR FORWARD COMPATIBILITY TESTING
+  // This is very similar to a feature introduced in Jelly-RDF 1.1.1
+  // See: https://github.com/Jelly-RDF/jelly-protobuf/issues/32
+  map<string, bytes> future_metadata = 115;
 }


### PR DESCRIPTION
Issue: https://github.com/Jelly-RDF/jelly-protobuf/issues/32

In 1.1.1, a new feature will be added in manner that doesn't break backward or forward compatibility. This PR adds a test to ensure that the existing implementation can really cope with such changes and safely ignore the new field.