### PR TITLE
Docs: fix titanium Maven dependency name

### DIFF
--- a/docs/docs/getting-started-devs.md
+++ b/docs/docs/getting-started-devs.md
@@ -73,7 +73,7 @@ If you aren't using a big RDF library like Jena or RDF4J, the simplest way to ge
 ```xml
 <dependency>
     <groupId>eu.ostrzyciel.jelly</groupId>
-    <artifactId>jelly-titanium-rdf-api</artifactId>
+    <artifactId>jelly-titanium-rdf-api_3</artifactId>
     <version>{{ jvm_package_version() }}</version>
 </dependency>
 ```

--- a/docs/docs/user/titanium.md
+++ b/docs/docs/user/titanium.md
@@ -9,7 +9,7 @@ If you are already using Jena or RDF4J, you should use the [`jelly-jena`](jena.m
 ```xml
 <dependency>
     <groupId>eu.ostrzyciel.jelly</groupId>
-    <artifactId>jelly-titanium-rdf-api</artifactId>
+    <artifactId>jelly-titanium-rdf-api_3</artifactId>
     <version>{{ jvm_package_version() }}</version>
 </dependency>
 ```


### PR DESCRIPTION
I forgot that we need to add a `_3` at the end of the artifact ID, because it's a Scala module.