### PR TITLE
Improve exception handling in core

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
@@ -1,11 +1,17 @@
 package eu.ostrzyciel.jelly.core
 
 private trait JellyExceptions:
-  final class RdfProtoDeserializationError(msg: String) extends Error(msg)
+  sealed abstract class RdfProtoError(msg: String, cause: Option[Throwable]) extends Error(msg):
+    if cause.isDefined then initCause(cause.get)
+  
+  final class RdfProtoDeserializationError(msg: String, cause: Option[Throwable] = None) 
+    extends RdfProtoError(msg, cause)
 
-  final class RdfProtoSerializationError(msg: String) extends Error(msg)
+  final class RdfProtoSerializationError(msg: String, cause: Option[Throwable] = None) 
+    extends RdfProtoError(msg, cause)
 
-  final class RdfProtoTranscodingError(msg: String) extends Error(msg)
+  final class RdfProtoTranscodingError(msg: String, cause: Option[Throwable] = None) 
+    extends RdfProtoError(msg, cause)
   
 private object JellyExceptions extends JellyExceptions:
   /**

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
@@ -143,6 +143,8 @@ object JellyOptions:
    *
    * @param requestedOptions Requested options of the stream.
    * @param supportedOptions Options that can be safely supported.
+   *
+   * @throws RdfProtoDeserializationError if the requested options are not supported.
    */
   def checkCompatibility(requestedOptions: RdfStreamOptions, supportedOptions: RdfStreamOptions): Unit =
     if requestedOptions.version > supportedOptions.version || requestedOptions.version > Constants.protoVersion then
@@ -182,6 +184,8 @@ object JellyOptions:
    *
    * @param options        Options of the stream.
    * @param expLogicalType Expected logical stream type. If UNSPECIFIED, no check is performed.
