### PR TITLE
Apply final/abstract in ProtoMessage to 2 methods

### DIFF
--- a/core-java/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core-java/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -41,7 +41,7 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      *
      * @return the size of the serialized proto form
      */
-    public int getSerializedSize() {
+    public final int getSerializedSize() {
         if (cachedSize < 0) {
             cachedSize = computeSerializedSize();
         }
@@ -162,9 +162,7 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      *
      * @return this
      */
-    public MessageType mergeFrom(MessageType other) {
-        throw new RuntimeException("Generated message does not implement mergeFrom");
-    }
+    public abstract MessageType mergeFrom(MessageType other);
 
     /**
      * Serialize to a byte array.


### PR DESCRIPTION
Tiny change, just to scope down the contract with implementers.

Disregard the branch name, I thought there was something to optimize, but there is not.