### PR TITLE
Unpin Python version in docs workflow

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -18,7 +18,6 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
           cache: pip
           cache-dependency-path: 'docs/requirements.txt'
   


### PR DESCRIPTION
Follows up #318. Forgot to check that before.
We can remove that line now, as the action understands the pin from `.python-version`.