### PR TITLE
Fix serializing literals with xsd:string in Jena

### DIFF
--- a/jena-java/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
+++ b/jena-java/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
@@ -4,6 +4,7 @@ import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Quad;
@@ -24,7 +25,8 @@ public final class JenaEncoderConverter
             final var lang = node.getLiteralLanguage();
             if (lang.isEmpty()) {
                 // RDF 1.1 spec: language tag MUST be non-empty. So, this is a plain or datatype literal.
-                if (node.getLiteralDatatype() == null) {
+                // We compare by reference, because the datatype is a singleton.
+                if (node.getLiteralDatatype() == XSDDatatype.XSDstring) {
                     encoder.makeSimpleLiteral(node.getLiteralLexicalForm());
                 } else {
                     encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI());
@@ -62,7 +64,8 @@ public final class JenaEncoderConverter
             final var lang = node.getLiteralLanguage();
             if (lang.isEmpty()) {
                 // RDF 1.1 spec: language tag MUST be non-empty. So, this is a plain or datatype literal.
-                if (node.getLiteralDatatype() == null) {
+                // We compare by reference, because the datatype is a singleton.
+                if (node.getLiteralDatatype() == XSDDatatype.XSDstring) {
                     encoder.makeSimpleLiteral(node.getLiteralLexicalForm());
                 } else {
                     encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI());

--- a/jena-java/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormat.java
+++ b/jena-java/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormat.java
@@ -10,43 +10,57 @@ public final class JellyFormat {
 
     private JellyFormat() {}
 
-    public static final RDFFormat JELLY_SMALL_STRICT = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.SMALL_STRICT).build()
-    );
+    public static final RDFFormat JELLY_SMALL_STRICT;
 
-    public static final RDFFormat JELLY_SMALL_GENERALIZED = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.SMALL_GENERALIZED).build()
-    );
+    public static final RDFFormat JELLY_SMALL_GENERALIZED;
 
-    public static final RDFFormat JELLY_SMALL_RDF_STAR = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.SMALL_RDF_STAR).build()
-    );
+    public static final RDFFormat JELLY_SMALL_RDF_STAR;
 
-    public static final RDFFormat JELLY_SMALL_ALL_FEATURES = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.SMALL_ALL_FEATURES).build()
-    );
+    public static final RDFFormat JELLY_SMALL_ALL_FEATURES;
 
-    public static final RDFFormat JELLY_BIG_STRICT = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.BIG_STRICT).build()
-    );
+    public static final RDFFormat JELLY_BIG_STRICT;
 
-    public static final RDFFormat JELLY_BIG_GENERALIZED = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.BIG_GENERALIZED).build()
-    );
+    public static final RDFFormat JELLY_BIG_GENERALIZED;
 
-    public static final RDFFormat JELLY_BIG_RDF_STAR = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.BIG_RDF_STAR).build()
-    );
+    public static final RDFFormat JELLY_BIG_RDF_STAR;
 
-    public static final RDFFormat JELLY_BIG_ALL_FEATURES = new RDFFormat(
-        JellyLanguage.JELLY,
-        JellyFormatVariant.builder().options(JellyOptions.BIG_ALL_FEATURES).build()
-    );
+    public static final RDFFormat JELLY_BIG_ALL_FEATURES;
+
+    static {
+        // Force initialize the language before initializing the formats
+        JellyLanguage.register();
+
+        JELLY_SMALL_STRICT = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.SMALL_STRICT).build()
+        );
+        JELLY_SMALL_GENERALIZED = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.SMALL_GENERALIZED).build()
+        );
+        JELLY_SMALL_RDF_STAR = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.SMALL_RDF_STAR).build()
+        );
+        JELLY_SMALL_ALL_FEATURES = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.SMALL_ALL_FEATURES).build()
+        );
+        JELLY_BIG_STRICT = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.BIG_STRICT).build()
+        );
+        JELLY_BIG_GENERALIZED = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.BIG_GENERALIZED).build()
+        );
+        JELLY_BIG_RDF_STAR = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.BIG_RDF_STAR).build()
+        );
+        JELLY_BIG_ALL_FEATURES = new RDFFormat(
+            JellyLanguage.JELLY,
+            JellyFormatVariant.builder().options(JellyOptions.BIG_ALL_FEATURES).build()
+        );
+    }
 }

--- a/rdf4j-java/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j-java/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -24,7 +24,7 @@ public class Rdf4jEncoderConverter
                 encoder.makeLangLiteral(literal, lex, lang.get());
             } else {
                 final var dt = literal.getDatatype();
-                if (dt != XSD.STRING) {
+                if (!dt.equals(XSD.STRING)) {
                     encoder.makeDtLiteral(literal, lex, dt.stringValue());
                 } else {
                     encoder.makeSimpleLiteral(lex);


### PR DESCRIPTION
For some reason, the Java code was looking for datatype == null, while it should be comparing by reference to XSDstring (yes, by reference, I'm 110% sure, I've even fixed a bug related to this in Jena).

This led to suboptimal compression and worse size results as compared to Jelly-JVM 2.10. With this fix, we are on exact size parity.

I've also changed up the init code in JellyFormat to depend on JellyLanguage, because otherwise if you first referenced something from JellyFormat, you received really "fun" errors.