### PR TITLE
core: require name lookup to have size >= 8

### DIFF
--- a/core-java/src/main/java/eu/neverblink/jelly/core/JellyOptions.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/JellyOptions.java
@@ -21,6 +21,11 @@ public class JellyOptions {
     public static final int SMALL_DT_TABLE_SIZE = 16;
 
     /**
+     * Minimum size of the name table, according to the spec.
+     */
+    public static final int MIN_NAME_TABLE_SIZE = 8;
+
+    /**
      * "Big" preset suitable for high-volume streams and larger machines.
      * Does not allow generalized RDF statements.
      */
@@ -208,7 +213,12 @@ public class JellyOptions {
             );
         }
 
-        checkTableSize("Name", requestedOptions.getMaxNameTableSize(), supportedOptions.getMaxNameTableSize(), 8);
+        checkTableSize(
+            "Name",
+            requestedOptions.getMaxNameTableSize(),
+            supportedOptions.getMaxNameTableSize(),
+            MIN_NAME_TABLE_SIZE
+        );
         checkTableSize("Prefix", requestedOptions.getMaxPrefixTableSize(), supportedOptions.getMaxPrefixTableSize());
         checkTableSize(
             "Datatype",

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -1,9 +1,6 @@
 package eu.neverblink.jelly.core.internal;
 
-import eu.neverblink.jelly.core.NodeEncoder;
-import eu.neverblink.jelly.core.RdfProtoSerializationError;
-import eu.neverblink.jelly.core.RdfTerm;
-import eu.neverblink.jelly.core.RowBufferAppender;
+import eu.neverblink.jelly.core.*;
 import eu.neverblink.jelly.core.proto.v1.RdfDatatypeEntry;
 import eu.neverblink.jelly.core.proto.v1.RdfNameEntry;
 import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntry;
@@ -104,6 +101,12 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         } else {
             prefixLookup = null;
             iriNodeCache = null;
+        }
+        if (nameTableSize < JellyOptions.MIN_NAME_TABLE_SIZE) {
+            throw new RdfProtoSerializationError(
+                "Requested name table size of %d is too small. The minimum is %d."
+                    .formatted(nameTableSize, JellyOptions.MIN_NAME_TABLE_SIZE)
+            );
         }
         nameOnlyIris = new RdfTerm.Iri[nameTableSize + 1];
         for (int i = 0; i < nameOnlyIris.length; i++) {

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -104,8 +104,10 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         }
         if (nameTableSize < JellyOptions.MIN_NAME_TABLE_SIZE) {
             throw new RdfProtoSerializationError(
-                "Requested name table size of %d is too small. The minimum is %d."
-                    .formatted(nameTableSize, JellyOptions.MIN_NAME_TABLE_SIZE)
+                "Requested name table size of %d is too small. The minimum is %d.".formatted(
+                        nameTableSize,
+                        JellyOptions.MIN_NAME_TABLE_SIZE
+                    )
             );
         }
         nameOnlyIris = new RdfTerm.Iri[nameTableSize + 1];

--- a/core-java/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
+++ b/core-java/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
@@ -1,9 +1,9 @@
 package eu.neverblink.jelly.core.internal
 
-import eu.neverblink.jelly.core.{JellyOptions, RdfProtoSerializationError, RowBufferAppender}
 import eu.neverblink.jelly.core.helpers.Mrl
 import eu.neverblink.jelly.core.helpers.RdfAdapter.*
 import eu.neverblink.jelly.core.proto.v1.*
+import eu.neverblink.jelly.core.{RdfProtoSerializationError, RowBufferAppender}
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -13,7 +13,7 @@ import scala.util.Random
 
 class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
   def smallOptions(prefixTableSize: Int): RdfStreamOptions = rdfStreamOptions(
-    maxNameTableSize = 4,
+    maxNameTableSize = 8,
     maxPrefixTableSize = prefixTableSize,
     maxDatatypeTableSize = 8,
   )
@@ -26,7 +26,7 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
       def appendDatatypeEntry(entry: RdfDatatypeEntry): Unit = buffer += rdfStreamRow(entry)
     }
     (NodeEncoderImpl[Mrl.Node](
-      prefixTableSize, 4, 8,
+      prefixTableSize, 8, 8,
       16, 16, 16, 
       appender
     ), buffer)
@@ -314,10 +314,14 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           ("https://test.org/other/Cake2", 0, 0),
           ("https://test.org/other/Cake3", 0, 0),
           ("https://test.org/other/Cake4", 0, 0),
-          ("https://test.org/other/Cake5", 0, 1),
-          ("https://test.org/other/Cake5", 0, 1),
+          ("https://test.org/other/Cake5", 0, 0),
+          ("https://test.org/other/Cake6", 0, 0),
+          ("https://test.org/other/Cake7", 0, 0),
+          ("https://test.org/other/Cake8", 0, 0),
+          ("https://test.org/other/Cake9", 0, 1),
+          ("https://test.org/other/Cake9", 0, 1),
           ("https://test.org#Cake2", 2, 0),
