### PR TITLE
Revert "Add a term-level interface to ProtoEncoder (#295)"

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -56,53 +56,16 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    *
    * @param triple triple to add
    * @return iterable of stream rows
-   * @throws NotImplementedError if the RDF library does not support triple objects
-   *                             (use `addTripleStatement(subject, predicate, object)` instead)
    */
-  final def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
-    addTripleStatement(
-      converter.getTstS(triple),
-      converter.getTstP(triple),
-      converter.getTstO(triple)
-    )
-
-  /**
-   * Add an RDF triple statement to the stream.
-   * @param subject subject
-   * @param predicate predicate
-   * @param `object` object
-   * @return iterable of stream rows
-   * @since 2.9.0
-   */
-  def addTripleStatement(subject: TNode, predicate: TNode, `object`: TNode): Iterable[RdfStreamRow]
+  def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow]
 
   /**
    * Add an RDF quad statement to the stream.
    *
    * @param quad quad to add
    * @return iterable of stream rows
-   * @throws NotImplementedError if the RDF library does not support quad objects
-   *                             (use `addQuadStatement(subject, predicate, object, graph)` instead)
    */
-  final def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
-    addQuadStatement(
-      converter.getQstS(quad),
-      converter.getQstP(quad),
-      converter.getQstO(quad),
-      converter.getQstG(quad)
-    )
-
-  /**
-   * Add an RDF quad statement to the stream.
-   *
-   * @param subject subject
-   * @param predicate predicate
-   * @param `object` object
-   * @param graph graph
-   * @return iterable of stream rows
-   * @since 2.9.0
-   */
-  def addQuadStatement(subject: TNode, predicate: TNode, `object`: TNode, graph: TNode): Iterable[RdfStreamRow]
+  def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow]
 
   /**
    * Signal the start of a new (named) delimited graph in a GRAPHS stream.

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoderConverter.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoderConverter.scala
@@ -16,7 +16,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the subject of the triple.
    * @param triple triple
    * @return
-   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstS(triple: TTriple): TNode
 
@@ -24,7 +23,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the predicate of the triple.
    * @param triple triple
    * @return
-   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstP(triple: TTriple): TNode
 
@@ -32,7 +30,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the object of the triple.
    * @param triple triple
    * @return
-   * @throws NotImplementedError if the RDF library does not support triple objects
    */
   def getTstO(triple: TTriple): TNode
 
@@ -40,7 +37,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the subject of the quad.
    * @param quad quad
    * @return
-   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstS(quad: TQuad): TNode
 
@@ -48,7 +44,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the predicate of the quad.
    * @param quad quad
    * @return
-   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstP(quad: TQuad): TNode
 
@@ -56,7 +51,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the graph of the quad.
    * @param quad quad
    * @return
-   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstO(quad: TQuad): TNode
 
@@ -64,7 +58,6 @@ trait ProtoEncoderConverter[TNode, -TTriple, -TQuad]:
    * Get the graph name of the quad.
    * @param quad quad
    * @return
-   * @throws NotImplementedError if the RDF library does not support quad objects
    */
   def getQstG(quad: TQuad): TNode
 

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderBase.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderBase.scala
@@ -30,19 +30,17 @@ private[core] trait ProtoEncoderBase[TNode, -TTriple, -TQuad]:
       lastGraph = node
       converter.graphNodeToProto(nodeEncoder, node)
 
-  protected final def tripleToProto(subject: TNode, predicate: TNode, `object`: TNode): RdfTriple =
+  protected final def tripleToProto(triple: TTriple): RdfTriple =
     RdfTriple(
-      subject = nodeToProtoWrapped(subject, lastSubject),
-      predicate = nodeToProtoWrapped(predicate, lastPredicate),
-      `object` = nodeToProtoWrapped(`object`, lastObject),
+      subject = nodeToProtoWrapped(converter.getTstS(triple), lastSubject),
+      predicate = nodeToProtoWrapped(converter.getTstP(triple), lastPredicate),
+      `object` = nodeToProtoWrapped(converter.getTstO(triple), lastObject),
     )
 
-  protected final def quadToProto(
-    subject: TNode, predicate: TNode, `object`: TNode, graph: TNode
-  ): RdfQuad =
+  protected final def quadToProto(quad: TQuad): RdfQuad =
     RdfQuad(
-      subject = nodeToProtoWrapped(subject, lastSubject),
-      predicate = nodeToProtoWrapped(predicate, lastPredicate),
-      `object` = nodeToProtoWrapped(`object`, lastObject),
-      graph = graphNodeToProtoWrapped(graph),
+      subject = nodeToProtoWrapped(converter.getQstS(quad), lastSubject),
+      predicate = nodeToProtoWrapped(converter.getQstP(quad), lastPredicate),
+      `object` = nodeToProtoWrapped(converter.getQstO(quad), lastObject),
+      graph = graphNodeToProtoWrapped(converter.getQstG(quad)),
     )

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoEncoderImpl.scala
@@ -32,19 +32,15 @@ private[core] final class ProtoEncoderImpl[TNode, -TTriple, -TQuad](
   override val maybeRowBuffer: Option[mutable.Buffer[RdfStreamRow]] = params.maybeRowBuffer
 
   /** @inheritdoc */
-  override def addTripleStatement(
-    subject: TNode, predicate: TNode, `object`: TNode
-  ): Iterable[RdfStreamRow] =
+  override def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(tripleToProto(subject, predicate, `object`))
+    val mainRow = RdfStreamRow(tripleToProto(triple))
     appendAndReturn(mainRow)
 
   /** @inheritdoc */
-  override def addQuadStatement(
-    subject: TNode, predicate: TNode, `object`: TNode, graph: TNode
-  ): Iterable[RdfStreamRow] =
+  override def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
     handleHeader()
-    val mainRow = RdfStreamRow(quadToProto(subject, predicate, `object`, graph))
+    val mainRow = RdfStreamRow(quadToProto(quad))
     appendAndReturn(mainRow)
 
   /** @inheritdoc */


### PR DESCRIPTION
This reverts commit 702fd63d3c76793e394528df775b21d1cc205cc6.

I was wrong, this is not needed to implement #294. I forgot that triple objects in this library are represented by a few strings, not a single string. So, we still need to allocate something to represent a node, and we can't skip the overhead.

Instead, I'd suggest to use the Titanium classes for RDF primitives. We have to use something, and I don't think it makes sense to introduce a new set of classes just for this integration.