### PR TITLE
Implement parsing with a single row buffer

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/memory/SingleRowBuffer.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/memory/SingleRowBuffer.java
@@ -1,0 +1,83 @@
+package eu.neverblink.jelly.core.memory;
+
+import eu.neverblink.jelly.core.proto.v1.RdfStreamRow;
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * Buffer holding only a single RdfStreamRow message.
+ * This can be used only in parsers, where the row after being parsed from the binary stream is
+ * immediately passed to the consumer (ProtoDecoder). You must NEVER keep a reference to the row
+ * after calling appendMessage() or clear(), because it will be reused and its contents will
+ * be overwritten.
+ */
+public final class SingleRowBuffer extends AbstractCollection<RdfStreamRow> implements RowBuffer {
+
+    private final RdfStreamRow.Mutable row = RdfStreamRow.newInstance();
+    private boolean pendingRow = false;
+    private final Consumer<RdfStreamRow> consumer;
+
+    /**
+     * Package-private constructor.
+     * Use RowBuffer.newSingle(Consumer&lt;RdfStreamRow&gt;) instead.
+     * @param consumer consumer to which the row will be passed
+     */
+    SingleRowBuffer(Consumer<RdfStreamRow> consumer) {
+        this.consumer = consumer;
+    }
+    
+    @Override
+    public Collection<RdfStreamRow> getRows() {
+        return this;
+    }
+
+    @Override
+    public RdfStreamRow.Mutable appendMessage() {
+        if (pendingRow) {
+            // Send the previous row to the consumer
+            consumer.accept(row);
+        } else {
+            pendingRow = true;
+        }
+        return row;
+    }
+
+    @Override
+    public Iterator<RdfStreamRow> iterator() {
+        if (!pendingRow) {
+            return Collections.emptyIterator();
+        } else {
+            return new Iterator<>() {
+                private boolean hasNext = true;
+
+                @Override
+                public boolean hasNext() {
+                    return hasNext;
+                }
+
+                @Override
+                public RdfStreamRow next() {
+                    if (hasNext) {
+                        hasNext = false;
+                        return row;
+                    }
+                    throw new IllegalStateException("No more elements");
+                }
+            };
+        }
+    }
+
+    @Override
+    public int size() {
+        return pendingRow ? 1 : 0;
+    }
+
+    @Override
+    public void clear() {
+        if (pendingRow) {
+            // If there is a row waiting to be consumed, send it to the consumer
+            consumer.accept(row);
+            pendingRow = false;
+        }
+    }
+}

--- a/core/src/main/java/eu/neverblink/jelly/core/memory/SingleRowBuffer.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/memory/SingleRowBuffer.java
@@ -25,7 +25,7 @@ public final class SingleRowBuffer extends AbstractCollection<RdfStreamRow> impl
     SingleRowBuffer(Consumer<RdfStreamRow> consumer) {
         this.consumer = consumer;
     }
-    
+
     @Override
     public Collection<RdfStreamRow> getRows() {
         return this;


### PR DESCRIPTION
Closes #371

As noted in #371, it's not really possible to pass everything on the stack when parsing protos, as this would break the merging behavior of Protobuf. We can, however, only even construct a single RdfStreamRow, and then immediately pass that to the decoder, which is what we've implemented here.

As compared to ReusableRowBuffer, it has the same allocation complexity (constant), but the difference is that we are accessing much less memory when parsing the frame. There is no need to scan the entire array of RdfStreamRows, as we only have one row being processed at all times. This essentially guarantees it will always be in L1 cache.

The savings from this are not amazing, because these rows don't take up *that* much space in memory. I've seen an improvement of maybe 2–3% in parsing speeds. Still, I think it's worth it, as the code to implement it is extremely simple and there is nothing really that can be done to improve this part further.