### PR TITLE
Rio&RIOT: add option to write non-delimited output

### DIFF
--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyFormat.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyFormat.scala
@@ -10,11 +10,17 @@ import org.apache.jena.riot.{RDFFormat, RDFFormatVariant}
  * @param opt Jelly options
  * @param frameSize size of each RdfStreamFrame, in rows
  * @param enableNamespaceDeclarations whether to include namespace declarations in the output
+ * @param delimited whether to write the output as delimited frames. Note: files saved to disk are
+ *                  recommended to be delimited, for better interoperability with other implementations.
+ *                  In a non-delimited file you can have ONLY ONE FRAME. If the input data is large,
+ *                  this will lead to an out-of-memory error. So, this makes sense only for small data.
+ *                  **Disable this only if you know what you are doing.**
  */
 case class JellyFormatVariant(
   opt: RdfStreamOptions = JellyOptions.smallAllFeatures,
   frameSize: Int = 256,
   enableNamespaceDeclarations: Boolean = false,
+  delimited: Boolean = true,
 ) extends RDFFormatVariant(opt.toString)
 
 /**

--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyLanguage.scala
@@ -92,6 +92,18 @@ object JellyLanguage:
   val SYMBOL_ENABLE_NAMESPACE_DECLARATIONS: util.Symbol =
     org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "enableNamespaceDeclarations")
 
+  /**
+   * Symbol for enabling/disabling delimiters between frames in the output. (ENABLED by default)
+   *
+   * Note: files saved to disk are recommended to be delimited, for better interoperability with other
+   * implementations. In a non-delimited file you can have ONLY ONE FRAME. If the input data is large,
+   * this will lead to an out-of-memory error. So, this makes sense only for small data.
+   *
+   * **Set this option to "false" only if you know what you are doing.**
+   */
+  val SYMBOL_DELIMITED_OUTPUT: util.Symbol =
+    org.apache.jena.sparql.util.Symbol.create(SYMBOL_NS + "delimitedOutput")
+
   private var registered = false
 
   register()

--- a/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
+++ b/rdf4j/src/main/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSettings.scala
@@ -14,11 +14,15 @@ object JellyWriterSettings:
     c
 
   def configFromOptions(
-    opt: RdfStreamOptions, frameSize: Long = 256L, enableNamespaceDeclarations: Boolean = false
+    opt: RdfStreamOptions,
+    frameSize: Long = 256L,
+    enableNamespaceDeclarations: Boolean = false,
+    delimited: Boolean = true,
   ): WriterConfig =
     val c = new WriterConfig()
     c.set(FRAME_SIZE, frameSize)
     c.set(ENABLE_NAMESPACE_DECLARATIONS, enableNamespaceDeclarations)
+    c.set(DELIMITED_OUTPUT, delimited)
     c.set(STREAM_NAME, opt.streamName)
     c.set(PHYSICAL_TYPE, opt.physicalType)
     c.set(ALLOW_RDF_STAR, opt.rdfStar)
@@ -41,6 +45,15 @@ object JellyWriterSettings:
       "It is only useful when you want to preserve the namespace declarations in the output. " +
       "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
     false
