### PR TITLE
Rewrite titanium to java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -436,6 +436,23 @@ lazy val titaniumRdfApi = (project in file("titanium-rdf-api"))
   )
   .dependsOn(core)
 
+lazy val titaniumRdfApiJava = (project in file("titanium-rdf-api-java"))
+  .settings(
+    name := "jelly-titanium-rdf-api-java",
+    organization := "eu.neverblink.jelly",
+    description := "Implementation of the Titanium RDF API for Jelly-JVM. " +
+      "See: https://github.com/filip26/titanium-rdf-api \n\n" +
+      "If you are already using RDF4J or Jena, it's recommended to use their dedicated " +
+      "integration modules instead of this one for better performance and more features." +
+      "\n\n This is the Java version of the Titanium RDF API adapter.",
+    libraryDependencies ++= Seq(
+      "com.apicatalog" % "titanium-rdf-api" % titaniumApiV,
+    ),
+    publishArtifact := false, // TODO: remove this when ready
+    commonSettings,
+  )
+  .dependsOn(coreJava)
+
 lazy val stream = (project in file("stream"))
   .settings(
     name := "jelly-stream",

--- a/build.sbt
+++ b/build.sbt
@@ -451,7 +451,7 @@ lazy val titaniumRdfApiJava = (project in file("titanium-rdf-api-java"))
     publishArtifact := false, // TODO: remove this when ready
     commonSettings,
   )
-  .dependsOn(coreJava)
+  .dependsOn(coreJava % "compile->compile;test->test")
 
 lazy val stream = (project in file("stream"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -539,7 +539,7 @@ lazy val integrationTestsJava = (project in file("integration-tests-java"))
     jenaPatch % "compile->compile;test->test",
     rdf4jJava,
     rdf4jPatch,
-    // titaniumRdfApi,
+    titaniumRdfApiJava,
   )
 
 lazy val examples = (project in file("examples"))

--- a/core-java/src/main/java/eu/neverblink/jelly/core/ProtoEncoder.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/ProtoEncoder.java
@@ -91,4 +91,12 @@ public abstract class ProtoEncoder<TNode>
     protected int getDatatypeTableSize() {
         return options.getMaxDatatypeTableSize();
     }
+
+    /**
+     * Returns the options for this encoder.
+     * @return the options for this encoder
+     */
+    public RdfStreamOptions getOptions() {
+        return options;
+    }
 }

--- a/core-java/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
+++ b/core-java/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
@@ -14,6 +14,10 @@ object RdfAdapter:
       .setId(id)
       .setValue(value)
 
+  def rdfNameEntry(value: String): RdfNameEntry =
+    RdfNameEntry.newInstance()
+      .setValue(value)
+
   def rdfPrefixEntry(id: Int, value: String): RdfPrefixEntry =
     RdfPrefixEntry.newInstance()
       .setId(id)

--- a/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
+++ b/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
@@ -159,7 +159,6 @@ class GeneralizedRdfSpec extends AnyWordSpec, Matchers, JenaTest:
 //    parsingFailureTests(Rdf4jReactiveSerDes(), boxed = true)
 //  }
 
-  // TODO: re-enable when the Titanium module is available
-//  "Titanium implementation" should {
-//    parsingFailureTests(TitaniumSerDes)
-//  }
+  "Titanium implementation" should {
+    parsingFailureTests(TitaniumSerDes)
+  }

--- a/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/IoSerDesSpec.scala
+++ b/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/IoSerDesSpec.scala
@@ -128,17 +128,17 @@ class IoSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
 //  runTest(JenaReactiveSerDes(), Rdf4jReactiveSerDes())
 
   // Titanium as serializer
-//  runTest(TitaniumSerDes, TitaniumSerDes)
-//  runTest(TitaniumSerDes, JenaSerDes)
-//  runTest(TitaniumSerDes, JenaStreamSerDes)
-//  runTest(TitaniumSerDes, Rdf4jSerDes)
+  runTest(TitaniumSerDes, TitaniumSerDes)
+  runTest(TitaniumSerDes, JenaSerDes)
+  runTest(TitaniumSerDes, JenaStreamSerDes)
+  runTest(TitaniumSerDes, Rdf4jSerDes)
 //  runTest(TitaniumSerDes, Rdf4jReactiveSerDes())
 //  runTest(TitaniumSerDes, JenaReactiveSerDes())
 
   // Titanium as deserializer
-//  runTest(JenaSerDes, TitaniumSerDes)
-//  runTest(JenaStreamSerDes, TitaniumSerDes)
-//  runTest(Rdf4jSerDes, TitaniumSerDes)
+  runTest(JenaSerDes, TitaniumSerDes)
+  runTest(JenaStreamSerDes, TitaniumSerDes)
+  runTest(Rdf4jSerDes, TitaniumSerDes)
 //  runTest(Rdf4jReactiveSerDes(), TitaniumSerDes)
 //  runTest(JenaReactiveSerDes(), TitaniumSerDes)
 

