### PR TITLE
Docs: Improve clarity of index.md

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,6 @@
 # Jelly-JVM
 
-**Jelly-JVM** is an implementation of the [Jelly serialization format and gRPC streaming protocol]({{ proto_link() }}) for the Java Virtual Machine (JVM). It supports [Apache Jena](https://jena.apache.org/), [Eclipse RDF4J](https://rdf4j.org/), and the [Titanium RDF API](https://github.com/filip26/titanium-rdf-api).
+**Jelly-JVM** is an implementation of the [Jelly serialization format and gRPC streaming protocol]({{ proto_link() }}) for the Java Virtual Machine (JVM). It supports [Apache Jena](user/jena.md), [Eclipse RDF4J](user/rdf4j.md), and the [Titanium RDF API](user/titanium.md).
 
 Jelly-JVM provides a **full stack** of utilities for fast and scalable RDF streaming with the [Jelly protocol]({{ proto_link( 'specification' ) }}). Oh, and [**it's *blazing-fast***]({{ proto_link('performance') }}), too!
 
@@ -25,19 +25,19 @@ The implementation is split into a few modules that can be used separately:
 - `jelly-core` – core generic code for serializing/deserializing Jelly data. You need an additional module (like `jelly-jena`) to integrate it with a specific RDF library.
     - {{ module_badges('core') }}
 
-- `jelly-jena` – interop code for the [Apache Jena](https://jena.apache.org/) library.
+- `jelly-jena` – interop code for the [Apache Jena](https://jena.apache.org/) library. **[:octicons-arrow-right-24: Learn more](user/jena.md)**
     - {{ module_badges('jena') }}
 
-- `jelly-rdf4j` – interop code for the [Eclipse RDF4J](https://rdf4j.org/) library.
+- `jelly-rdf4j` – interop code for the [Eclipse RDF4J](https://rdf4j.org/) library. **[:octicons-arrow-right-24: Learn more](user/rdf4j.md)**
     - {{ module_badges('rdf4j') }}
 
-- `jelly-titanium-rdf-api` – integration with the minimalistic [Titanium RDF API](https://github.com/filip26/titanium-rdf-api).
+- `jelly-titanium-rdf-api` – integration with the [Titanium RDF API](https://github.com/filip26/titanium-rdf-api). **[:octicons-arrow-right-24: Learn more](user/titanium.md)**
     - {{ module_badges('titanium-rdf-api') }}
 
-- `jelly-stream` – utilities for building [Reactive Streams](https://www.reactive-streams.org/) of RDF data, based on Pekko Streams. Useful for integrating with for example gRPC, Kafka, MQTT...
+- `jelly-stream` – utilities for building [Reactive Streams](https://www.reactive-streams.org/) of RDF data, based on Pekko Streams. Useful for integrating with for example gRPC, Kafka, MQTT... **[:octicons-arrow-right-24: Learn more](user/reactive.md)**
     - {{ module_badges('stream') }}
 
-- `jelly-grpc` – implementation of a gRPC client and server for the [Jelly gRPC streaming protocol]({{ proto_link( 'specification/streaming' ) }}).
+- `jelly-grpc` – implementation of a gRPC client and server for the [Jelly gRPC streaming protocol]({{ proto_link( 'specification/streaming' ) }}). **[:octicons-arrow-right-24: Learn more](user/grpc.md)**
     - {{ module_badges('grpc') }}
 
 ## Plugin JARs


### PR DESCRIPTION
Make the library-related links point to relevant user guides. Add more links to the guides in the module list.