+  )
+
+  val DELIMITED_OUTPUT = new BooleanRioSetting(
+    "eu.ostrzyciel.jelly.convert.rdf4j.rio.delimitedOutput",
+    "Write the output as delimited frames. Note: files saved to disk are recommended to be delimited, " +
+      "for better interoperability with other implementations. In a non-delimited file you can have ONLY ONE FRAME. " +
+      "If the input data is large, this will lead to an out-of-memory error. So, this makes sense only for small data. " +
+      "**Disable this only if you know what you are doing.**",
+    true
   )
 
   val STREAM_NAME = new StringRioSetting(

--- a/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
+++ b/rdf4j/src/test/scala/eu/ostrzyciel/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
@@ -1,5 +1,6 @@
 package eu.ostrzyciel.jelly.convert.rdf4j.rio
 
+import eu.ostrzyciel.jelly.core.IoUtils
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.scalatest.matchers.should.Matchers
@@ -11,6 +12,11 @@ import scala.annotation.nowarn
 @nowarn("msg=deprecated")
 class JellyWriterSpec extends AnyWordSpec, Matchers:
   val vf = SimpleValueFactory.getInstance()
+  val testStatement = vf.createStatement(
+    vf.createIRI("http://example.com/s"),
+    vf.createIRI("http://example.com/p"),
+    vf.createIRI("http://example.com/o")
+  )
   
   "JellyWriter" should {
     "ignore the generalized RDF setting" in {
@@ -18,16 +24,76 @@ class JellyWriterSpec extends AnyWordSpec, Matchers:
       val writer = JellyWriterFactory().getWriter(os)
       writer.set(JellyWriterSettings.ALLOW_GENERALIZED_STATEMENTS, true)
       writer.startRDF()
-      writer.handleStatement(vf.createStatement(
-        vf.createIRI("http://example.com/s"),
-        vf.createIRI("http://example.com/p"),
-        vf.createIRI("http://example.com/o")
-      ))
+      writer.handleStatement(testStatement)
       writer.endRDF()
 
       val bytes = os.toByteArray
       val rows = RdfStreamFrame.parseDelimitedFrom(ByteArrayInputStream(bytes)).get.rows
       rows.head.row.isOptions should be(true)
       rows.head.row.options.generalizedStatements should be(false)
+    }
+
+    "write delimited frames by default" in {
+      val os = new ByteArrayOutputStream()
+      val writer = JellyWriterFactory().getWriter(os)
+      writer.startRDF()
+      writer.handleStatement(testStatement)
+      writer.endRDF()
+
+      val bytes = os.toByteArray
+      bytes.size should be > 10
+      val (delimited, _) = IoUtils.autodetectDelimiting(ByteArrayInputStream(bytes))
+      delimited should be(true)
+    }
+
+    "write non-delimited frames if requested" in {
+      val os = new ByteArrayOutputStream()
+      val writer = JellyWriterFactory().getWriter(os)
+      writer.set(JellyWriterSettings.DELIMITED_OUTPUT, false)
+      writer.startRDF()
+      writer.handleStatement(testStatement)
+      writer.endRDF()
+
+      val bytes = os.toByteArray
+      bytes.size should be > 10
+      val (delimited, _) = IoUtils.autodetectDelimiting(ByteArrayInputStream(bytes))
+      delimited should be(false)
+    }
+
+    "split stream into multiple frames if it's non-delimited" in {
+      val os = new ByteArrayOutputStream()
+      val writer = JellyWriterFactory().getWriter(os)
+      writer.set(JellyWriterSettings.FRAME_SIZE, 1)
+      writer.startRDF()
+      for _ <- 1 to 100 do
+        writer.handleStatement(testStatement)
+      writer.endRDF()
+
+      val bytes = os.toByteArray
+      val (delimited, is) = IoUtils.autodetectDelimiting(ByteArrayInputStream(bytes))
+      delimited should be(true)
+      for i <- 0 until 100 do
+        val f = RdfStreamFrame.parseDelimitedFrom(is)
+        f.isDefined should be(true)
+        f.get.rows.size should be > 0
+      is.available() should be(0)
+    }
+
+    "not split stream into multiple frames if it's non-delimited" in {
+      val os = new ByteArrayOutputStream()
+      val writer = JellyWriterFactory().getWriter(os)
+      writer.set(JellyWriterSettings.FRAME_SIZE, 1)
+      writer.set(JellyWriterSettings.DELIMITED_OUTPUT, false)
+      writer.startRDF()
+      for _ <- 1 to 10_000 do
+        writer.handleStatement(testStatement)
+      writer.endRDF()
+
+      val bytes = os.toByteArray
+      val (delimited, is) = IoUtils.autodetectDelimiting(ByteArrayInputStream(bytes))
+      delimited should be(false)
+      val f = RdfStreamFrame.parseFrom(is)
+      f.rows.size should be > 10_000
+      is.available() should be(0)
     }
   }


### PR DESCRIPTION
Needed for: https://github.com/Jelly-RDF/cli/issues/55

This adds an option in the Rio and RIOT writers to disable frame delimiters. This is useful in some scenarios (if, e.g., the output stream is pointed to some internal buffer), or for development.

This should not be used by default for writing files to disk, as the entire frame (entire stream, in this case) would have to be kept in memory before being serialized. This is obviously not great.