### PR TITLE
Implement arbitrary graphs for ns decl in Jelly-Patch

### DIFF
--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
@@ -165,7 +165,7 @@ public abstract class DecoderBase<TNode, TDatatype> {
      */
     protected final TNode convertGraphTermWrapped(int kind, GraphBase graph) {
         if (graph.getGraph() == null && lastGraph.hasNoValue()) {
-            // Special case: Jena and RDF4J allow null graph terms in the input, 
+            // Special case: Jena and RDF4J allow null graph terms in the input,
             // so we do not treat them as errors.
             return null;
         }

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
@@ -165,7 +165,8 @@ public abstract class DecoderBase<TNode, TDatatype> {
      */
     protected final TNode convertGraphTermWrapped(int kind, GraphBase graph) {
         if (graph.getGraph() == null && lastGraph.hasNoValue()) {
-            // Special case: Jena and RDF4J allow null graph terms in the input, so we do not treat them as errors.
+            // Special case: Jena and RDF4J allow null graph terms in the input, 
+            // so we do not treat them as errors.
             return null;
         }
 

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
@@ -18,8 +18,6 @@ public abstract class EncoderBase<TNode> implements RdfBufferAppender<TNode> {
         OBJECT,
         GRAPH,
         NAMESPACE,
-        // Temporary. TODO: remove
-        NAMESPACE_GRAPH,
         HEADER,
     }
 
@@ -33,7 +31,7 @@ public abstract class EncoderBase<TNode> implements RdfBufferAppender<TNode> {
 
     protected SpoTerm currentTerm = SpoTerm.SUBJECT;
     private SpoBase.Setters currentSpoBase = null;
-    private GraphBase.Setters currentGraphBase = null;
+    protected GraphBase.Setters currentGraphBase = null;
     protected NsBase.Setters currentNsBase = null;
     protected HeaderBase.Setters currentHeaderBase = null;
 
@@ -103,7 +101,7 @@ public abstract class EncoderBase<TNode> implements RdfBufferAppender<TNode> {
         }
     }
 
-    private void graphNodeToProtoWrapped(TNode node) {
+    protected final void graphNodeToProtoWrapped(TNode node) {
         // Graph nodes may be null in Jena for example... so we need to handle that.
         if ((node != null || lastGraph != null) && (node == null || !node.equals(lastGraph))) {
             lastGraph = node;
@@ -120,7 +118,6 @@ public abstract class EncoderBase<TNode> implements RdfBufferAppender<TNode> {
             case OBJECT -> currentSpoBase.setOIri(iri);
             case GRAPH -> currentGraphBase.setGIri(iri);
             case NAMESPACE -> currentNsBase.setValue(iri);
-            case NAMESPACE_GRAPH -> currentNsBase.setGraph(iri);
             case HEADER -> currentHeaderBase.setHIri(iri);
         }
     }

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/proto/NsBase.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/proto/NsBase.java
@@ -5,11 +5,5 @@ import eu.neverblink.jelly.core.proto.v1.RdfIri;
 public interface NsBase {
     interface Setters extends NsBase {
         NsBase setValue(RdfIri iri);
-
-        // Temporary. This will be removed when we change the namespace graph term to the same
-        // as the graph term in RdfQuad.
-        default NsBase setGraph(RdfIri iri) {
-            return null;
-        }
     }
 }

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/JellyPatchConstants.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/JellyPatchConstants.java
@@ -8,7 +8,7 @@ public class JellyPatchConstants {
     private JellyPatchConstants() {}
 
     public static final String JELLY_PATCH_NAME = "Jelly-Patch";
-    public static final String JELLY_PATCH_FILE_EXTENSION = "jelly-patch";
+    public static final String JELLY_PATCH_FILE_EXTENSION = "jellyp";
     public static final String JELLY_PATCH_CONTENT_TYPE = "application/x-jelly-rdf-patch";
 
     public static final int PROTO_VERSION_1_0_X = 1;

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchHandler.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchHandler.java
@@ -29,7 +29,8 @@ public interface PatchHandler<TNode> {
      *
      * @param name     the name of the namespace (without the trailing colon, required)
      * @param iriValue the IRI value of the namespace (required)
-     * @param graph    the named graph to which the namespace belongs (optional)
+     * @param graph    the named graph to which the namespace belongs
+     *                 (required in QUADS streams, always null in TRIPLES streams)
      */
     void addNamespace(String name, TNode iriValue, TNode graph);
 
@@ -39,7 +40,8 @@ public interface PatchHandler<TNode> {
      *
      * @param name     the name of the namespace (without the trailing colon, required)
      * @param iriValue the IRI value of the namespace (optional)
-     * @param graph    the named graph to which the namespace belongs (optional)
+     * @param graph    the graph to which the namespace belongs
+     *                 (required in QUADS streams, always null in TRIPLES streams)
      */
     void deleteNamespace(String name, TNode iriValue, TNode graph);
 

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -3,7 +3,6 @@ package eu.neverblink.jelly.core.patch.internal;
 import eu.neverblink.jelly.core.*;
 import eu.neverblink.jelly.core.patch.PatchEncoder;
 import eu.neverblink.jelly.core.proto.v1.RdfDatatypeEntry;
-import eu.neverblink.jelly.core.proto.v1.RdfIri;
 import eu.neverblink.jelly.core.proto.v1.RdfNameEntry;
 import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntry;
 import eu.neverblink.jelly.core.proto.v1.patch.*;
@@ -126,8 +125,9 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
             converter.nodeToProto(nodeEncoder.provide(), iriValue);
         }
         if (graph != null) {
-            this.currentTerm = SpoTerm.NAMESPACE_GRAPH;
-            converter.nodeToProto(nodeEncoder.provide(), graph);
+            this.currentGraphBase = namespace;
+            this.currentTerm = SpoTerm.GRAPH;
+            this.graphNodeToProtoWrapped(graph);
         }
         return namespace;
     }

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchDecoderSpec.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchDecoderSpec.scala
@@ -265,6 +265,19 @@ class PatchDecoderSpec extends AnyWordSpec, Matchers:
       out.statements.result() shouldBe PatchTestCases.Quads1.mrl
     }
 
+    "decode quads with generalized namespace declarations" in {
+      val input = PatchTestCases.Quads2NsDeclOnly.encodedFull(
+        JellyPatchOptions.SMALL_STRICT.clone
+          .setStatementType(PatchStatementType.QUADS)
+          .setStreamType(PatchStreamType.FLAT),
+        10_000
+      ).head
+      val out = PatchCollector()
+      val decoder = MockPatchConverterFactory.quadsDecoder(out, null)
+      decoder.ingestFrame(input)
+      out.statements.result() shouldBe PatchTestCases.Quads2NsDeclOnly.mrl
+    }
+
     "not accept a stream with statement type TRIPLES" in {
       val input = rdfPatchFrame(Seq(
         rdfPatchRow(JellyPatchOptions.SMALL_STRICT.clone

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/Mpl.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/Mpl.scala
@@ -7,7 +7,7 @@ import eu.neverblink.jelly.core.patch.PatchHandler.AnyPatchHandler
  * "Mpl" stands for "mock RDF patch library".
  */
 object Mpl:
-  final case class NsDecl(prefix: String, iri: Iri = null, graph: Iri = null)
+  final case class NsDecl(prefix: String, iri: Iri = null, graph: Node = null)
   
   sealed trait PatchStatement:
     /**

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
@@ -87,13 +87,12 @@ object PatchAdapter:
       .setKey(key)
       .setHTripleTerm(value)
 
-  def rdfPatchNamespace(name: String, value: RdfIri = null, graph: RdfIri = null): RdfPatchNamespace = {
+  // Set the graph yourself on the returned object
+  def rdfPatchNamespace(name: String, value: RdfIri = null): RdfPatchNamespace.Mutable =
     val ns = RdfPatchNamespace.newInstance()
     if (name != null) ns.setName(name)
     if (value != null) ns.setValue(value)
-    if (graph != null) ns.setGraph(graph)
     ns
-  }
 
   def rdfPatchPunctuation(): RdfPatchPunctuation =
     RdfPatchPunctuation.newInstance()

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchCollector.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchCollector.scala
@@ -35,10 +35,10 @@ final class PatchCollector extends AnyPatchHandler[Mrl.Node]:
     statements += Mpl.TxAbort
 
   def addNamespace(name: String, iriValue: Mrl.Node, graph: Mrl.Node): Unit =
-    statements += Mpl.Add(Mpl.NsDecl(name, iriValue.asInstanceOf[Mrl.Iri], graph.asInstanceOf[Mrl.Iri]))
+    statements += Mpl.Add(Mpl.NsDecl(name, iriValue.asInstanceOf[Mrl.Iri], graph))
 
   def deleteNamespace(name: String, iriValue: Mrl.Node, graph: Mrl.Node): Unit =
-    statements += Mpl.Delete(Mpl.NsDecl(name, iriValue.asInstanceOf[Mrl.Iri], graph.asInstanceOf[Mrl.Iri]))
+    statements += Mpl.Delete(Mpl.NsDecl(name, iriValue.asInstanceOf[Mrl.Iri], graph))
 
   def header(key: String, value: Mrl.Node): Unit =
     statements += Mpl.Header(key, value)

--- a/rdf-protos-java/src/main/args.txt
+++ b/rdf-protos-java/src/main/args.txt
@@ -8,8 +8,10 @@ implements_RdfGraphStart=eu.neverblink.jelly.core.internal.proto.GraphBase,
 implements_RdfGraphStart.Mutable=eu.neverblink.jelly.core.internal.proto.GraphBase.Setters,
 implements_RdfNamespaceDeclaration=eu.neverblink.jelly.core.internal.proto.NsBase,
 implements_RdfNamespaceDeclaration.Mutable=eu.neverblink.jelly.core.internal.proto.NsBase.Setters,
-implements_RdfPatchNamespace=eu.neverblink.jelly.core.internal.proto.NsBase,
-implements_RdfPatchNamespace.Mutable=eu.neverblink.jelly.core.internal.proto.NsBase.Setters,
+implements_RdfPatchNamespace=eu.neverblink.jelly.core.internal.proto.NsBase;
+    eu.neverblink.jelly.core.internal.proto.GraphBase,
+implements_RdfPatchNamespace.Mutable=eu.neverblink.jelly.core.internal.proto.NsBase.Setters;
+    eu.neverblink.jelly.core.internal.proto.GraphBase.Setters,
 implements_RdfPatchHeader=eu.neverblink.jelly.core.internal.proto.HeaderBase,
 implements_RdfPatchHeader.Mutable=eu.neverblink.jelly.core.internal.proto.HeaderBase.Setters,
 replace_package=eu.ostrzyciel=eu.neverblink


### PR DESCRIPTION
Issue: https://github.com/Jelly-RDF/jelly-protobuf/issues/11

Depends on (**merge it first, then change the submodule branch here to main!**): https://github.com/Jelly-RDF/jelly-protobuf/pull/67

Allow any graph term to be used in namespace declarations, not only IRIs. This actually simplifies the code a bit.

@nk2IsHere **importantes** this may break the integration tests for Patch, but I have no way of fixing them now. Please just keep it in mind when later restoring them.