### PR TITLE
Never mark Rio outputs as using generalized RDF

### DIFF
--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/IoSerDesSpec.scala
@@ -141,7 +141,9 @@ class IoSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
     des: NativeSerDes[TMDes, TDDes],
   ) =
     f"${ser.name} serializer + ${des.name} deserializer" should {
-      for (encOptions, decOptions, presetName) <- presetsUnsupported do
+      for (encOptions, decOptions, presetName) <- presetsUnsupported.filter(
+        p => checkImplOptSupport(ser, Some(p._1))
+      ) do
         for (name, file) <- TestCases.triples.filter(
           f => ser.supportsRdfStar && des.supportsRdfStar || !f._1.contains("star")
         ) do

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jReactiveSerDes.scala
@@ -17,6 +17,8 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
 
   override def name: String = "Reactive (RDF4J)"
 
+  override def supportsGeneralizedStatements: Boolean = false
+
   override def readTriplesW3C(is: InputStream): Seq[Statement] = Rdf4jSerDes.readTriplesW3C(is)
 
   override def readQuadsW3C(is: InputStream): Seq[Statement] = Rdf4jSerDes.readQuadsW3C(is)

--- a/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
+++ b/integration-tests/src/test/scala/eu/ostrzyciel/jelly/integration_tests/io/Rdf4jSerDes.scala
@@ -15,6 +15,8 @@ given seqMeasure[T]: Measure[Seq[T]] = (seq: Seq[T]) => seq.size
 object Rdf4jSerDes extends NativeSerDes[Seq[Statement], Seq[Statement]]:
   val name = "RDF4J"
 
+  override def supportsGeneralizedStatements: Boolean = false
+
   private def read(is: InputStream, format: RDFFormat, supportedOptions: Option[RdfStreamOptions] = None): 
   Seq[Statement] =
     val parser = Rio.createParser(format)

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
@@ -77,7 +77,7 @@ final class JellyWriter(out: OutputStream) extends AbstractRDFWriter:
       options, enableNamespaceDeclarations, Some(buffer)
     ))
 
-  override def consumeStatement(st: Statement): Unit =
+  override protected def consumeStatement(st: Statement): Unit =
     checkWritingStarted()
     if options.physicalType.isTriples then
       encoder.addTripleStatement(st)

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriter.scala
@@ -9,6 +9,7 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter
 
 import java.io.OutputStream
 import java.util
+import scala.annotation.nowarn
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -32,6 +33,7 @@ final class JellyWriter(out: OutputStream) extends AbstractRDFWriter:
 
   override def getRDFFormat: RDFFormat = JELLY
 
+  @nowarn("cat=deprecation")
   override def getSupportedSettings: util.HashSet[RioSetting[_]] =
     val s = new util.HashSet[RioSetting[_]](super.getSupportedSettings)
     s.add(STREAM_NAME)
@@ -62,7 +64,7 @@ final class JellyWriter(out: OutputStream) extends AbstractRDFWriter:
     options = RdfStreamOptions(
       streamName = c.get(STREAM_NAME),
       physicalType = pType,
-      generalizedStatements = c.get(ALLOW_GENERALIZED_STATEMENTS).booleanValue(),
+      generalizedStatements = false, // option to set it is deprecated
       rdfStar = c.get(ALLOW_RDF_STAR).booleanValue(),
       maxNameTableSize = c.get(MAX_NAME_TABLE_SIZE).toInt,
       maxPrefixTableSize = c.get(MAX_PREFIX_TABLE_SIZE).toInt,

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
@@ -21,7 +21,6 @@ object JellyWriterSettings:
     c.set(ENABLE_NAMESPACE_DECLARATIONS, enableNamespaceDeclarations)
     c.set(STREAM_NAME, opt.streamName)
     c.set(PHYSICAL_TYPE, opt.physicalType)
-    c.set(ALLOW_GENERALIZED_STATEMENTS, opt.generalizedStatements)
     c.set(ALLOW_RDF_STAR, opt.rdfStar)
     c.set(MAX_NAME_TABLE_SIZE, opt.maxNameTableSize.toLong)
     c.set(MAX_PREFIX_TABLE_SIZE, opt.maxPrefixTableSize.toLong)
@@ -56,11 +55,13 @@ object JellyWriterSettings:
     PhysicalStreamType.QUADS
   )
 
+  @deprecated("Generalized statements are not supported by RDF4J Rio", "2.9.0")
   val ALLOW_GENERALIZED_STATEMENTS = new BooleanRioSetting(
     "eu.ostrzyciel.jelly.convert.rdf4j.rio.allowGeneralizedStatements",
-    "Allow generalized statements. Enabled by default, because we cannot know this in advance. " +
-      "If your data does not contain generalized statements, it is recommended that you set this to false.",
-    true
+    "DEPRECATED since Jelly-JVM 2.9.0: Allow generalized statements. Disabled by default, because " +
+      "RDF4J Rio does not really support generalized statements. This option was mistakenly " +
+      "included in previous versions on the assumption that it does.",
+    false
   )
   
   val ALLOW_RDF_STAR = new BooleanRioSetting(

--- a/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
+++ b/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
@@ -1,0 +1,33 @@
+package eu.ostrzyciel.jelly.convert.rdf4j.rio
+
+import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import scala.annotation.nowarn
+
+@nowarn("msg=deprecated")
+class JellyWriterSpec extends AnyWordSpec, Matchers:
+  val vf = SimpleValueFactory.getInstance()
+  
+  "JellyWriter" should {
+    "ignore the generalized RDF setting" in {
+      val os = new ByteArrayOutputStream()
+      val writer = JellyWriterFactory().getWriter(os)
+      writer.set(JellyWriterSettings.ALLOW_GENERALIZED_STATEMENTS, true)
+      writer.startRDF()
+      writer.handleStatement(vf.createStatement(
+        vf.createIRI("http://example.com/s"),
+        vf.createIRI("http://example.com/p"),
+        vf.createIRI("http://example.com/o")
+      ))
+      writer.endRDF()
+
+      val bytes = os.toByteArray
+      val rows = RdfStreamFrame.parseDelimitedFrom(ByteArrayInputStream(bytes)).get.rows
+      rows.head.row.isOptions should be(true)
+      rows.head.row.options.generalizedStatements should be(false)
+    }
+  }


### PR DESCRIPTION
RDF4J Rio simply does not have an API capable of producing generalized statements. It was my mistake including this option in the Rio integration: #222

However, it's still possible to serialize generalized statements using the new, low-level term-based API: #295