-          ("https://test.org#Cake5", 0, 1),
+          ("https://test.org#Cake9", 0, 1),
           // prefix "" evicts the previous number #1
           ("Cake2", 1, 0),
         )
@@ -337,7 +341,11 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           (true, 3, "https://test.org/other/"),
           (false, 0, "Cake3"),
           (false, 0, "Cake4"),
-          (false, 1, "Cake5"),
+          (false, 0, "Cake5"),
+          (false, 0, "Cake6"),
+          (false, 0, "Cake7"),
+          (false, 0, "Cake8"),
+          (false, 1, "Cake9"),
           (true, 1, ""),
         )
 
@@ -430,6 +438,10 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           ("https://test.org#Cake1", 0),
           ("https://test.org/test/Cake1", 0),
           ("https://test.org/Cake2", 0),
+          ("https://test.org/Cake3", 0),
+          ("https://test.org/Cake4", 0),
+          ("https://test.org/Cake5", 0),
+          ("https://test.org/Cake6", 0),
           ("https://test.org#Cake2", 1),
           ("https://test.org/other/Cake1", 0),
           ("https://test.org/other/Cake2", 0),
@@ -437,6 +449,10 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           ("https://test.org/other/Cake1", 2),
           ("https://test.org/other/Cake2", 0),
           ("https://test.org/other/Cake3", 0),
+          ("https://test.org/other/Cake3_1", 0),
+          ("https://test.org/other/Cake3_2", 0),
+          ("https://test.org/other/Cake3_3", 0),
+          ("https://test.org/other/Cake3_4", 0),
           ("https://test.org/other/Cake4", 1),
           ("https://test.org/other/Cake5", 0),
           ("https://test.org/other/Cake5", 2),
@@ -447,6 +463,15 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
           val iri = encoder.makeIri(sIri)
           iri.prefixId should be(0)
           iri.nameId should be(eName)
+      }
+
+      "throw exception if name table size = 1" in {
+        val e = intercept[RdfProtoSerializationError] {
+          NodeEncoderImpl[Mrl.Node](
+            16, 1, 16, 16, 16, 16, null
+          )
+        }
+        e.getMessage should include("Requested name table size of 1 is too small. The minimum is 8.")
       }
     }
   }

--- a/core/src/main/java/eu/ostrzyciel/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/ostrzyciel/jelly/core/internal/NodeEncoderImpl.java
@@ -99,6 +99,11 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             prefixLookup = null;
             iriNodeCache = null;
         }
+        if (nameTableSize < 8) {
+            throw JellyExceptions.rdfProtoSerializationError(
+                "Requested name table size of %d is too small. The minimum is 8.".formatted(nameTableSize)
+            );
+        }
         nameOnlyIris = new RdfIri[nameTableSize + 1];
         for (int i = 0; i < nameOnlyIris.length; i++) {
             nameOnlyIris[i] = new RdfIri(0, i);

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/JellyOptions.scala
@@ -16,6 +16,11 @@ object JellyOptions:
   private[core] inline val smallDtTableSize = 16
 
   /**
+   * Minimum size of the name table, according to the spec.
+   */
+  private[core] inline val minNameTableSize = 8
+
+  /**
    * "Big" preset suitable for high-volume streams and larger machines.
    * Does not allow generalized RDF statements.
    * @return

--- a/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/BaseJellyOptions.scala
+++ b/core/src/main/scala/eu/ostrzyciel/jelly/core/proto/v1/BaseJellyOptions.scala
@@ -1,6 +1,7 @@
 package eu.ostrzyciel.jelly.core.proto.v1
 
 import eu.ostrzyciel.jelly.core.JellyExceptions.RdfProtoDeserializationError
+import eu.ostrzyciel.jelly.core.JellyOptions
 
 /**
  * Base options shared by Jelly-RDF, Jelly-Patch and possible future extensions.
@@ -56,7 +57,12 @@ private[core] object BaseJellyOptions:
         )
 
     // The minimum size of the name lookup is hard-coded in the spec.
-    checkTableSize("Name", requestedOptions.maxNameTableSize, supportedOptions.maxNameTableSize, 8)
+    checkTableSize(
+      "Name",
+      requestedOptions.maxNameTableSize,
+      supportedOptions.maxNameTableSize,
+      JellyOptions.minNameTableSize
+    )
     checkTableSize("Prefix", requestedOptions.maxPrefixTableSize, supportedOptions.maxPrefixTableSize)
     // The datatype lookup can be empty if the stream does not use datatype literals.
     checkTableSize("Datatype", requestedOptions.maxDatatypeTableSize, supportedOptions.maxDatatypeTableSize)


### PR DESCRIPTION
Issue: https://github.com/Jelly-RDF/cli/issues/86

This is in line with what's written in the spec: `This field is REQUIRED and MUST be set to a value greater than or equal to 8.`

Ported to both the Java and Scala versions.