### PR TITLE
Add a term-level interface to ProtoEncoder

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -56,16 +56,53 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    *
    * @param triple triple to add
    * @return iterable of stream rows
+   * @throws NotImplementedError if the RDF library does not support triple objects
+   *                             (use `addTripleStatement(subject, predicate, object)` instead)
    */
-  def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow]
+  final def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
+    addTripleStatement(
+      converter.getTstS(triple),
+      converter.getTstP(triple),
+      converter.getTstO(triple)
+    )
+
+  /**
+   * Add an RDF triple statement to the stream.
+   * @param subject subject
+   * @param predicate predicate
+   * @param `object` object
+   * @return iterable of stream rows
+   * @since 2.9.0
+   */
+  def addTripleStatement(subject: TNode, predicate: TNode, `object`: TNode): Iterable[RdfStreamRow]
 
   /**
    * Add an RDF quad statement to the stream.
    *
    * @param quad quad to add
    * @return iterable of stream rows
+   * @throws NotImplementedError if the RDF library does not support quad objects
+   *                             (use `addQuadStatement(subject, predicate, object, graph)` instead)
    */
-  def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow]
+  final def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
+    addQuadStatement(
+      converter.getQstS(quad),
+      converter.getQstP(quad),
+      converter.getQstO(quad),
+      converter.getQstG(quad)
+    )
+
+  /**
+   * Add an RDF quad statement to the stream.
+   *
+   * @param subject subject
+   * @param predicate predicate
+   * @param `object` object
+   * @param graph graph
+   * @return iterable of stream rows
+   * @since 2.9.0
+   */
+  def addQuadStatement(subject: TNode, predicate: TNode, `object`: TNode, graph: TNode): Iterable[RdfStreamRow]
 
   /**
    * Signal the start of a new (named) delimited graph in a GRAPHS stream.

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoderConverter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoderConverter.scala
@@ -16,6 +16,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the subject of the triple.
    * @param triple triple
    * @return
+   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstS(triple: TTriple): TNode
 
@@ -23,6 +24,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the predicate of the triple.
    * @param triple triple
    * @return
+   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstP(triple: TTriple): TNode
 
@@ -30,6 +32,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the object of the triple.
    * @param triple triple
    * @return
+   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstO(triple: TTriple): TNode
 
@@ -37,6 +40,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the subject of the quad.
    * @param quad quad
    * @return
+   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstS(quad: TQuad): TNode
 
@@ -44,6 +48,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the predicate of the quad.
    * @param quad quad
    * @return
+   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstP(quad: TQuad): TNode
 
@@ -51,6 +56,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the graph of the quad.
    * @param quad quad
    * @return
+   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstO(quad: TQuad): TNode
 
@@ -58,6 +64,7 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the graph name of the quad.
    * @param quad quad
    * @return
+   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstG(quad: TQuad): TNode
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderBase.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderBase.scala
@@ -30,17 +30,19 @@ private[core] trait ProtoEncoderBase[TNode, -TTriple, -TQuad]:
       lastGraph = node
       converter.graphNodeToProto(nodeEncoder, node)
 
-  protected final def tripleToProto(triple: TTriple): RdfTriple =
+  protected final def tripleToProto(subject: TNode, predicate: TNode, `object`: TNode): RdfTriple =
     RdfTriple(
-      subject = nodeToProtoWrapped(converter.getTstS(triple), lastSubject),
-      predicate = nodeToProtoWrapped(converter.getTstP(triple), lastPredicate),
-      `object` = nodeToProtoWrapped(converter.getTstO(triple), lastObject),
+      subject = nodeToProtoWrapped(subject, lastSubject),
+      predicate = nodeToProtoWrapped(predicate, lastPredicate),
+      `object` = nodeToProtoWrapped(`object`, lastObject),
     )
 
-  protected final def quadToProto(quad: TQuad): RdfQuad =
+  protected final def quadToProto(
+    subject: TNode, predicate: TNode, `object`: TNode, graph: TNode
+  ): RdfQuad =
     RdfQuad(
-      subject = nodeToProtoWrapped(converter.getQstS(quad), lastSubject),
-      predicate = nodeToProtoWrapped(converter.getQstP(quad), lastPredicate),
-      `object` = nodeToProtoWrapped(converter.getQstO(quad), lastObject),
-      graph = graphNodeToProtoWrapped(converter.getQstG(quad)),
+      subject = nodeToProtoWrapped(subject, lastSubject),
+      predicate = nodeToProtoWrapped(predicate, lastPredicate),
+      `object` = nodeToProtoWrapped(`object`, lastObject),
+      graph = graphNodeToProtoWrapped(graph),
     )

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
@@ -32,15 +32,19 @@ private[core] final class ProtoEncoderImpl[TNode, -TTriple, -TQuad](
   override val maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = params.maybeRowBuffer
 
   /** @inheritdoc */
-  override def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
+  override def addTripleStatement(
+    subject: TNode, predicate: TNode, `object`: TNode
+  ): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(tripleToProto(triple))
+    val mainRow = RdfStreamRow(tripleToProto(subject, predicate, `object`))
     appendAndReturn(mainRow)
 
   /** @inheritdoc */
-  override def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
+  override def addQuadStatement(
+    subject: TNode, predicate: TNode, `object`: TNode, graph: TNode
+  ): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(quadToProto(quad))
+    val mainRow = RdfStreamRow(quadToProto(subject, predicate, `object`, graph))
     appendAndReturn(mainRow)
 
   /** @inheritdoc */


### PR DESCRIPTION
Preparatory work for implementing #294 in an efficient manner.

This adds an interface to call the ProtoEncoder with individual terms (like [s, p, o]), instead of only complete triple/quad objects. This will make it possible to skip creating useless triple/quad objects when converting from an titanium-rdf-api stream to Jelly.

I also looked into implementing something like this for the ProtoDecoder, but it's not as simple. We'd need to change from pull-based parsing to push-based. The NamespaceHandler already works in this way, but moving the triples/quads to this behavior would create serious problems in `jelly-stream`. Converting from callbacks to a Pekko stream is a mess requiring additional state management. I'll look into it again, but for now let's merge this as-is.