### PR TITLE
RIOT: fix applying non-delimited option in writer factory

### DIFF
--- a/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
+++ b/jena/src/main/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriter.scala
@@ -45,7 +45,8 @@ private[riot] object Util:
       frameSize = context.getInt(JellyLanguage.SYMBOL_FRAME_SIZE, baseVariant.frameSize),
       enableNamespaceDeclarations = context.isTrue(JellyLanguage.SYMBOL_ENABLE_NAMESPACE_DECLARATIONS) ||
         baseVariant.enableNamespaceDeclarations,
-      delimited = context.isTrue(JellyLanguage.SYMBOL_DELIMITED_OUTPUT) || baseVariant.delimited,
+      // undef -> true, true -> true, false -> false
+      delimited = context.isTrueOrUndef(JellyLanguage.SYMBOL_DELIMITED_OUTPUT),
     )
 
 /**

--- a/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriterFactorySpec.scala
+++ b/jena/src/test/scala/eu/ostrzyciel/jelly/convert/jena/riot/JellyWriterFactorySpec.scala
@@ -1,7 +1,7 @@
 package eu.ostrzyciel.jelly.convert.jena.riot
 
 import eu.ostrzyciel.jelly.convert.jena.traits.JenaTest
-import eu.ostrzyciel.jelly.core.Constants
+import eu.ostrzyciel.jelly.core.{Constants, IoUtils}
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.apache.jena.graph.{NodeFactory, Triple}
 import org.apache.jena.riot.RDFFormat
@@ -100,4 +100,16 @@ class JellyWriterFactorySpec extends AnyWordSpec, Matchers, JenaTest:
           else
             options.version should be (Constants.protoVersion_1_0_x)
         }
+
+      "apply the `delimited` parameter set to false" in {
+        val os = new ByteArrayOutputStream()
+        val format = RDFFormat(JellyLanguage.JELLY)
+        val ctx = new Context()
+        ctx.set(JellyLanguage.SYMBOL_DELIMITED_OUTPUT, false)
+        factory(format, ctx, os)
+        val bytes = os.toByteArray
+        bytes should not be empty
+        val is = new ByteArrayInputStream(bytes)
+        IoUtils.autodetectDelimiting(is)._1 should be(false)
+      }
     }


### PR DESCRIPTION
There was an error in the writer factory that caused the non-delimited option to be applied improperly. I did in fact forget to make a factory test for this feature.

Follow-up of #321 