+   *
+   * @throws RdfProtoDeserializationError if the requested options are not supported.
    */
   private def checkLogicalStreamType(options: RdfStreamOptions, expLogicalType: LogicalStreamType): Unit =
     val baseLogicalType = options.logicalType.toBaseType

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoEncoder.scala
@@ -54,10 +54,12 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
   /**
    * Add an RDF triple statement to the stream.
    *
+   * If your library does not support quad objects, use `addTripleStatement(s, p, o)` instead.
+   *
    * @param triple triple to add
    * @return iterable of stream rows
-   * @throws NotImplementedError if the RDF library does not support triple objects
-   *                             (use `addTripleStatement(subject, predicate, object)` instead)
+   * @throws RdfProtoSerializationError if the library does not support triple objects or
+   *                                    if a serialization error occurs.
    */
   final def addTripleStatement(triple: TTriple): Iterable[RdfStreamRow] =
     addTripleStatement(
@@ -73,16 +75,19 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    * @param `object` object
    * @return iterable of stream rows
    * @since 2.9.0
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def addTripleStatement(subject: TNode, predicate: TNode, `object`: TNode): Iterable[RdfStreamRow]
 
   /**
    * Add an RDF quad statement to the stream.
    *
+   * If your library does not support quad objects, use `addQuadStatement(s, p, o, g)` instead.
+   *
    * @param quad quad to add
    * @return iterable of stream rows
-   * @throws NotImplementedError if the RDF library does not support quad objects
-   *                             (use `addQuadStatement(subject, predicate, object, graph)` instead)
+   * @throws RdfProtoSerializationError if the library does not support quad objects or
+   *                                    if a serialization error occurs.
    */
   final def addQuadStatement(quad: TQuad): Iterable[RdfStreamRow] =
     addQuadStatement(
@@ -101,6 +106,7 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    * @param graph graph
    * @return iterable of stream rows
    * @since 2.9.0
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def addQuadStatement(subject: TNode, predicate: TNode, `object`: TNode, graph: TNode): Iterable[RdfStreamRow]
 
@@ -110,6 +116,7 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    *
    * @param graph graph node
    * @return iterable of stream rows
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def startGraph(graph: TNode): Iterable[RdfStreamRow]
 
@@ -117,6 +124,7 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    * Signal the start of the default delimited graph in a GRAPHS stream.
    *
    * @return iterable of stream rows
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def startDefaultGraph(): Iterable[RdfStreamRow]
 
@@ -124,6 +132,7 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    * Signal the end of a delimited graph in a GRAPHS stream.
    *
    * @return iterable of stream rows (always of length 1)
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def endGraph(): Iterable[RdfStreamRow]
 
@@ -134,5 +143,6 @@ trait ProtoEncoder[TNode, -TTriple, -TQuad, -TQuoted]
    * @param name     short name of the namespace (without the colon)
    * @param iriValue IRI of the namespace
    * @return iterable of stream rows
+   * @throws RdfProtoSerializationError if a serialization error occurs
    */
   def declareNamespace(name: String, iriValue: String): Iterable[RdfStreamRow]

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/ProtoTranscoder.scala
@@ -41,6 +41,7 @@ trait ProtoTranscoder:
    *
    * @param row the row to ingest
    * @return zero or more rows
+   * @throws RdfProtoTranscodingError if the row can't be transcoded
    */
   def ingestRow(row: RdfStreamRow): Iterable[RdfStreamRow]
 
@@ -49,5 +50,6 @@ trait ProtoTranscoder:
    *
    * @param frame the frame to ingest
    * @return the frame
+   * @throws RdfProtoTranscodingError if the frame can't be transcoded
    */
   def ingestFrame(frame: RdfStreamFrame): RdfStreamFrame

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jDecoderConverter.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/Rdf4jDecoderConverter.scala
@@ -1,6 +1,7 @@
 package eu.ostrzyciel.jelly.convert.rdf4j
 
 import eu.ostrzyciel.jelly.core.ProtoDecoderConverter
+import eu.ostrzyciel.jelly.core.RdfProtoDeserializationError
 import org.eclipse.rdf4j.model.*
 import org.eclipse.rdf4j.model.base.CoreDatatype
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
@@ -24,23 +25,38 @@ final class Rdf4jDecoderConverter extends ProtoDecoderConverter[Value, Rdf4jData
   override inline def makeIriNode(iri: String) = vf.createIRI(iri)
 
   // RDF4J doesn't accept generalized statements (unlike Jena) which is why we need to do a type cast here.
-  override inline def makeTripleNode(s: Value, p: Value, o: Value) = vf.createTriple(
-    s.asInstanceOf[Resource],
-    p.asInstanceOf[IRI],
-    o,
-  )
+  override inline def makeTripleNode(s: Value, p: Value, o: Value) = try {
+    vf.createTriple(
+      s.asInstanceOf[Resource],
+      p.asInstanceOf[IRI],
+      o,
+    )
+  } catch
+    case e: ClassCastException => throw new RdfProtoDeserializationError(
+      s"Cannot create generalized triple node with $s, $p, $o", Some(e)
+    )
 
   override inline def makeDefaultGraphNode(): Value = null
 
-  override inline def makeTriple(s: Value, p: Value, o: Value) = vf.createStatement(
-    s.asInstanceOf[Resource],
-    p.asInstanceOf[IRI],
-    o,
-  )
+  override inline def makeTriple(s: Value, p: Value, o: Value) = try {
+    vf.createStatement(
+      s.asInstanceOf[Resource],
+      p.asInstanceOf[IRI],
+      o,
+    )
+  } catch
+    case e: ClassCastException => throw new RdfProtoDeserializationError(
+      s"Cannot create generalized triple with $s, $p, $o", Some(e)
+    )
 
-  override inline def makeQuad(s: Value, p: Value, o: Value, g: Value) = vf.createStatement(
-    s.asInstanceOf[Resource],
-    p.asInstanceOf[IRI],
-    o,
-    g.asInstanceOf[Resource],
-  )
+  override inline def makeQuad(s: Value, p: Value, o: Value, g: Value) = try {
+    vf.createStatement(
+      s.asInstanceOf[Resource],
+      p.asInstanceOf[IRI],
+      o,
+      g.asInstanceOf[Resource],
+    )
+  } catch
+    case e: ClassCastException => throw new RdfProtoDeserializationError(
+      s"Cannot create generalized quad with $s, $p, $o, $g", Some(e)
+    )

--- a/titanium-rdf-api/src/main/scala/eu/ostrzyciel/jelly/convert/titanium/internal/TitaniumDecoderConverter.scala
+++ b/titanium-rdf-api/src/main/scala/eu/ostrzyciel/jelly/convert/titanium/internal/TitaniumDecoderConverter.scala
@@ -2,6 +2,7 @@ package eu.ostrzyciel.jelly.convert.titanium.internal
 
 import eu.ostrzyciel.jelly.convert.titanium.internal.TitaniumRdf.*
 import eu.ostrzyciel.jelly.core.ProtoDecoderConverter
+import eu.ostrzyciel.jelly.core.RdfProtoDeserializationError
 
 /**
  * A Jelly decoder converter for the titanium-rdf-api.
@@ -18,16 +19,26 @@ private[titanium] final class TitaniumDecoderConverter extends ProtoDecoderConve
       "quoted triples.")
   override def makeDefaultGraphNode(): Node = null
 
-  override def makeTriple(s: Node, p: Node, o: Node): Quad = Quad(
-    s.asInstanceOf[String],
-    p.asInstanceOf[String],
-    o,
-    null
-  )
+  override def makeTriple(s: Node, p: Node, o: Node): Quad = try {
+    Quad(
+      s.asInstanceOf[String],
+      p.asInstanceOf[String],
+      o,
+      null
+    )
+  } catch
+    case e: ClassCastException => throw new RdfProtoDeserializationError(
+      s"Cannot create generalized triple with $s, $p, $o", Some(e)
+    )
 
-  override def makeQuad(s: Node, p: Node, o: Node, g: Node): Quad = Quad(
-    s.asInstanceOf[String],
-    p.asInstanceOf[String],
-    o,
-    g.asInstanceOf[String]
-  )
+  override def makeQuad(s: Node, p: Node, o: Node, g: Node): Quad = try {
+    Quad(
+      s.asInstanceOf[String],
+      p.asInstanceOf[String],
+      o,
+      g.asInstanceOf[String]
+    )
+  } catch
+    case e: ClassCastException => throw new RdfProtoDeserializationError(
+      s"Cannot create generalized quad with $s, $p, $o, $g", Some(e)
+    )


### PR DESCRIPTION
This tidies up exception handling in decoders and encoders, reducing the chance that some NPE, array-out-of-bounds, class-cast, or whatever exception slips out. There would be nothing inherently *wrong* with that, as it's all unchecked exceptions anyway, but such exceptions are not very informative to users. By catching and re-throwing them, we can make it clearer why a failure has occurred.