### PR TITLE
Optimize code for always-empty messages

### DIFF
--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
@@ -172,7 +172,6 @@ public abstract class EncoderBase<TNode> implements RdfBufferAppender<TNode> {
 
     @Override
     public void appendDefaultGraph() {
-        // TODO: use a shared instance here
-        currentGraphBase.setGDefaultGraph(RdfDefaultGraph.newInstance());
+        currentGraphBase.setGDefaultGraph(RdfDefaultGraph.EMPTY);
     }
 }

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -19,6 +19,10 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
 
     private boolean hasEmittedOptions = false;
     private final Collection<RdfStreamRow> rowBuffer;
+    
+    // Rows ending the graph are always identical
+    private static final RdfStreamRow ROW_GRAPH_END = 
+        RdfStreamRow.newInstance().setGraphEnd(RdfGraphEnd.EMPTY);
 
     /**
      * Constructor for the ProtoEncoderImpl class.
@@ -61,10 +65,7 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         if (!hasEmittedOptions) {
             throw new RdfProtoSerializationError("Cannot end a delimited graph before starting one");
         }
-        // TODO: use a singleton here
-        final var graphEnd = RdfGraphEnd.newInstance();
-        final var graphRow = RdfStreamRow.newInstance().setGraphEnd(graphEnd);
-        rowBuffer.add(graphRow);
+        rowBuffer.add(ROW_GRAPH_END);
     }
 
     @Override

--- a/core-java/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core-java/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -19,10 +19,9 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
 
     private boolean hasEmittedOptions = false;
     private final Collection<RdfStreamRow> rowBuffer;
-    
+
     // Rows ending the graph are always identical
-    private static final RdfStreamRow ROW_GRAPH_END = 
-        RdfStreamRow.newInstance().setGraphEnd(RdfGraphEnd.EMPTY);
+    private static final RdfStreamRow ROW_GRAPH_END = RdfStreamRow.newInstance().setGraphEnd(RdfGraphEnd.EMPTY);
 
     /**
      * Constructor for the ProtoEncoderImpl class.

--- a/core-java/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
+++ b/core-java/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
@@ -137,7 +137,7 @@ object RdfAdapter:
       .setMaxDatatypeTableSize(maxDatatypeTableSize)
 
   def rdfDefaultGraph(): RdfDefaultGraph =
-    RdfDefaultGraph.newInstance()
+    RdfDefaultGraph.EMPTY
 
   type RdfGraphValue =
     RdfIri
@@ -162,7 +162,7 @@ object RdfAdapter:
     RdfGraphStart.newInstance()
 
   def rdfGraphEnd(): RdfGraphEnd =
-    RdfGraphEnd.newInstance()
+    RdfGraphEnd.EMPTY
 
   def rdfQuad(subject: RdfSpoValue, predicate: RdfSpoValue, `object`: RdfSpoValue, graph: RdfGraphValue = null): RdfQuad = {
     var quad = RdfQuad.newInstance()

--- a/core-java/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
+++ b/core-java/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
@@ -34,8 +34,7 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
       override def appendLiteral(literal: RdfLiteral): Unit = termBuffer += literal
       override def appendQuotedTriple(subject: Mrl.Node, predicate: Mrl.Node, `object`: Mrl.Node): Unit =
         termBuffer += ((subject, predicate, `object`))
-      // TODO: replace with singleton
-      override def appendDefaultGraph(): Unit = termBuffer += RdfDefaultGraph.newInstance()
+      override def appendDefaultGraph(): Unit = termBuffer += RdfDefaultGraph.EMPTY
     }
     (NodeEncoderImpl[Mrl.Node](
       prefixTableSize, 8, 8,

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -18,6 +18,16 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
 
     private boolean hasEmittedOptions = false;
 
+    // These rows are always identical, so we can use singletons
+    private static final RdfPatchRow ROW_PUNCTUATION = RdfPatchRow.newInstance()
+        .setPunctuation(RdfPatchPunctuation.EMPTY);
+    private static final RdfPatchRow ROW_TX_START = RdfPatchRow.newInstance()
+        .setTransactionStart(RdfPatchTransactionStart.EMPTY);
+    private static final RdfPatchRow ROW_TX_COMMIT = RdfPatchRow.newInstance()
+        .setTransactionCommit(RdfPatchTransactionCommit.EMPTY);
+    private static final RdfPatchRow ROW_TX_ABORT = RdfPatchRow.newInstance()
+        .setTransactionAbort(RdfPatchTransactionAbort.EMPTY);
+
     /**
      * Constructor.
      *
@@ -78,28 +88,19 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
     @Override
     public void transactionStart() {
         emitOptions();
-        // TODO: optimize, use a singleton here
-        final var transactionStart = RdfPatchTransactionStart.newInstance();
-        final var mainRow = RdfPatchRow.newInstance().setTransactionStart(transactionStart);
-        rowBuffer.add(mainRow);
+        rowBuffer.add(ROW_TX_START);
     }
 
     @Override
     public void transactionCommit() {
         emitOptions();
-        // TODO: optimize, use a singleton here
-        final var transactionCommit = RdfPatchTransactionCommit.newInstance();
-        final var mainRow = RdfPatchRow.newInstance().setTransactionCommit(transactionCommit);
-        rowBuffer.add(mainRow);
+        rowBuffer.add(ROW_TX_COMMIT);
     }
 
     @Override
     public void transactionAbort() {
         emitOptions();
-        // TODO: optimize, use a singleton here
-        final var transactionAbort = RdfPatchTransactionAbort.newInstance();
-        final var mainRow = RdfPatchRow.newInstance().setTransactionAbort(transactionAbort);
-        rowBuffer.add(mainRow);
+        rowBuffer.add(ROW_TX_ABORT);
     }
 
     @Override
@@ -149,11 +150,7 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         if (options.getStreamType() != PatchStreamType.PUNCTUATED) {
             throw new RdfProtoSerializationError("Punctuation is not allowed in this stream type.");
         }
-
-        // TODO: optimize, use a singleton here
-        var punctuation = RdfPatchPunctuation.newInstance();
-        var mainRow = RdfPatchRow.newInstance().setPunctuation(punctuation);
-        rowBuffer.add(mainRow);
+        rowBuffer.add(ROW_PUNCTUATION);
     }
 
     private void emitOptions() {

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
@@ -95,13 +95,13 @@ object PatchAdapter:
     ns
 
   def rdfPatchPunctuation(): RdfPatchPunctuation =
-    RdfPatchPunctuation.newInstance()
+    RdfPatchPunctuation.EMPTY
 
   def rdfPatchTransactionStart(): RdfPatchTransactionStart =
-    RdfPatchTransactionStart.newInstance()
+    RdfPatchTransactionStart.EMPTY
 
   def rdfPatchTransactionCommit(): RdfPatchTransactionCommit =
-    RdfPatchTransactionCommit.newInstance()
+    RdfPatchTransactionCommit.EMPTY
 
   def rdfPatchTransactionAbort(): RdfPatchTransactionAbort =
-    RdfPatchTransactionAbort.newInstance()
+    RdfPatchTransactionAbort.EMPTY

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/FieldGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/FieldGenerator.scala
@@ -259,6 +259,12 @@ class FieldGenerator(val info: FieldInfo):
       "$<}\n", 
       m
     )
+    else if (info.isEmptyMessage) method.addNamedCode("" +
+      "$writeTagToOutput:L" +
+      "// Message is always empty: write length zero\n" +
+      "output.writeRawByte((byte) 0);\n",
+      m
+    )
     else if (info.isMessageOrGroup) method.addNamedCode("" + // non-repeated
       "$writeTagToOutput:L" +
       "output.writeUInt32NoTag($field:N.getSerializedSize());\n" +
@@ -291,7 +297,6 @@ class FieldGenerator(val info: FieldInfo):
       m
     )
     else if (info.isRepeated) { // non packed
-
       method.addNamedCode("" + 
         "size += " +
         // if 1 byte per tag, we can skip the multiplication
@@ -302,6 +307,8 @@ class FieldGenerator(val info: FieldInfo):
     }
     else if (info.isFixedWidth) 
       method.addStatement("size += $L", info.bytesPerTag + info.getFixedWidth) // non-repeated
+    else if (info.isEmptyMessage)
+      method.addStatement("size += $L", info.bytesPerTag + 1) // 1 byte for varint "0"
     else if (info.isMessageOrGroup) {
       method.addNamedCode(
         "final int dataSize = $field:N$secondArgs:L.getSerializedSize();\n" +

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/RequestInfo.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/RequestInfo.scala
@@ -167,6 +167,8 @@ object RequestInfo:
       new RequestInfo.OneOfInfo(
         parentFile, this, typeName, descriptor.getOneofDecl(i), i
       )
+
+    val isEmptyMessage: Boolean = fieldCount == 0 && oneOfCount == 0
   }
 
   class FieldInfo(
@@ -318,6 +320,12 @@ object RequestInfo:
       t match
         case name: ParameterizedTypeName => name.rawType
         case _ => t
+
+    def isEmptyMessage: Boolean =
+      if isMessageOrGroup then
+        parentFile.parentRequest.typeRegistry
+          .resolveMessageInfoFromProto(descriptor).isEmptyMessage
+      else false
   }
 
   class EnumInfo(

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/TypeRegistry.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/TypeRegistry.scala
@@ -43,6 +43,13 @@ class TypeRegistry:
   private final val messageMap = new java.util.HashMap[TypeName, MessageInfo]
   private final val hasRequiredMap = new java.util.HashMap[TypeName, RequiredType]
   
+  def resolveMessageInfoFromProto(descriptor: FieldDescriptorProto): MessageInfo =
+    val typeId = descriptor.getTypeName
+    val typeName = checkNotNull(typeMap.get(typeId), "Unable to resolve type id: " + typeId)
+    val messageInfo = messageMap.get(typeName)
+    checkNotNull(messageInfo, "Unable to resolve message info for: " + typeName)
+    messageInfo
+  
   def resolveJavaTypeFromProto(descriptor: FieldDescriptorProto): TypeName =
     descriptor.getType match
       case TYPE_DOUBLE => TypeName.DOUBLE

--- a/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
+++ b/integration-tests-java/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
@@ -67,7 +67,7 @@ class GeneralizedRdfSpec extends AnyWordSpec, Matchers, JenaTest:
       rdfLiteral("p"),
       rdfLiteral("o"),
     )),
-    rdfStreamRow(RdfGraphEnd.newInstance()),
+    rdfStreamRow(RdfGraphEnd.EMPTY),
   ))
   private val bytesGraphs = frameAsDelimited(frameGraphs)
 

--- a/jena-java/src/test/scala/eu/neverblink/jelly/convert/jena/JenaProtoEncoderSpec.scala
+++ b/jena-java/src/test/scala/eu/neverblink/jelly/convert/jena/JenaProtoEncoderSpec.scala
@@ -18,8 +18,7 @@ class JenaProtoEncoderSpec extends AnyWordSpec, Matchers, JenaTest:
 
   private val encodedDefaultGraph = RdfStreamRow.newInstance
     .setGraphStart(
-      RdfGraphStart.newInstance
-        .setGDefaultGraph(RdfDefaultGraph.newInstance)
+      RdfGraphStart.newInstance.setGDefaultGraph(RdfDefaultGraph.EMPTY)
     )
   
   "JenaProtoEncoder" should {


### PR DESCRIPTION
Issue: #348 

- These messages are always identical, so we don't ever need to allocate them. Instead, use .EMPTY singleton
- These messages are always serialized in the same way -- tag number + byte `\0` to indicate zero length. We can hardcoded that in proto code.
- These messages always have the same size (0). We can hardcode that.
- These messages are always parsed in the same way -- read the tag and skip the rest. Note that we can't assume that the read content will always be 0 bytes in length. If we make these messages non-empty in the future, the current impl should also be able to parse that without doing something funny.

In general, this should reduce allocations a little and speed things up a little.