### PR TITLE
Match spec-defined behavior with small table sizes

### DIFF
--- a/core/src/main/java/eu/ostrzyciel/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/internal/EncoderLookup.java
@@ -53,7 +53,7 @@ final class EncoderLookup {
     // Tail pointer for the table.
     private int tail;
     // Maximum size of the lookup.
-    private final int size;
+    final int size;
     // Current size of the lookup (how many entries are used).
     // This will monotonically increase until it reaches the maximum size.
     private int used;

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/internal/NodeEncoderImpl.java
@@ -1,10 +1,10 @@
 package eu.ostrzyciel.jelly.core.internal;
 
+import eu.ostrzyciel.jelly.core.JellyExceptions;
 import eu.ostrzyciel.jelly.core.NodeEncoder;
 import eu.ostrzyciel.jelly.core.proto.v1.*;
 
 import java.util.LinkedHashMap;
-import java.util.function.Function;
 
 /**
  * Encodes RDF nodes native to the used RDF library (e.g., Apache Jena, RDF4J) into Jelly's protobuf objects.
@@ -203,6 +203,11 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      */
     @Override
     public UniversalTerm makeDtLiteral(TNode key, String lex, String datatypeName) {
+        if (datatypeLookup.size == 0) {
+            throw JellyExceptions.rdfProtoSerializationError("Datatype literals cannot be " +
+                    "encoded when the datatype table is disabled. Set the datatype table size " +
+                    "to a positive value.");
+        }
         var cachedNode = dtLiteralNodeCache.computeIfAbsent(key, k -> new DependentNode());
         // Check if the value is still valid
         if (cachedNode.encoded != null &&

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyExceptions.scala
@@ -22,4 +22,12 @@ private object JellyExceptions extends JellyExceptions:
   private[core] def rdfProtoDeserializationError(msg: String): RdfProtoDeserializationError =
     new RdfProtoDeserializationError(msg)
 
+  /**
+   * Helper method to allow Java code to throw a [[RdfProtoSerializationError]].
+   * @param msg error message
+   * @return an instance of [[RdfProtoSerializationError]]
+   */
+  private[core] def rdfProtoSerializationError(msg: String): RdfProtoSerializationError =
+    new RdfProtoSerializationError(msg)
+
 export JellyExceptions.*

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
@@ -170,11 +170,11 @@ object JellyOptions:
           s"smaller than the minimum supported size of $minSize."
         )
 
-    // The minimum sizes are hard-coded because it would be impossible to reliably encode the stream
-    // with smaller tables, especially if RDF-star is used.
-    checkTableSize("Name", requestedOptions.maxNameTableSize, supportedOptions.maxNameTableSize, 16)
+    // The minimum size of the name lookup is hard-coded in the spec.
+    checkTableSize("Name", requestedOptions.maxNameTableSize, supportedOptions.maxNameTableSize, 8)
     checkTableSize("Prefix", requestedOptions.maxPrefixTableSize, supportedOptions.maxPrefixTableSize)
-    checkTableSize("Datatype", requestedOptions.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize, 8)
+    // The datatype lookup can be empty if the stream does not use datatype literals.
+    checkTableSize("Datatype", requestedOptions.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize)
 
     checkLogicalStreamType(requestedOptions, supportedOptions.logicalType)
 

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/ProtoDecoderSpec.scala
@@ -674,25 +674,21 @@ class ProtoDecoderSpec extends AnyWordSpec, Matchers:
         val data = wrapEncodedFull(Seq(
           JellyOptions.smallGeneralized
             .withPhysicalType(streamType)
-            .withMaxNameTableSize(2) // 16 is the minimum
+            .withMaxNameTableSize(2) // 8 is the minimum
         ))
         val error = intercept[RdfProtoDeserializationError] {
           decoderFactory(None).ingestRow(data.head)
         }
         error.getMessage should include("name table size of 2")
-        error.getMessage should include("smaller than the minimum supported size of 16")
+        error.getMessage should include("smaller than the minimum supported size of 8")
       }
 
-      "throw exception on a stream with a datatype table size smaller than supported" in {
+      "accept a datatype table size = 0" in {
         val data = wrapEncodedFull(Seq(
           JellyOptions.smallGeneralized
             .withPhysicalType(streamType)
-            .withMaxDatatypeTableSize(2) // 8 is the minimum
+            .withMaxDatatypeTableSize(0)
         ))
-        val error = intercept[RdfProtoDeserializationError] {
-          decoderFactory(None).ingestRow(data.head)
-        }
-        error.getMessage should include("datatype table size of 2")
-        error.getMessage should include("smaller than the minimum supported size of 8")
+        decoderFactory(None).ingestRow(data.head) should be (None)
       }
     }

--- a/core/src/test/scala/eu/ostrzyciel/jelly/core/internal/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/ostrzyciel/jelly/core/internal/NodeEncoderSpec.scala
@@ -1,5 +1,7 @@
 package eu.ostrzyciel.jelly.core.internal
 
+import eu.ostrzyciel.jelly.core.JellyExceptions.RdfProtoSerializationError
+import eu.ostrzyciel.jelly.core.JellyOptions
 import eu.ostrzyciel.jelly.core.helpers.Mrl
 import eu.ostrzyciel.jelly.core.proto.v1.*
 import org.scalatest.Inspectors
@@ -212,6 +214,19 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           )
           node.literal.lex should be (s"v$i")
           node.literal.literalKind.datatype should be (i + 4)
+      }
+
+      "throw exception if datatype table size = 0" in {
+        val encoder = NodeEncoderImpl[Mrl.Node](
+          JellyOptions.smallStrict.withMaxDatatypeTableSize(0), null, 16, 16, 16
+        )
+        val e = intercept[RdfProtoSerializationError] {
+          encoder.makeDtLiteral(
+            Mrl.DtLiteral("v1", Mrl.Datatype("dt1")),
+            "v1", "dt1",
+          )
+        }
+        e.getMessage should include ("Datatype literals cannot be encoded when the datatype table")
       }
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/Jelly-RDF/jelly-rdf.github.io/pull/35

Make the smallest allowed name table size be 8.

Allow 0-sized datatype tables, if no datatype literals are used.

Update tests to make sure this behavior is respected.