### PR TITLE
Fix documentation edit links

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,7 +28,7 @@ markdown_extensions:
 
 repo_url: https://github.com/Jelly-RDF/jelly-jvm
 repo_name: Jelly-RDF/jelly-jvm
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/docs/
 
 theme:
   name: material


### PR DESCRIPTION
Currently clicking the edit button in the top-right corner leads to a 404 error due to misconfiguration.

The fix works, tested it locally.