### PR TITLE
Make AnyStatementDecoder ignore duplicate options

### DIFF
--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoDecoderImpl.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/internal/ProtoDecoderImpl.scala
@@ -249,19 +249,18 @@ object ProtoDecoderImpl:
       // Reset the logical type to UNSPECIFIED to ignore checking if it's supported by the inner decoder
       val newSupportedOptions = supportedOptions.copy(logicalType = LogicalStreamType.UNSPECIFIED)
       JellyOptions.checkCompatibility(opts, newSupportedOptions)
-      if inner.isDefined then
-        throw new RdfProtoDeserializationError("Stream options are already set. " +
-          "The physical type of the stream cannot be inferred.")
-      val dec = opts.physicalType match
-        case PhysicalStreamType.TRIPLES =>
-          new TriplesDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
-        case PhysicalStreamType.QUADS =>
-          new QuadsDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
-        case PhysicalStreamType.GRAPHS =>
-          new GraphsAsQuadsDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
-        case PhysicalStreamType.UNSPECIFIED =>
-          throw new RdfProtoDeserializationError("Incoming physical stream type is not set.")
-        case _ =>
-          throw new RdfProtoDeserializationError("Incoming physical stream type is not recognized.")
+      // If options already set, ignore them
+      if inner.isEmpty then
+        val dec = opts.physicalType match
+          case PhysicalStreamType.TRIPLES =>
+            new TriplesDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
+          case PhysicalStreamType.QUADS =>
+            new QuadsDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
+          case PhysicalStreamType.GRAPHS =>
+            new GraphsAsQuadsDecoder[TNode, TDatatype, TTriple, TQuad](converter, newSupportedOptions, nsHandler)
+          case PhysicalStreamType.UNSPECIFIED =>
+            throw new RdfProtoDeserializationError("Incoming physical stream type is not set.")
+          case _ =>
+            throw new RdfProtoDeserializationError("Incoming physical stream type is not recognized.")
 
-      inner = Some(dec.asInstanceOf[ProtoDecoderImpl[TNode, TDatatype, TTriple, TQuad, TTriple | TQuad]])
+        inner = Some(dec.asInstanceOf[ProtoDecoderImpl[TNode, TDatatype, TTriple, TQuad, TTriple | TQuad]])

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -518,17 +518,21 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
       error.getMessage should include ("Stream options are not set")
     }
 
-    "should throw when encountering stream options twice" in {
+    "should ignore multiple stream options" in {
       val decoder = MockConverterFactory.anyStatementDecoder()
       val data = wrapEncodedFull(Seq(
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.TRIPLES),
         JellyOptions.smallGeneralized.withPhysicalType(PhysicalStreamType.TRIPLES),
+        RdfTriple(
+          RdfTerm.Bnode("1"),
+          RdfTerm.Bnode("2"),
+          RdfTerm.Bnode("3"),
+        ),
       ))
       decoder.ingestRow(data.head)
-      val error = intercept[RdfProtoDeserializationError] {
-        decoder.ingestRow(data(1))
-      }
-      error.getMessage should include ("Stream options are already set")
+      decoder.ingestRow(data(1))
+      val t = decoder.ingestRow(data(2))
+      t.get should be (a[Triple])
     }
   }
 


### PR DESCRIPTION
This was the only decoder that threw an error when encountering duplicate stream options, which was pretty inconsistent. This was technically OK with the spec ("Implementations SHOULD NOT throw an error if the stream options header is present more than once in the stream."), but was not the RECOMMENDED behavior.

Encountered while working on: https://github.com/Jelly-RDF/cli/issues/66