### PR TITLE
Clean up publishing of Java modules in sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,10 @@ lazy val commonJavaSettings = Seq(
   crossPaths := false,
   crossVersion := CrossVersion.disabled,
   autoScalaLibrary := false,
+  libraryDependencies ++= Seq(
+    // Add test-time dependency on Scala for ScalaTest
+    "org.scala-lang" %% "scala3-library" % (ThisBuild / scalaVersion).value % Test,
+  ),
 )
 
 lazy val prepareGoogleProtos = taskKey[Seq[File]](

--- a/build.sbt
+++ b/build.sbt
@@ -389,7 +389,6 @@ lazy val integrationTests = (project in file("integration-tests"))
     Compile / compile := (Compile / compile).dependsOn(ProtobufConfig / protobufRunProtoc).value,
     ProtobufConfig / protobufIncludeFilters := Seq(Glob(baseDirectory.value.toPath) / "**" / "rdf.proto"),
     commonSettings,
-    publishArtifact := false
   )
   .dependsOn(
     core % "compile->compile;test->test",

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
@@ -37,7 +37,7 @@ public interface TitaniumJellyEncoder extends RdfQuadConsumer {
 
     /**
      * Returns the rows in the encoded row buffer as a collection and clears the buffer.
-     * @return java.util.Iterable<RdfStreamRow>
+     * @return java.util.Iterable&lt;RdfStreamRow&gt;
      */
     Iterable<RdfStreamRow> getRows();
 


### PR DESCRIPTION
Issue: #348 

Ensures that pure Java modules are published without a dependency on Scala and without the `_3` suffix in package name.

I've also fixed some wonky internal dependencies (compile depended on test instead of the other way around), and I've re-enabled the publishing of all modules that should be published.