--- a/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/TitaniumSerDes.scala
+++ b/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/TitaniumSerDes.scala
@@ -1,52 +1,52 @@
-//package eu.neverblink.jelly.integration_tests.rdf.io
-//
-//import com.apicatalog.rdf.nquads.NQuadsReader
-//import com.apicatalog.rdf.{RdfDataset, RdfDatasetSupplier}
-//import eu.neverblink.jelly.convert.titanium.{TitaniumJellyReader, TitaniumJellyWriter}
-//import eu.neverblink.jelly.core.JellyOptions
-//import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions
-//import eu.neverblink.jelly.integration_tests.rdf.helpers.TitaniumDatasetEmitter
-//import eu.neverblink.jelly.integration_tests.util.Measure
-//
-//import java.io.{InputStream, InputStreamReader, OutputStream}
-//
-//given mTitaniumDataset: Measure[RdfDataset] = (ds: RdfDataset) => ds.size
-//
-//object TitaniumSerDes extends NativeSerDes[RdfDataset, RdfDataset]:
-//
-//  override def name: String = "Titanium"
-//
-//  override def supportsRdfStar: Boolean = false
-//
-//  override def supportsGeneralizedStatements: Boolean = false
-//
-//  override def readTriplesW3C(is: InputStream): RdfDataset =
-//    val reader = NQuadsReader(InputStreamReader(is))
-//    val ds = RdfDatasetSupplier()
-//    reader.provide(ds)
-//    ds.get()
-//
-//  override def readQuadsW3C(is: InputStream): RdfDataset = readTriplesW3C(is)
-//
-//  override def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): RdfDataset =
-//    val reader = TitaniumJellyReader.factory(
-//      supportedOptions.getOrElse(JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
-//    )
-//    val ds = RdfDatasetSupplier()
-//    reader.parseAll(ds, is)
-//    ds.get()
-//
-//  override def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): RdfDataset =
-//    readTriplesJelly(is, supportedOptions)
-//
-//  override def writeTriplesJelly(os: OutputStream, model: RdfDataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
-//    val writer = TitaniumJellyWriter.factory(
-//      os,
-//      opt.getOrElse(JellyOptions.SMALL_STRICT),
-//      frameSize,
-//    )
-//    TitaniumDatasetEmitter.emitDatasetTo(model, writer)
-//    writer.close()
-//
-//  override def writeQuadsJelly(os: OutputStream, dataset: RdfDataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
-//    writeTriplesJelly(os, dataset, opt, frameSize)
+package eu.neverblink.jelly.integration_tests.rdf.io
+
+import com.apicatalog.rdf.nquads.NQuadsReader
+import com.apicatalog.rdf.{RdfDataset, RdfDatasetSupplier}
+import eu.neverblink.jelly.convert.titanium.{TitaniumJellyReader, TitaniumJellyWriter}
+import eu.neverblink.jelly.core.JellyOptions
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions
+import eu.neverblink.jelly.integration_tests.rdf.helpers.TitaniumDatasetEmitter
+import eu.neverblink.jelly.integration_tests.util.Measure
+
+import java.io.{InputStream, InputStreamReader, OutputStream}
+
+given mTitaniumDataset: Measure[RdfDataset] = (ds: RdfDataset) => ds.size
+
+object TitaniumSerDes extends NativeSerDes[RdfDataset, RdfDataset]:
+
+  override def name: String = "Titanium"
+
+  override def supportsRdfStar: Boolean = false
+
+  override def supportsGeneralizedStatements: Boolean = false
+
+  override def readTriplesW3C(is: InputStream): RdfDataset =
+    val reader = NQuadsReader(InputStreamReader(is))
+    val ds = RdfDatasetSupplier()
+    reader.provide(ds)
+    ds.get()
+
+  override def readQuadsW3C(is: InputStream): RdfDataset = readTriplesW3C(is)
+
+  override def readTriplesJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): RdfDataset =
+    val reader = TitaniumJellyReader.factory(
+      supportedOptions.getOrElse(JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+    )
+    val ds = RdfDatasetSupplier()
+    reader.parseAll(ds, is)
+    ds.get()
+
+  override def readQuadsJelly(is: InputStream, supportedOptions: Option[RdfStreamOptions]): RdfDataset =
+    readTriplesJelly(is, supportedOptions)
+
+  override def writeTriplesJelly(os: OutputStream, model: RdfDataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
+    val writer = TitaniumJellyWriter.factory(
+      os,
+      opt.getOrElse(JellyOptions.SMALL_STRICT),
+      frameSize,
+    )
+    TitaniumDatasetEmitter.emitDatasetTo(model, writer)
+    writer.close()
+
+  override def writeQuadsJelly(os: OutputStream, dataset: RdfDataset, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
+    writeTriplesJelly(os, dataset, opt, frameSize)

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
@@ -8,57 +8,57 @@ import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
 import eu.neverblink.jelly.core.RdfHandler;
 import eu.neverblink.jelly.core.RdfProtoDeserializationError;
 
-final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandler<TitaniumNode> {
+final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandler<Object> {
 
     private RdfQuadConsumer consumer;
 
     @Override
-    public void handleQuad(TitaniumNode s, TitaniumNode p, TitaniumNode o, TitaniumNode g) {
+    public void handleQuad(Object s, Object p, Object o, Object g) {
         try {
-            switch (o.type()) {
+            switch (TitaniumNode.typeOf(o)) {
                 case IRI, BLANK -> consumer.quad(
-                    s.asStringValue(),
-                    p.asStringValue(),
-                    o.asStringValue(),
+                    TitaniumNode.iriLikeOf(s),
+                    TitaniumNode.iriLikeOf(p),
+                    TitaniumNode.iriLikeOf(o),
                     null,
                     null,
                     null,
-                    g != null ? g.asStringValue() : null
+                    TitaniumNode.iriLikeOf(g)
                 );
                 case LANG_LITERAL -> {
-                    final var langLiteral = o.asLangLiteral();
+                    final var langLiteral = TitaniumNode.langLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         langLiteral.lex(),
                         DT_LANG_STRING,
                         langLiteral.lang(),
                         null,
-                        g != null ? g.asStringValue() : null
+                        TitaniumNode.iriLikeOf(g)
                     );
                 }
                 case SIMPLE_LITERAL -> {
-                    var simpleLiteral = o.asSimpleLiteral();
+                    var simpleLiteral = TitaniumNode.simpleLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         simpleLiteral.lex(),
                         DT_STRING,
                         null,
                         null,
-                        g != null ? g.asStringValue() : null
+                        TitaniumNode.iriLikeOf(g)
                     );
                 }
                 case DT_LITERAL -> {
-                    var dtLiteral = o.asDtLiteral();
+                    var dtLiteral = TitaniumNode.dtLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         dtLiteral.lex(),
                         dtLiteral.dt(),
                         null,
                         null,
-                        g != null ? g.asStringValue() : null
+                        TitaniumNode.iriLikeOf(g)
                     );
                 }
             }
@@ -68,23 +68,23 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
     }
 
     @Override
-    public void handleTriple(TitaniumNode s, TitaniumNode p, TitaniumNode o) {
+    public void handleTriple(Object s, Object p, Object o) {
         try {
-            switch (o.type()) {
+            switch (TitaniumNode.typeOf(o)) {
                 case IRI, BLANK -> consumer.quad(
-                    s.asStringValue(),
-                    p.asStringValue(),
-                    o.asStringValue(),
+                    TitaniumNode.iriLikeOf(s),
+                    TitaniumNode.iriLikeOf(p),
+                    TitaniumNode.iriLikeOf(o),
                     null,
                     null,
                     null,
                     null
                 );
                 case LANG_LITERAL -> {
-                    final var langLiteral = o.asLangLiteral();
+                    final var langLiteral = TitaniumNode.langLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         langLiteral.lex(),
                         DT_LANG_STRING,
                         langLiteral.lang(),
@@ -93,10 +93,10 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
                     );
                 }
                 case SIMPLE_LITERAL -> {
-                    var simpleLiteral = o.asSimpleLiteral();
+                    var simpleLiteral = TitaniumNode.simpleLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         simpleLiteral.lex(),
                         DT_STRING,
                         null,
@@ -105,10 +105,10 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
                     );
                 }
                 case DT_LITERAL -> {
-                    var dtLiteral = o.asDtLiteral();
+                    var dtLiteral = TitaniumNode.dtLiteralOf(o);
                     consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
+                        TitaniumNode.iriLikeOf(s),
+                        TitaniumNode.iriLikeOf(p),
                         dtLiteral.lex(),
                         dtLiteral.dt(),
                         null,

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
@@ -3,10 +3,10 @@ package eu.neverblink.jelly.convert.titanium;
 import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_LANG_STRING;
 import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_STRING;
 
-import com.apicatalog.rdf.api.RdfConsumerException;
 import com.apicatalog.rdf.api.RdfQuadConsumer;
 import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
 import eu.neverblink.jelly.core.RdfHandler;
+import eu.neverblink.jelly.core.RdfProtoDeserializationError;
 
 final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandler<TitaniumNode> {
 
@@ -16,18 +16,16 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
     public void handleQuad(TitaniumNode s, TitaniumNode p, TitaniumNode o, TitaniumNode g) {
         try {
             switch (o.type()) {
-                case IRI:
-                    consumer.quad(
-                        s.asStringValue(),
-                        p.asStringValue(),
-                        o.asStringValue(),
-                        null,
-                        null,
-                        null,
-                        g.asStringValue()
-                    );
-                    break;
-                case LANG_LITERAL:
+                case IRI, BLANK -> consumer.quad(
+                    s.asStringValue(),
+                    p.asStringValue(),
+                    o.asStringValue(),
+                    null,
+                    null,
+                    null,
+                    g != null ? g.asStringValue() : null
+                );
+                case LANG_LITERAL -> {
                     final var langLiteral = o.asLangLiteral();
                     consumer.quad(
                         s.asStringValue(),
@@ -36,10 +34,10 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
                         DT_LANG_STRING,
                         langLiteral.lang(),
                         null,
-                        g.asStringValue()
+                        g != null ? g.asStringValue() : null
                     );
-                    break;
-                case SIMPLE_LITERAL:
+                }
+                case SIMPLE_LITERAL -> {
                     var simpleLiteral = o.asSimpleLiteral();
                     consumer.quad(
                         s.asStringValue(),
@@ -48,10 +46,10 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
                         DT_STRING,
                         null,
                         null,
-                        g.asStringValue()
+                        g != null ? g.asStringValue() : null
                     );
-                    break;
-                case DT_LITERAL:
+                }
+                case DT_LITERAL -> {
                     var dtLiteral = o.asDtLiteral();
                     consumer.quad(
                         s.asStringValue(),
@@ -60,18 +58,68 @@ final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandle
                         dtLiteral.dt(),
                         null,
                         null,
-                        g.asStringValue()
+                        g != null ? g.asStringValue() : null
                     );
-                    break;
+                }
             }
-        } catch (RdfConsumerException e) {
-            throw new IllegalStateException(e);
+        } catch (Exception e) {
+            throw new RdfProtoDeserializationError("Could not parse generalized quad statement", e);
         }
     }
 
     @Override
     public void handleTriple(TitaniumNode s, TitaniumNode p, TitaniumNode o) {
-        throw new UnsupportedOperationException("Triple not supported in Titanium Jelly");
+        try {
+            switch (o.type()) {
+                case IRI, BLANK -> consumer.quad(
+                    s.asStringValue(),
+                    p.asStringValue(),
+                    o.asStringValue(),
+                    null,
+                    null,
+                    null,
+                    null
+                );
+                case LANG_LITERAL -> {
+                    final var langLiteral = o.asLangLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        langLiteral.lex(),
+                        DT_LANG_STRING,
+                        langLiteral.lang(),
+                        null,
+                        null
+                    );
+                }
+                case SIMPLE_LITERAL -> {
+                    var simpleLiteral = o.asSimpleLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        simpleLiteral.lex(),
+                        DT_STRING,
+                        null,
+                        null,
+                        null
+                    );
+                }
+                case DT_LITERAL -> {
+                    var dtLiteral = o.asDtLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        dtLiteral.lex(),
+                        dtLiteral.dt(),
+                        null,
+                        null,
+                        null
+                    );
+                }
+            }
+        } catch (Exception e) {
+            throw new RdfProtoDeserializationError("Could not parse generalized triple statement", e);
+        }
     }
 
     public void assignConsumer(RdfQuadConsumer consumer) {

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumAnyStatementHandler.java
@@ -1,0 +1,80 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_LANG_STRING;
+import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_STRING;
+
+import com.apicatalog.rdf.api.RdfConsumerException;
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
+import eu.neverblink.jelly.core.RdfHandler;
+
+final class TitaniumAnyStatementHandler implements RdfHandler.AnyStatementHandler<TitaniumNode> {
+
+    private RdfQuadConsumer consumer;
+
+    @Override
+    public void handleQuad(TitaniumNode s, TitaniumNode p, TitaniumNode o, TitaniumNode g) {
+        try {
+            switch (o.type()) {
+                case IRI:
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        o.asStringValue(),
+                        null,
+                        null,
+                        null,
+                        g.asStringValue()
+                    );
+                    break;
+                case LANG_LITERAL:
+                    final var langLiteral = o.asLangLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        langLiteral.lex(),
+                        DT_LANG_STRING,
+                        langLiteral.lang(),
+                        null,
+                        g.asStringValue()
+                    );
+                    break;
+                case SIMPLE_LITERAL:
+                    var simpleLiteral = o.asSimpleLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        simpleLiteral.lex(),
+                        DT_STRING,
+                        null,
+                        null,
+                        g.asStringValue()
+                    );
+                    break;
+                case DT_LITERAL:
+                    var dtLiteral = o.asDtLiteral();
+                    consumer.quad(
+                        s.asStringValue(),
+                        p.asStringValue(),
+                        dtLiteral.lex(),
+                        dtLiteral.dt(),
+                        null,
+                        null,
+                        g.asStringValue()
+                    );
+                    break;
+            }
+        } catch (RdfConsumerException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void handleTriple(TitaniumNode s, TitaniumNode p, TitaniumNode o) {
+        throw new UnsupportedOperationException("Triple not supported in Titanium Jelly");
+    }
+
+    public void assignConsumer(RdfQuadConsumer consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumConstants.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumConstants.java
@@ -1,0 +1,10 @@
+package eu.neverblink.jelly.convert.titanium;
+
+public final class TitaniumConstants {
+
+    private TitaniumConstants() {}
+
+    // https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
+    public static final String DT_STRING = "http://www.w3.org/2001/XMLSchema#string";
+    public static final String DT_LANG_STRING = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoder.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoder.java
@@ -1,7 +1,6 @@
 package eu.neverblink.jelly.convert.titanium;
 
 import com.apicatalog.rdf.api.RdfQuadConsumer;
-import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
 import eu.neverblink.jelly.core.JellyOptions;
 import eu.neverblink.jelly.core.RdfHandler;
 import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
@@ -26,7 +25,7 @@ public interface TitaniumJellyDecoder {
      */
     static TitaniumJellyDecoder factory(
         RdfStreamOptions supportedOptions,
-        RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler
+        RdfHandler.AnyStatementHandler<Object> anyStatementHandler
     ) {
         return new TitaniumJellyDecoderImpl(supportedOptions, anyStatementHandler);
     }
@@ -36,7 +35,7 @@ public interface TitaniumJellyDecoder {
      * This method uses the default supported options.
      * @return TitaniumJellyDecoder
      */
-    static TitaniumJellyDecoder factory(RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler) {
+    static TitaniumJellyDecoder factory(RdfHandler.AnyStatementHandler<Object> anyStatementHandler) {
         return factory(JellyOptions.DEFAULT_SUPPORTED_OPTIONS, anyStatementHandler);
     }
 

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoder.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoder.java
@@ -1,0 +1,68 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
+import eu.neverblink.jelly.core.JellyOptions;
+import eu.neverblink.jelly.core.RdfHandler;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamRow;
+
+/**
+ * Low-level decoder of Jelly data. You can use this for implementing your own Jelly deserializers.
+ * Alternatively, you can use the ready-made TitaniumJellyReader for a higher-level API.
+ * @since 2.9.0
+ */
+public interface TitaniumJellyDecoder {
+    /**
+     * Factory method to create a new TitaniumJellyDecoder instance.
+     * @param supportedOptions Maximum supported options of the Jelly parser. You can use this to
+     *                         increase the limit on the lookup table size, for example. You should
+     *                         always first obtain the default options from
+     *                         JellyOptions.defaultSupportedOptions() and then modify them as needed.
+     * @param anyStatementHandler The handler to use for the AnyStatementHandler. This is used to
+     *                            handle the decoded data output.
+     * @return TitaniumJellyDecoder
+     */
+    static TitaniumJellyDecoder factory(
+        RdfStreamOptions supportedOptions,
+        RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler
+    ) {
+        return new TitaniumJellyDecoderImpl(supportedOptions, anyStatementHandler);
+    }
+
+    /**
+     * Factory method to create a new TitaniumJellyDecoder instance.
+     * This method uses the default supported options.
+     * @return TitaniumJellyDecoder
+     */
+    static TitaniumJellyDecoder factory(RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler) {
+        return factory(JellyOptions.DEFAULT_SUPPORTED_OPTIONS, anyStatementHandler);
+    }
+
+    /**
+     * Ingests a frame of Jelly-RDF data and sends the quads to the consumer.
+     * <p>
+     * The consumer's `quad` method will be called zero or more times per frame, corresponding to
+     * the number of quads in the frame.
+     * @param consumer The consumer to send the quads to.
+     * @param frame The frame to ingest.
+     */
+    void ingestFrame(RdfQuadConsumer consumer, RdfStreamFrame frame);
+
+    /**
+     * Ingests a row of Jelly-RDF data and sends the quads to the consumer.
+     * <p>
+     * The consumer's `quad` method will be called zero or one times per row, corresponding to
+     * the number of quads in the row.
+     * @param consumer The consumer to send the quads to.
+     * @param row The row to ingest.
+     */
+    void ingestRow(RdfQuadConsumer consumer, RdfStreamRow row);
+
+    /**
+     * Returns the supported options that this decoder uses.
+     * @return RdfStreamOptions
+     */
+    RdfStreamOptions getSupportedOptions();
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoderImpl.java
@@ -2,7 +2,6 @@ package eu.neverblink.jelly.convert.titanium;
 
 import com.apicatalog.rdf.api.RdfQuadConsumer;
 import eu.neverblink.jelly.convert.titanium.internal.TitaniumConverterFactory;
-import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
 import eu.neverblink.jelly.core.InternalApi;
 import eu.neverblink.jelly.core.ProtoDecoder;
 import eu.neverblink.jelly.core.RdfHandler;
@@ -17,11 +16,11 @@ class TitaniumJellyDecoderImpl implements TitaniumJellyDecoder {
 
     // Decode any physical stream type. Titanium only supports quads, but that's fine. We will
     // implicitly put triples in the default graph.
-    private final ProtoDecoder<TitaniumNode, String> decoder;
+    private final ProtoDecoder<Object, String> decoder;
 
     public TitaniumJellyDecoderImpl(
         RdfStreamOptions supportedOptions,
-        RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler
+        RdfHandler.AnyStatementHandler<Object> anyStatementHandler
     ) {
         this.supportedOptions = supportedOptions;
         this.decoder = TitaniumConverterFactory.getInstance()

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyDecoderImpl.java
@@ -1,0 +1,47 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumConverterFactory;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
+import eu.neverblink.jelly.core.InternalApi;
+import eu.neverblink.jelly.core.ProtoDecoder;
+import eu.neverblink.jelly.core.RdfHandler;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamRow;
+
+@InternalApi
+class TitaniumJellyDecoderImpl implements TitaniumJellyDecoder {
+
+    private final RdfStreamOptions supportedOptions;
+
+    // Decode any physical stream type. Titanium only supports quads, but that's fine. We will
+    // implicitly put triples in the default graph.
+    private final ProtoDecoder<TitaniumNode, String> decoder;
+
+    public TitaniumJellyDecoderImpl(
+        RdfStreamOptions supportedOptions,
+        RdfHandler.AnyStatementHandler<TitaniumNode> anyStatementHandler
+    ) {
+        this.supportedOptions = supportedOptions;
+        this.decoder = TitaniumConverterFactory.getInstance()
+            .anyStatementDecoder(anyStatementHandler, supportedOptions);
+    }
+
+    @Override
+    public void ingestFrame(RdfQuadConsumer consumer, RdfStreamFrame frame) {
+        for (final var row : frame.getRows()) {
+            ingestRow(consumer, row);
+        }
+    }
+
+    @Override
+    public void ingestRow(RdfQuadConsumer consumer, RdfStreamRow row) {
+        decoder.ingestRow(row);
+    }
+
+    @Override
+    public RdfStreamOptions getSupportedOptions() {
+        return supportedOptions;
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
@@ -42,6 +42,12 @@ public interface TitaniumJellyEncoder extends RdfQuadConsumer {
     Iterable<RdfStreamRow> getRows();
 
     /**
+     * Clears the encoded row buffer.
+     * This method is called automatically when the buffer is flushed.
+     */
+    void clearRows();
+
+    /**
      * Returns the options that this encoder uses.
      * @return RdfStreamOptions
      */

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
@@ -1,0 +1,49 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.core.JellyOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamRow;
+
+/**
+ * Low-level encoder of Jelly data. You can use this for implementing your own Jelly serializers.
+ * Alternatively, you can use the ready-made TitaniumJellyWriter for a higher-level API.
+ * @since 2.9.0
+ */
+public interface TitaniumJellyEncoder extends RdfQuadConsumer {
+    /**
+     * Factory method to create a new TitaniumJellyEncoder instance.
+     * @param options The options to use for encoding.
+     * @return TitaniumJellyEncoder
+     */
+    static TitaniumJellyEncoder factory(RdfStreamOptions options) {
+        return new TitaniumJellyEncoderImpl(options);
+    }
+
+    /**
+     * Factory method to create a new TitaniumJellyEncoder instance.
+     * This method uses the default options.
+     * @return TitaniumJellyEncoder
+     */
+    static TitaniumJellyEncoder factory() {
+        return factory(JellyOptions.SMALL_STRICT);
+    }
+
+    /**
+     * Returns the number of rows currently in the encoded row buffer.
+     * @return int
+     */
+    int getRowCount();
+
+    /**
+     * Returns the rows in the encoded row buffer as a collection and clears the buffer.
+     * @return java.util.Iterable<RdfStreamRow>
+     */
+    Iterable<RdfStreamRow> getRows();
+
+    /**
+     * Returns the options that this encoder uses.
+     * @return RdfStreamOptions
+     */
+    RdfStreamOptions getOptions();
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
@@ -7,6 +7,7 @@ import com.apicatalog.rdf.api.RdfQuadConsumer;
 import eu.neverblink.jelly.convert.titanium.internal.TitaniumConverterFactory;
 import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
 import eu.neverblink.jelly.core.ProtoEncoder;
+import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.proto.v1.LogicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.PhysicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
@@ -42,6 +43,11 @@ final class TitaniumJellyEncoderImpl implements TitaniumJellyEncoder {
     @Override
     public Iterable<RdfStreamRow> getRows() {
         return buffer;
+    }
+
+    @Override
+    public void clearRows() {
+        buffer.clear();
     }
 
     @Override
@@ -86,7 +92,7 @@ final class TitaniumJellyEncoderImpl implements TitaniumJellyEncoder {
                     new TitaniumNode.StringNode(graph)
                 );
             }
-        } catch (final Exception e) {
+        } catch (RdfProtoSerializationError e) {
             throw new RdfConsumerException(e.getMessage(), e);
         }
 

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
@@ -5,7 +5,7 @@ import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_STRING;
 import com.apicatalog.rdf.api.RdfConsumerException;
 import com.apicatalog.rdf.api.RdfQuadConsumer;
 import eu.neverblink.jelly.convert.titanium.internal.TitaniumConverterFactory;
-import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumLiteral;
 import eu.neverblink.jelly.core.ProtoEncoder;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.proto.v1.LogicalStreamType;
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 final class TitaniumJellyEncoderImpl implements TitaniumJellyEncoder {
 
-    private final ProtoEncoder<TitaniumNode> encoder;
+    private final ProtoEncoder<Object> encoder;
 
     private final Collection<RdfStreamRow> buffer = new ArrayList<>();
 
@@ -69,28 +69,18 @@ final class TitaniumJellyEncoderImpl implements TitaniumJellyEncoder {
         // intermediate objects.
         try {
             if (RdfQuadConsumer.isLiteral(datatype, language, direction)) {
-                final TitaniumNode literal;
+                final TitaniumLiteral literal;
                 if (RdfQuadConsumer.isLangString(datatype, language, direction)) {
-                    literal = new TitaniumNode.LangLiteral(object, language);
+                    literal = new TitaniumLiteral.LangLiteral(object, language);
                 } else if (datatype.equals(DT_STRING)) {
-                    literal = new TitaniumNode.SimpleLiteral(object);
+                    literal = new TitaniumLiteral.SimpleLiteral(object);
                 } else {
-                    literal = new TitaniumNode.DtLiteral(object, datatype);
+                    literal = new TitaniumLiteral.DtLiteral(object, datatype);
                 }
 
-                encoder.handleQuad(
-                    new TitaniumNode.StringNode(subject),
-                    new TitaniumNode.StringNode(predicate),
-                    literal,
-                    new TitaniumNode.StringNode(graph)
-                );
+                encoder.handleQuad(subject, predicate, literal, graph);
             } else {
-                encoder.handleQuad(
-                    new TitaniumNode.StringNode(subject),
-                    new TitaniumNode.StringNode(predicate),
-                    new TitaniumNode.StringNode(object),
-                    new TitaniumNode.StringNode(graph)
-                );
+                encoder.handleQuad(subject, predicate, object, graph);
             }
         } catch (RdfProtoSerializationError e) {
             throw new RdfConsumerException(e.getMessage(), e);

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoderImpl.java
@@ -1,0 +1,95 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import static eu.neverblink.jelly.convert.titanium.TitaniumConstants.DT_STRING;
+
+import com.apicatalog.rdf.api.RdfConsumerException;
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumConverterFactory;
+import eu.neverblink.jelly.convert.titanium.internal.TitaniumNode;
+import eu.neverblink.jelly.core.ProtoEncoder;
+import eu.neverblink.jelly.core.proto.v1.LogicalStreamType;
+import eu.neverblink.jelly.core.proto.v1.PhysicalStreamType;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamRow;
+import java.util.ArrayList;
+import java.util.Collection;
+
+final class TitaniumJellyEncoderImpl implements TitaniumJellyEncoder {
+
+    private final ProtoEncoder<TitaniumNode> encoder;
+
+    private final Collection<RdfStreamRow> buffer = new ArrayList<>();
+
+    public TitaniumJellyEncoderImpl(RdfStreamOptions options) {
+        // We set the stream type to QUADS, as this is the only type supported by Titanium.
+        final var supportedOptions = options
+            .clone()
+            .setPhysicalType(PhysicalStreamType.QUADS)
+            .setLogicalType(LogicalStreamType.FLAT_QUADS)
+            // It's impossible to emit generalized statements or RDF-star in Titanium.
+            .setGeneralizedStatements(false)
+            .setRdfStar(false);
+
+        this.encoder = TitaniumConverterFactory.getInstance()
+            .encoder(ProtoEncoder.Params.of(supportedOptions, false, buffer));
+    }
+
+    @Override
+    public int getRowCount() {
+        return buffer.size();
+    }
+
+    @Override
+    public Iterable<RdfStreamRow> getRows() {
+        return buffer;
+    }
+
+    @Override
+    public RdfStreamOptions getOptions() {
+        return encoder.getOptions();
+    }
+
+    @Override
+    public RdfQuadConsumer quad(
+        String subject,
+        String predicate,
+        String object,
+        String datatype,
+        String language,
+        String direction,
+        String graph
+    ) throws RdfConsumerException {
+        // IRIs and bnodes don't need further processing. For literals, we must allocate
+        // intermediate objects.
+        try {
+            if (RdfQuadConsumer.isLiteral(datatype, language, direction)) {
+                final TitaniumNode literal;
+                if (RdfQuadConsumer.isLangString(datatype, language, direction)) {
+                    literal = new TitaniumNode.LangLiteral(object, language);
+                } else if (datatype.equals(DT_STRING)) {
+                    literal = new TitaniumNode.SimpleLiteral(object);
+                } else {
+                    literal = new TitaniumNode.DtLiteral(object, datatype);
+                }
+
+                encoder.handleQuad(
+                    new TitaniumNode.StringNode(subject),
+                    new TitaniumNode.StringNode(predicate),
+                    literal,
+                    new TitaniumNode.StringNode(graph)
+                );
+            } else {
+                encoder.handleQuad(
+                    new TitaniumNode.StringNode(subject),
+                    new TitaniumNode.StringNode(predicate),
+                    new TitaniumNode.StringNode(object),
+                    new TitaniumNode.StringNode(graph)
+                );
+            }
+        } catch (final Exception e) {
+            throw new RdfConsumerException(e.getMessage(), e);
+        }
+
+        return this;
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReader.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReader.java
@@ -1,0 +1,63 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.core.JellyOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Parser for the Jelly-RDF format implemented in Titanium RDF API.
+ * If you need fine-grained control over how the data is read, use the lower-level
+ * TitaniumJellyDecoder instead.
+ * @since 2.9.0
+ */
+public interface TitaniumJellyReader {
+    /**
+     * Factory method to create a new TitaniumJellyParser instance.
+     * @param supportedOptions Maximum supported options of the Jelly parser. You can use this to
+     *                         increase the limit on the lookup table size, for example. You should
+     *                         always first obtain the default options from
+     *                         JellyOptions.defaultSupportedOptions() and then modify them as needed.
+     * @return TitaniumJellyParser
+     */
+    static TitaniumJellyReader factory(RdfStreamOptions supportedOptions) {
+        return new TitaniumJellyReaderImpl(supportedOptions);
+    }
+
+    /**
+     * Factory method to create a new TitaniumJellyParser instance.
+     * This method uses the default supported options.
+     * @return TitaniumJellyParser
+     */
+    static TitaniumJellyReader factory() {
+        return factory(JellyOptions.DEFAULT_SUPPORTED_OPTIONS);
+    }
+
+    /**
+     * Parses all frames from the input stream and sends the quads to the consumer.
+     * <p>
+     * The consumer's `quad` method will be called zero or more times, corresponding to
+     * the number of quads in the entire stream.
+     * @param consumer The consumer to send the quads to.
+     * @param inputStream The input stream to read from.
+     */
+    void parseAll(RdfQuadConsumer consumer, InputStream inputStream) throws IOException;
+
+    /**
+     * Parses a single frame from the input stream and sends the quads to the consumer.
+     * If you want to parse the entire stream, use `parseAll` instead.
+     * <p>
+     * The consumer's `quad` method will be called zero or more times, corresponding to
+     * the number of quads in the frame.
+     * @param consumer The consumer to send the quads to.
+     * @param inputStream The input stream to read from.
+     */
+    void parseFrame(RdfQuadConsumer consumer, InputStream inputStream) throws IOException;
+
+    /**
+     * Returns the supported options that this parser uses.
+     * @return RdfStreamOptions
+     */
+    RdfStreamOptions getSupportedOptions();
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReaderImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReaderImpl.java
@@ -1,0 +1,69 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import static eu.neverblink.jelly.core.utils.IoUtils.readStream;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.jelly.core.utils.IoUtils;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * TitaniumJellyReaderImpl is an implementation of the TitaniumJellyReader interface.
+ * It is responsible for parsing Titanium Jelly frames and converting them into RDF quads.
+ */
+final class TitaniumJellyReaderImpl implements TitaniumJellyReader {
+
+    private final RdfStreamOptions supportedOptions;
+
+    private final TitaniumAnyStatementHandler handler = new TitaniumAnyStatementHandler();
+    private final TitaniumJellyDecoder decoder;
+
+    TitaniumJellyReaderImpl(RdfStreamOptions supportedOptions) {
+        this.supportedOptions = supportedOptions;
+        this.decoder = new TitaniumJellyDecoderImpl(supportedOptions, handler);
+    }
+
+    @Override
+    public void parseAll(RdfQuadConsumer consumer, InputStream inputStream) throws IOException {
+        parseInternal(consumer, inputStream, false);
+    }
+
+    @Override
+    public void parseFrame(RdfQuadConsumer consumer, InputStream inputStream) throws IOException {
+        parseInternal(consumer, inputStream, true);
+    }
+
+    @Override
+    public RdfStreamOptions getSupportedOptions() {
+        return supportedOptions;
+    }
+
+    private void parseInternal(RdfQuadConsumer consumer, InputStream inputStream, boolean oneFrame) throws IOException {
+        handler.assignConsumer(consumer);
+
+        var delimitingResponse = IoUtils.autodetectDelimiting(inputStream);
+        if (!delimitingResponse.isDelimited()) {
+            // File contains a single frame
+            var newIn = delimitingResponse.newInput();
+            var frame = RdfStreamFrame.parseFrom(newIn);
+            decoder.ingestFrame(consumer, frame);
+            return;
+        }
+
+        // Delimiting response is true
+        if (oneFrame) {
+            // May contain multiple frames, but we only want one
+            var newIn = delimitingResponse.newInput();
+            var frame = RdfStreamFrame.parseDelimitedFrom(newIn);
+            decoder.ingestFrame(consumer, frame);
+            return;
+        }
+
+        // May contain multiple frames
+        readStream(delimitingResponse.newInput(), RdfStreamFrame::parseDelimitedFrom, frame ->
+            decoder.ingestFrame(consumer, frame)
+        );
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriter.java
@@ -1,0 +1,56 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyWriterImpl;
+import eu.neverblink.jelly.core.JellyOptions;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import java.io.OutputStream;
+
+/**
+ * Writer for the Jelly-RDF format implemented in Titanium RDF API.
+ * If you need fine-grained control over the stream frames, their metadata, or how they are
+ * written to bytes, use the lower-level TitaniumJellyEncoder instead.
+ * <p>
+ * The close() method MUST be called at the end to flush the buffer and write the last frame.
+ * @since 2.9.0
+ */
+public interface TitaniumJellyWriter extends RdfQuadConsumer, AutoCloseable {
+    /**
+     * Factory method to create a new TitaniumJellyWriter instance.
+     * @param outputStream The output stream to write to.
+     * @param options The options to use for encoding.
+     * @param frameSize Maximum number of rows to buffer before writing to the output stream.
+     * @return TitaniumJellyWriter
+     */
+    static TitaniumJellyWriter factory(OutputStream outputStream, RdfStreamOptions options, int frameSize) {
+        return new TitaniumJellyWriterImpl(outputStream, options, frameSize);
+    }
+
+    /**
+     * Factory method to create a new TitaniumJellyWriter instance.
+     * This method uses the default options (small preset) and a frame size of 256.
+     * @param outputStream The output stream to write to.
+     * @return TitaniumJellyWriter
+     */
+    static TitaniumJellyWriter factory(OutputStream outputStream) {
+        return factory(outputStream, JellyOptions.SMALL_STRICT, 256);
+    }
+
+    /**
+     * Returns the output stream that this writer writes to.
+     * @return OutputStream
+     */
+    OutputStream getOutputStream();
+
+    /**
+     * Returns the options that this writer uses.
+     * @return RdfStreamOptions
+     */
+    RdfStreamOptions getOptions();
+
+    /**
+     * Returns the frame size that this writer uses.
+     * @return int
+     */
+    int getFrameSize();
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriterImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriterImpl.java
@@ -1,0 +1,80 @@
+package eu.neverblink.jelly.convert.titanium;
+
+import com.apicatalog.rdf.api.RdfConsumerException;
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+final class TitaniumJellyWriterImpl implements TitaniumJellyWriter, Closeable {
+
+    private final OutputStream outputStream;
+    private final int frameSize;
+
+    private final TitaniumJellyEncoder encoder;
+
+    TitaniumJellyWriterImpl(OutputStream outputStream, RdfStreamOptions options, int frameSize) {
+        this.outputStream = outputStream;
+        this.frameSize = frameSize;
+
+        this.encoder = new TitaniumJellyEncoderImpl(options);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+
+    @Override
+    public RdfStreamOptions getOptions() {
+        return encoder.getOptions();
+    }
+
+    @Override
+    public int getFrameSize() {
+        return frameSize;
+    }
+
+    @Override
+    public RdfQuadConsumer quad(
+        String subject,
+        String predicate,
+        String object,
+        String datatype,
+        String language,
+        String direction,
+        String graph
+    ) throws RdfConsumerException {
+        encoder.quad(subject, predicate, object, datatype, language, direction, graph);
+        if (encoder.getRowCount() >= frameSize) {
+            final var frame = RdfStreamFrame.newInstance();
+            for (final var row : encoder.getRows()) {
+                frame.addRows(row);
+            }
+            try {
+                frame.writeDelimitedTo(outputStream);
+            } catch (IOException e) {
+                throw new RdfConsumerException(e);
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (encoder.getRowCount() > 0) {
+            final var frame = RdfStreamFrame.newInstance();
+            for (final var row : encoder.getRows()) {
+                frame.addRows(row);
+            }
+            frame.writeDelimitedTo(outputStream);
+        }
+
+        if (outputStream != null) {
+            outputStream.close();
+        }
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriterImpl.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriterImpl.java
@@ -58,6 +58,8 @@ final class TitaniumJellyWriterImpl implements TitaniumJellyWriter, Closeable {
             } catch (IOException e) {
                 throw new RdfConsumerException(e);
             }
+
+            encoder.clearRows();
         }
 
         return this;
@@ -71,6 +73,8 @@ final class TitaniumJellyWriterImpl implements TitaniumJellyWriter, Closeable {
                 frame.addRows(row);
             }
             frame.writeDelimitedTo(outputStream);
+
+            encoder.clearRows();
         }
 
         if (outputStream != null) {

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
@@ -1,0 +1,36 @@
+package eu.neverblink.jelly.convert.titanium.internal;
+
+import eu.neverblink.jelly.core.InternalApi;
+import eu.neverblink.jelly.core.JellyConverterFactory;
+
+/**
+ * A singleton factory for creating Jelly Titanium converters.
+ * <p>
+ * This class is a singleton and should be accessed via the {@link #getInstance()} method.
+ */
+@InternalApi
+public class TitaniumConverterFactory extends JellyConverterFactory<TitaniumNode, String, TitaniumEncoderConverter, TitaniumDecoderConverter> {
+    
+    private static final TitaniumConverterFactory INSTANCE = new TitaniumConverterFactory();
+
+    private TitaniumConverterFactory() {}
+
+    /**
+     * Returns the singleton instance of the {@link TitaniumConverterFactory}.
+     *
+     * @return the singleton instance of the {@link TitaniumConverterFactory}
+     */
+    public static TitaniumConverterFactory getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public TitaniumEncoderConverter encoderConverter() {
+        return new TitaniumEncoderConverter();
+    }
+
+    @Override
+    public TitaniumDecoderConverter decoderConverter() {
+        return new TitaniumDecoderConverter();
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
@@ -10,7 +10,7 @@ import eu.neverblink.jelly.core.JellyConverterFactory;
  */
 @InternalApi
 public class TitaniumConverterFactory
-    extends JellyConverterFactory<TitaniumNode, String, TitaniumEncoderConverter, TitaniumDecoderConverter> {
+    extends JellyConverterFactory<Object, String, TitaniumEncoderConverter, TitaniumDecoderConverter> {
 
     private static final TitaniumConverterFactory INSTANCE = new TitaniumConverterFactory();
 

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumConverterFactory.java
@@ -9,8 +9,9 @@ import eu.neverblink.jelly.core.JellyConverterFactory;
  * This class is a singleton and should be accessed via the {@link #getInstance()} method.
  */
 @InternalApi
-public class TitaniumConverterFactory extends JellyConverterFactory<TitaniumNode, String, TitaniumEncoderConverter, TitaniumDecoderConverter> {
-    
+public class TitaniumConverterFactory
+    extends JellyConverterFactory<TitaniumNode, String, TitaniumEncoderConverter, TitaniumDecoderConverter> {
+
     private static final TitaniumConverterFactory INSTANCE = new TitaniumConverterFactory();
 
     private TitaniumConverterFactory() {}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumDecoderConverter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumDecoderConverter.java
@@ -7,21 +7,21 @@ import eu.neverblink.jelly.core.ProtoDecoderConverter;
  * A Jelly decoder converter for the titanium-rdf-api.
  */
 @InternalApi
-public final class TitaniumDecoderConverter implements ProtoDecoderConverter<TitaniumNode, String> {
+public final class TitaniumDecoderConverter implements ProtoDecoderConverter<Object, String> {
 
     @Override
-    public TitaniumNode makeSimpleLiteral(String lex) {
-        return new TitaniumNode.SimpleLiteral(lex);
+    public Object makeSimpleLiteral(String lex) {
+        return new TitaniumLiteral.SimpleLiteral(lex);
     }
 
     @Override
-    public TitaniumNode makeLangLiteral(String lex, String lang) {
-        return new TitaniumNode.LangLiteral(lex, lang);
+    public Object makeLangLiteral(String lex, String lang) {
+        return new TitaniumLiteral.LangLiteral(lex, lang);
     }
 
     @Override
-    public TitaniumNode makeDtLiteral(String lex, String dt) {
-        return new TitaniumNode.DtLiteral(lex, dt);
+    public Object makeDtLiteral(String lex, String dt) {
+        return new TitaniumLiteral.DtLiteral(lex, dt);
     }
 
     @Override
@@ -30,24 +30,24 @@ public final class TitaniumDecoderConverter implements ProtoDecoderConverter<Tit
     }
 
     @Override
-    public TitaniumNode makeBlankNode(String label) {
-        return new TitaniumNode.StringNode("_:".concat(label));
+    public Object makeBlankNode(String label) {
+        return "_:".concat(label);
     }
 
     @Override
-    public TitaniumNode makeIriNode(String iri) {
-        return new TitaniumNode.StringNode(iri);
+    public Object makeIriNode(String iri) {
+        return iri;
     }
 
     @Override
-    public TitaniumNode makeTripleNode(TitaniumNode s, TitaniumNode p, TitaniumNode o) {
+    public Object makeTripleNode(Object s, Object p, Object o) {
         throw new UnsupportedOperationException(
             "The titanium-rdf-api implementation of Jelly does not support quoted triples."
         );
     }
 
     @Override
-    public TitaniumNode makeDefaultGraphNode() {
+    public Object makeDefaultGraphNode() {
         return null;
     }
 }

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumDecoderConverter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumDecoderConverter.java
@@ -1,0 +1,53 @@
+package eu.neverblink.jelly.convert.titanium.internal;
+
+import eu.neverblink.jelly.core.InternalApi;
+import eu.neverblink.jelly.core.ProtoDecoderConverter;
+
+/**
+ * A Jelly decoder converter for the titanium-rdf-api.
+ */
+@InternalApi
+public final class TitaniumDecoderConverter implements ProtoDecoderConverter<TitaniumNode, String> {
+
+    @Override
+    public TitaniumNode makeSimpleLiteral(String lex) {
+        return new TitaniumNode.SimpleLiteral(lex);
+    }
+
+    @Override
+    public TitaniumNode makeLangLiteral(String lex, String lang) {
+        return new TitaniumNode.LangLiteral(lex, lang);
+    }
+
+    @Override
+    public TitaniumNode makeDtLiteral(String lex, String dt) {
+        return new TitaniumNode.DtLiteral(lex, dt);
+    }
+
+    @Override
+    public String makeDatatype(String dt) {
+        return dt;
+    }
+
+    @Override
+    public TitaniumNode makeBlankNode(String label) {
+        return new TitaniumNode.StringNode("_:".concat(label));
+    }
+
+    @Override
+    public TitaniumNode makeIriNode(String iri) {
+        return new TitaniumNode.StringNode(iri);
+    }
+
+    @Override
+    public TitaniumNode makeTripleNode(TitaniumNode s, TitaniumNode p, TitaniumNode o) {
+        throw new UnsupportedOperationException(
+            "The titanium-rdf-api implementation of Jelly does not support quoted triples."
+        );
+    }
+
+    @Override
+    public TitaniumNode makeDefaultGraphNode() {
+        return null;
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -7,29 +7,26 @@ import eu.neverblink.jelly.core.RdfProtoSerializationError;
 
 /**
  * Converter for translating between Titanium RDF API nodes/terms and Jelly proto objects.
- * <p>
- * Quad class is used here, but is not intended to be used with the encoder.
- * The only reason it's here is to satisfy the type signature of the trait.
  */
 @InternalApi
-public final class TitaniumEncoderConverter implements ProtoEncoderConverter<TitaniumNode> {
+public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Object> {
 
     @Override
-    public void nodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
+    public void nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
-            switch (titaniumNode.type()) {
-                case IRI -> encoder.makeIri(titaniumNode.asStringValue());
-                case BLANK -> encoder.makeBlankNode(titaniumNode.asStringValue().substring(2)); // remove "_:"
-                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(titaniumNode.asSimpleLiteral().lex());
+            switch (TitaniumNode.typeOf(titaniumNode)) {
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2)); // remove "_:"
+                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(TitaniumNode.simpleLiteralOf(titaniumNode).lex());
                 case LANG_LITERAL -> encoder.makeLangLiteral(
                     titaniumNode,
-                    titaniumNode.asLangLiteral().lex(),
-                    titaniumNode.asLangLiteral().lang()
+                    TitaniumNode.langLiteralOf(titaniumNode).lex(),
+                    TitaniumNode.langLiteralOf(titaniumNode).lang()
                 );
                 case DT_LITERAL -> encoder.makeDtLiteral(
                     titaniumNode,
-                    titaniumNode.asDtLiteral().lex(),
-                    titaniumNode.asDtLiteral().dt()
+                    TitaniumNode.dtLiteralOf(titaniumNode).lex(),
+                    TitaniumNode.dtLiteralOf(titaniumNode).dt()
                 );
                 default -> throw new IllegalStateException("Cannot encode null as S/P/O term.");
             }
@@ -39,22 +36,16 @@ public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Tit
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
+    public void graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
             if (titaniumNode == null) {
                 encoder.makeDefaultGraph();
                 return;
             }
 
-            // Special case for null graph node when wrapped string is null
-            if (titaniumNode.asStringValue() == null) {
-                encoder.makeDefaultGraph();
-                return;
-            }
-
-            switch (titaniumNode.type()) {
-                case IRI -> encoder.makeIri(titaniumNode.asStringValue());
-                case BLANK -> encoder.makeBlankNode(titaniumNode.asStringValue().substring(2)); // remove "_:"
+            switch (TitaniumNode.typeOf(titaniumNode)) {
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2)); // remove "_:"
                 default -> throw new RdfProtoSerializationError(
                     "Cannot encode null as graph node: %s".formatted(titaniumNode)
                 );

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -1,0 +1,51 @@
+package eu.neverblink.jelly.convert.titanium.internal;
+
+import eu.neverblink.jelly.core.InternalApi;
+import eu.neverblink.jelly.core.NodeEncoder;
+import eu.neverblink.jelly.core.ProtoEncoderConverter;
+
+/**
+ * Converter for translating between Titanium RDF API nodes/terms and Jelly proto objects.
+ * <p>
+ * Quad class is used here, but is not intended to be used with the encoder.
+ * The only reason it's here is to satisfy the type signature of the trait.
+ */
+@InternalApi
+public final class TitaniumEncoderConverter implements ProtoEncoderConverter<TitaniumNode> {
+
+    @Override
+    public void nodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
+        switch (titaniumNode.type()) {
+            case IRI -> encoder.makeIri(titaniumNode.asString().value());
+            case BLANK -> encoder.makeBlankNode(titaniumNode.asString().value().substring(2)); // remove "_:"
+            case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(titaniumNode.asSimpleLiteral().lex());
+            case LANG_LITERAL -> encoder.makeLangLiteral(
+                titaniumNode,
+                titaniumNode.asLangLiteral().lex(),
+                titaniumNode.asLangLiteral().lang()
+            );
+            case DT_LITERAL -> encoder.makeDtLiteral(
+                titaniumNode,
+                titaniumNode.asDtLiteral().lex(),
+                titaniumNode.asDtLiteral().dt()
+            );
+            default -> throw new IllegalArgumentException("Cannot encode null as S/P/O term.");
+        }
+    }
+
+    @Override
+    public void graphNodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
+        if (titaniumNode == null) {
+            encoder.makeDefaultGraph();
+            return;
+        }
+
+        switch (titaniumNode.type()) {
+            case IRI -> encoder.makeIri(titaniumNode.asString().value());
+            case BLANK -> encoder.makeBlankNode(titaniumNode.asString().value().substring(2)); // remove "_:"
+            default -> throw new IllegalArgumentException(
+                "Cannot encode null as graph node: %s".formatted(titaniumNode)
+            );
+        }
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -3,6 +3,7 @@ package eu.neverblink.jelly.convert.titanium.internal;
 import eu.neverblink.jelly.core.InternalApi;
 import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
+import eu.neverblink.jelly.core.RdfProtoSerializationError;
 
 /**
  * Converter for translating between Titanium RDF API nodes/terms and Jelly proto objects.
@@ -15,37 +16,51 @@ public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Tit
 
     @Override
     public void nodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
-        switch (titaniumNode.type()) {
-            case IRI -> encoder.makeIri(titaniumNode.asString().value());
-            case BLANK -> encoder.makeBlankNode(titaniumNode.asString().value().substring(2)); // remove "_:"
-            case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(titaniumNode.asSimpleLiteral().lex());
-            case LANG_LITERAL -> encoder.makeLangLiteral(
-                titaniumNode,
-                titaniumNode.asLangLiteral().lex(),
-                titaniumNode.asLangLiteral().lang()
-            );
-            case DT_LITERAL -> encoder.makeDtLiteral(
-                titaniumNode,
-                titaniumNode.asDtLiteral().lex(),
-                titaniumNode.asDtLiteral().dt()
-            );
-            default -> throw new IllegalArgumentException("Cannot encode null as S/P/O term.");
+        try {
+            switch (titaniumNode.type()) {
+                case IRI -> encoder.makeIri(titaniumNode.asStringValue());
+                case BLANK -> encoder.makeBlankNode(titaniumNode.asStringValue().substring(2)); // remove "_:"
+                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(titaniumNode.asSimpleLiteral().lex());
+                case LANG_LITERAL -> encoder.makeLangLiteral(
+                    titaniumNode,
+                    titaniumNode.asLangLiteral().lex(),
+                    titaniumNode.asLangLiteral().lang()
+                );
+                case DT_LITERAL -> encoder.makeDtLiteral(
+                    titaniumNode,
+                    titaniumNode.asDtLiteral().lex(),
+                    titaniumNode.asDtLiteral().dt()
+                );
+                default -> throw new IllegalStateException("Cannot encode null as S/P/O term.");
+            }
+        } catch (Exception e) {
+            throw new RdfProtoSerializationError(e.getMessage(), e);
         }
     }
 
     @Override
     public void graphNodeToProto(NodeEncoder<TitaniumNode> encoder, TitaniumNode titaniumNode) {
-        if (titaniumNode == null) {
-            encoder.makeDefaultGraph();
-            return;
-        }
+        try {
+            if (titaniumNode == null) {
+                encoder.makeDefaultGraph();
+                return;
+            }
 
-        switch (titaniumNode.type()) {
-            case IRI -> encoder.makeIri(titaniumNode.asString().value());
-            case BLANK -> encoder.makeBlankNode(titaniumNode.asString().value().substring(2)); // remove "_:"
-            default -> throw new IllegalArgumentException(
-                "Cannot encode null as graph node: %s".formatted(titaniumNode)
-            );
+            // Special case for null graph node when wrapped string is null
+            if (titaniumNode.asStringValue() == null) {
+                encoder.makeDefaultGraph();
+                return;
+            }
+
+            switch (titaniumNode.type()) {
+                case IRI -> encoder.makeIri(titaniumNode.asStringValue());
+                case BLANK -> encoder.makeBlankNode(titaniumNode.asStringValue().substring(2)); // remove "_:"
+                default -> throw new RdfProtoSerializationError(
+                    "Cannot encode null as graph node: %s".formatted(titaniumNode)
+                );
+            }
+        } catch (Exception e) {
+            throw new RdfProtoSerializationError(e.getMessage(), e);
         }
     }
 }

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumLiteral.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumLiteral.java
@@ -1,0 +1,35 @@
+package eu.neverblink.jelly.convert.titanium.internal;
+
+import eu.neverblink.jelly.core.InternalApi;
+
+/**
+ * Internal representations of RDF literal data inside the Titanium converter.
+ * <p>
+ * These are not intended to be used outside of the converter's code.
+ */
+@InternalApi
+public sealed interface TitaniumLiteral {
+    TitaniumNode.TitaniumNodeType type();
+
+    record SimpleLiteral(String lex) implements TitaniumLiteral {
+        @Override
+        public TitaniumNode.TitaniumNodeType type() {
+            return TitaniumNode.TitaniumNodeType.SIMPLE_LITERAL;
+        }
+    }
+
+    // No support for RDF 1.2 directionality... yet.
+    record LangLiteral(String lex, String lang) implements TitaniumLiteral {
+        @Override
+        public TitaniumNode.TitaniumNodeType type() {
+            return TitaniumNode.TitaniumNodeType.LANG_LITERAL;
+        }
+    }
+
+    record DtLiteral(String lex, String dt) implements TitaniumLiteral {
+        @Override
+        public TitaniumNode.TitaniumNodeType type() {
+            return TitaniumNode.TitaniumNodeType.DT_LITERAL;
+        }
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
@@ -16,7 +16,6 @@ public sealed interface TitaniumNode {
         SIMPLE_LITERAL,
         LANG_LITERAL,
         DT_LITERAL,
-        QUAD,
     }
 
     TitaniumNodeType type();
@@ -24,13 +23,9 @@ public sealed interface TitaniumNode {
     default StringNode asString() {
         return (StringNode) this;
     }
-    
+
     default String asStringValue() {
         return asString().value();
-    }
-
-    default Quad asQuad() {
-        return (Quad) this;
     }
 
     default SimpleLiteral asSimpleLiteral() {
@@ -52,13 +47,6 @@ public sealed interface TitaniumNode {
         @Override
         public TitaniumNodeType type() {
             return RdfQuadConsumer.isBlank(value) ? TitaniumNodeType.BLANK : TitaniumNodeType.IRI;
-        }
-    }
-
-    record Quad(String s, String p, TitaniumNode o, String g) implements TitaniumNode {
-        @Override
-        public TitaniumNodeType type() {
-            return TitaniumNodeType.QUAD;
         }
     }
 

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
@@ -1,0 +1,86 @@
+package eu.neverblink.jelly.convert.titanium.internal;
+
+import com.apicatalog.rdf.api.RdfQuadConsumer;
+import eu.neverblink.jelly.core.InternalApi;
+
+/**
+ * Internal representations of RDF data inside the Titanium converter.
+ * <p>
+ * These are not intended to be used outside of the converter's code.
+ */
+@InternalApi
+public sealed interface TitaniumNode {
+    enum TitaniumNodeType {
+        IRI,
+        BLANK,
+        SIMPLE_LITERAL,
+        LANG_LITERAL,
+        DT_LITERAL,
+        QUAD,
+    }
+
+    TitaniumNodeType type();
+
+    default StringNode asString() {
+        return (StringNode) this;
+    }
+    
+    default String asStringValue() {
+        return asString().value();
+    }
+
+    default Quad asQuad() {
+        return (Quad) this;
+    }
+
+    default SimpleLiteral asSimpleLiteral() {
+        return (SimpleLiteral) this;
+    }
+
+    default LangLiteral asLangLiteral() {
+        return (LangLiteral) this;
+    }
+
+    default DtLiteral asDtLiteral() {
+        return (DtLiteral) this;
+    }
+
+    sealed interface TitaniumLiteral extends TitaniumNode {}
+
+    // String used to represent IRIs and blank nodes
+    record StringNode(String value) implements TitaniumNode {
+        @Override
+        public TitaniumNodeType type() {
+            return RdfQuadConsumer.isBlank(value) ? TitaniumNodeType.BLANK : TitaniumNodeType.IRI;
+        }
+    }
+
+    record Quad(String s, String p, TitaniumNode o, String g) implements TitaniumNode {
+        @Override
+        public TitaniumNodeType type() {
+            return TitaniumNodeType.QUAD;
+        }
+    }
+
+    record SimpleLiteral(String lex) implements TitaniumLiteral {
+        @Override
+        public TitaniumNodeType type() {
+            return TitaniumNodeType.SIMPLE_LITERAL;
+        }
+    }
+
+    // No support for RDF 1.2 directionality... yet.
+    record LangLiteral(String lex, String lang) implements TitaniumLiteral {
+        @Override
+        public TitaniumNodeType type() {
+            return TitaniumNodeType.LANG_LITERAL;
+        }
+    }
+
+    record DtLiteral(String lex, String dt) implements TitaniumLiteral {
+        @Override
+        public TitaniumNodeType type() {
+            return TitaniumNodeType.DT_LITERAL;
+        }
+    }
+}

--- a/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
+++ b/titanium-rdf-api-java/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumNode.java
@@ -4,13 +4,16 @@ import com.apicatalog.rdf.api.RdfQuadConsumer;
 import eu.neverblink.jelly.core.InternalApi;
 
 /**
- * Internal representations of RDF data inside the Titanium converter.
+ * Internal tools to represent RDF data inside the Titanium converter.
  * <p>
  * These are not intended to be used outside of the converter's code.
  */
 @InternalApi
-public sealed interface TitaniumNode {
-    enum TitaniumNodeType {
+public final class TitaniumNode {
+
+    private TitaniumNode() {}
+
+    public enum TitaniumNodeType {
         IRI,
         BLANK,
         SIMPLE_LITERAL,
@@ -18,57 +21,31 @@ public sealed interface TitaniumNode {
         DT_LITERAL,
     }
 
-    TitaniumNodeType type();
-
-    default StringNode asString() {
-        return (StringNode) this;
-    }
-
-    default String asStringValue() {
-        return asString().value();
-    }
-
-    default SimpleLiteral asSimpleLiteral() {
-        return (SimpleLiteral) this;
-    }
-
-    default LangLiteral asLangLiteral() {
-        return (LangLiteral) this;
-    }
-
-    default DtLiteral asDtLiteral() {
-        return (DtLiteral) this;
-    }
-
-    sealed interface TitaniumLiteral extends TitaniumNode {}
-
-    // String used to represent IRIs and blank nodes
-    record StringNode(String value) implements TitaniumNode {
-        @Override
-        public TitaniumNodeType type() {
-            return RdfQuadConsumer.isBlank(value) ? TitaniumNodeType.BLANK : TitaniumNodeType.IRI;
+    public static TitaniumNodeType typeOf(Object node) {
+        if ((node instanceof String iriLike)) {
+            return RdfQuadConsumer.isBlank(iriLike) ? TitaniumNodeType.BLANK : TitaniumNodeType.IRI;
         }
+
+        if ((node instanceof TitaniumLiteral literal)) {
+            return literal.type();
+        }
+
+        return null;
     }
 
-    record SimpleLiteral(String lex) implements TitaniumLiteral {
-        @Override
-        public TitaniumNodeType type() {
-            return TitaniumNodeType.SIMPLE_LITERAL;
-        }
+    public static String iriLikeOf(Object node) {
+        return (String) node;
     }
 
-    // No support for RDF 1.2 directionality... yet.
-    record LangLiteral(String lex, String lang) implements TitaniumLiteral {
-        @Override
-        public TitaniumNodeType type() {
-            return TitaniumNodeType.LANG_LITERAL;
-        }
+    public static TitaniumLiteral.SimpleLiteral simpleLiteralOf(Object node) {
+        return (TitaniumLiteral.SimpleLiteral) node;
     }
 
-    record DtLiteral(String lex, String dt) implements TitaniumLiteral {
-        @Override
-        public TitaniumNodeType type() {
-            return TitaniumNodeType.DT_LITERAL;
-        }
+    public static TitaniumLiteral.LangLiteral langLiteralOf(Object node) {
+        return (TitaniumLiteral.LangLiteral) node;
+    }
+
+    public static TitaniumLiteral.DtLiteral dtLiteralOf(Object node) {
+        return (TitaniumLiteral.DtLiteral) node;
     }
 }

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/IntegrationSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/IntegrationSpec.scala
@@ -1,0 +1,93 @@
+package eu.neveblink.jelly.convert.titanium
+
+import com.apicatalog.rdf.api.RdfQuadConsumer
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyReader
+import eu.neverblink.jelly.core.JellyOptions
+import eu.neverblink.jelly.core.proto.v1.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+/**
+ * Integration tests for some Titanium-specific APIs.
+ */
+class IntegrationSpec extends AnyWordSpec, Matchers:
+  val testFrame = RdfStreamFrame.newInstance()
+    .addRows(
+      RdfStreamRow.newInstance()
+        .setOptions(JellyOptions.SMALL_STRICT.clone().setPhysicalType(PhysicalStreamType.QUADS))
+    )
+    .addRows(
+      RdfStreamRow.newInstance()
+        .setName(RdfNameEntry.newInstance().setValue("http://example.org/iri"))
+    )
+    .addRows(
+      RdfStreamRow.newInstance()
+        .setQuad(
+          RdfQuad.newInstance()
+            .setSubject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.S_IRI)
+            .setPredicate(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.P_IRI)
+            .setObject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.O_IRI)
+            .setGraph(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.G_IRI)
+        )
+    )
+
+  val testFrame2 = RdfStreamFrame.newInstance()
+    .addRows(
+      RdfStreamRow.newInstance()
+        .setQuad(
+          RdfQuad.newInstance()
+            .setSubject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.S_IRI)
+            .setPredicate(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.P_IRI)
+            .setObject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.O_IRI)
+            .setGraph(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.G_IRI)
+        )
+    )
+
+  class CollectorConsumer extends RdfQuadConsumer:
+    var quads = Seq.empty[(String, String, String, String, String, String, String)]
+
+    override def quad(
+      subject: String, predicate: String, `object`: String,
+      datatype: String, language: String, direction: String, graph: String
+    ): RdfQuadConsumer =
+      quads = quads :+ (subject, predicate, `object`, datatype, language, direction, graph)
+      this
+
+  "TitaniumJellyReader" should {
+    "parse a single non-delimited frame" in {
+      val is = ByteArrayInputStream(testFrame.toByteArray)
+      val reader = TitaniumJellyReader.factory()
+      val cons = CollectorConsumer()
+      reader.parseFrame(cons, is)
+      cons.quads should have size 1
+    }
+
+    "parse a single non-delimited frame with parseAll" in {
+      val is = ByteArrayInputStream(testFrame.toByteArray)
+      val reader = TitaniumJellyReader.factory()
+      val cons = CollectorConsumer()
+      reader.parseAll(cons, is)
+      cons.quads should have size 1
+    }
+
+    "parse a few non-delimited frames with parseFrame" in {
+      val reader = TitaniumJellyReader.factory()
+      val cons = CollectorConsumer()
+      reader.parseFrame(cons, ByteArrayInputStream(testFrame.toByteArray))
+      reader.parseFrame(cons, ByteArrayInputStream(testFrame2.toByteArray))
+      reader.parseFrame(cons, ByteArrayInputStream(testFrame2.toByteArray))
+      cons.quads should have size 3
+    }
+
+    "parse a single delimited frame" in {
+      val os = ByteArrayOutputStream()
+      testFrame.writeDelimitedTo(os)
+      val is = ByteArrayInputStream(os.toByteArray)
+      val reader = TitaniumJellyReader.factory()
+      val cons = CollectorConsumer()
+      reader.parseFrame(cons, is)
+      cons.quads should have size 1
+    }
+  }

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/IntegrationSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/IntegrationSpec.scala
@@ -4,6 +4,7 @@ import com.apicatalog.rdf.api.RdfQuadConsumer
 import eu.neverblink.jelly.convert.titanium.TitaniumJellyReader
 import eu.neverblink.jelly.core.JellyOptions
 import eu.neverblink.jelly.core.proto.v1.*
+import eu.neverblink.jelly.core.helpers.RdfAdapter.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -13,37 +14,33 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
  * Integration tests for some Titanium-specific APIs.
  */
 class IntegrationSpec extends AnyWordSpec, Matchers:
-  val testFrame = RdfStreamFrame.newInstance()
-    .addRows(
-      RdfStreamRow.newInstance()
-        .setOptions(JellyOptions.SMALL_STRICT.clone().setPhysicalType(PhysicalStreamType.QUADS))
+  val testFrame = rdfStreamFrame(rows = Seq(
+    rdfStreamRow(
+      JellyOptions.SMALL_STRICT
+        .clone()
+        .setPhysicalType(PhysicalStreamType.QUADS)
+    ),
+    rdfStreamRow(rdfNameEntry(value = "http://example.org/iri")),
+    rdfStreamRow(
+      rdfQuad(
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+      )
     )
-    .addRows(
-      RdfStreamRow.newInstance()
-        .setName(RdfNameEntry.newInstance().setValue("http://example.org/iri"))
-    )
-    .addRows(
-      RdfStreamRow.newInstance()
-        .setQuad(
-          RdfQuad.newInstance()
-            .setSubject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.S_IRI)
-            .setPredicate(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.P_IRI)
-            .setObject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.O_IRI)
-            .setGraph(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.G_IRI)
-        )
-    )
+  ))
 
-  val testFrame2 = RdfStreamFrame.newInstance()
-    .addRows(
-      RdfStreamRow.newInstance()
-        .setQuad(
-          RdfQuad.newInstance()
-            .setSubject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.S_IRI)
-            .setPredicate(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.P_IRI)
-            .setObject(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.O_IRI)
-            .setGraph(RdfIri.newInstance().setPrefixId(0).setNameId(1), RdfQuad.G_IRI)
-        )
+  val testFrame2 = rdfStreamFrame(rows = Seq(
+    rdfStreamRow(
+      rdfQuad(
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+        rdfIri(0, 1),
+      )
     )
+  ))
 
   class CollectorConsumer extends RdfQuadConsumer:
     var quads = Seq.empty[(String, String, String, String, String, String, String)]

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyDecoderSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyDecoderSpec.scala
@@ -1,0 +1,23 @@
+package eu.neveblink.jelly.convert.titanium
+
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyDecoder
+import eu.neverblink.jelly.core.JellyOptions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Tests for the auxiliary methods of the TitaniumJellyDecoder.
+ * The main tests are done in the integration-tests module.
+ */
+class TitaniumJellyDecoderSpec extends AnyWordSpec, Matchers:
+  "TitaniumJellyDecoder" should {
+    "be created with default options" in {
+      val reader = TitaniumJellyDecoder.factory(null) // null here is any statement handler, which is ok for this test
+      reader.getSupportedOptions should be (JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+    }
+
+    "be created with custom options" in {
+      val reader = TitaniumJellyDecoder.factory(JellyOptions.BIG_STRICT, null) // null here is any statement handler
+      reader.getSupportedOptions should be (JellyOptions.BIG_STRICT)
+    }
+  }

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyEncoderSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyEncoderSpec.scala
@@ -1,0 +1,50 @@
+package eu.neveblink.jelly.convert.titanium
+
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyEncoder
+import eu.neverblink.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType}
+import eu.neverblink.jelly.core.{JellyConstants, JellyOptions}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Tests for the auxiliary methods of the TitaniumJellyEncoder.
+ * The main tests are done in the integration-tests module.
+ */
+class TitaniumJellyEncoderSpec extends AnyWordSpec, Matchers:
+  "TitaniumJellyEncoder" should {
+    "be created with default options" in {
+      val encoder = TitaniumJellyEncoder.factory()
+      encoder.getOptions should be (
+        JellyOptions.SMALL_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.QUADS)
+          .setLogicalType(LogicalStreamType.FLAT_QUADS)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+      )
+      encoder.getRows.asScala.size should be (0)
+    }
+
+    "be created with custom options" in {
+      val encoder = TitaniumJellyEncoder.factory(JellyOptions.BIG_STRICT)
+      encoder.getOptions should be (
+        JellyOptions.BIG_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.QUADS)
+          .setLogicalType(LogicalStreamType.FLAT_QUADS)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+      )
+      encoder.quad("s", "p", "o", null, null, null, "g")
+      encoder.getRowCount should be > (1)
+      encoder.getRows.asScala.size should be > (1)
+    }
+
+    "ignore enabling RDF-star and generalized statements" in {
+      val encoder = TitaniumJellyEncoder.factory(JellyOptions.BIG_ALL_FEATURES)
+      encoder.getOptions should be (
+        JellyOptions.BIG_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.QUADS)
+          .setLogicalType(LogicalStreamType.FLAT_QUADS)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+      )
+    }
+  }

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyReaderSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyReaderSpec.scala
@@ -1,0 +1,23 @@
+package eu.neveblink.jelly.convert.titanium
+
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyReader
+import eu.neverblink.jelly.core.JellyOptions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Tests for the auxiliary methods of the TitaniumJellyReader.
+ * The main tests are done in the integration-tests module.
+ */
+class TitaniumJellyReaderSpec extends AnyWordSpec, Matchers:
+  "TitaniumJellyReader" should {
+    "be created with default options" in {
+      val reader = TitaniumJellyReader.factory()
+      reader.getSupportedOptions should be (JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+    }
+
+    "be created with custom options" in {
+      val reader = TitaniumJellyReader.factory(JellyOptions.BIG_STRICT)
+      reader.getSupportedOptions should be (JellyOptions.BIG_STRICT)
+    }
+  }

--- a/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyWriterSpec.scala
+++ b/titanium-rdf-api-java/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyWriterSpec.scala
@@ -1,0 +1,47 @@
+package eu.neveblink.jelly.convert.titanium
+
+import eu.neverblink.jelly.convert.titanium.TitaniumJellyWriter
+import eu.neverblink.jelly.core.{JellyOptions, JellyConstants}
+import eu.neverblink.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Tests for the auxiliary methods of the TitaniumJellyWriter.
+ * The main tests are done in the integration-tests module.
+ */
+class TitaniumJellyWriterSpec extends AnyWordSpec, Matchers:
+  "TitaniumJellyWriter" should {
+    "be created with default options" in {
+      val os = new java.io.ByteArrayOutputStream()
+      val writer = TitaniumJellyWriter.factory(os)
+      writer.getOptions should be (
+        JellyOptions.SMALL_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.QUADS)
+          .setLogicalType(LogicalStreamType.FLAT_QUADS)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+      )
+      writer.getOutputStream should be (os)
+      writer.getFrameSize should be (256)
+    }
+
+    "be created with custom options" in {
+      val os = new java.io.ByteArrayOutputStream()
+      val writer = TitaniumJellyWriter.factory(
+        os,
+        // Incorrect type, should be overridden
+        JellyOptions.BIG_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.GRAPHS)
+          .setLogicalType(LogicalStreamType.DATASETS),
+        123,
+      )
+      writer.getOptions should be (
+        JellyOptions.BIG_STRICT.clone()
+          .setPhysicalType(PhysicalStreamType.QUADS)
+          .setLogicalType(LogicalStreamType.FLAT_QUADS)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+      )
+      writer.getOutputStream should be (os)
+      writer.getFrameSize should be (123)
+    }
+  }


### PR DESCRIPTION
This PR rewrites Titanium RDF API to java as a separate module.
Integration tests for this modules are also unblocked, and passing.
Due to a change of decoder api to use `RdfHandler`, the API of `TitaniumJellyDecoder` was changed significantly.
The API of `TitaniumJellyEncoder` is also changed to separate getting rows and cleaning rows up into explicit actions.

