### PR TITLE
Fix marking code as generated in IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,9 +95,10 @@ lazy val core = (project in file("core"))
     Compile / sourceGenerators += Def.task {
       Generator.gen(
         inputDir = (rdfProtos / target).value / ("scala-" + scalaVersion.value) / "src_managed" / "main",
-        outputDir = sourceManaged.value / "scalapb",
+        outputDir = sourceManaged.value / "main" / "scalapb",
       )
     }.dependsOn(rdfProtos / Compile / PB.generate),
+    Compile / sourceManaged := sourceManaged.value / "main",
     commonSettings,
   )
 


### PR DESCRIPTION
IntelliJ was looking for generated code under `Compile / sourceManaged`, which was not set correctly. This caused annoying syntax highlighting errors that could be fixed by manually specifying the managed sources directory. With this fix, it will happen automatically.