### PR TITLE
Remove redundant readTag call in tableswitch-based mergeFrom

### DIFF
--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
@@ -269,8 +269,13 @@ class MessageGenerator(val info: MessageInfo):
     mergeFrom.beginControlFlow("case 0:").addStatement("return this").endControlFlow
     // default case -> skip field
     val ifSkipField = named("if (!input.skipField(tag))")
-    mergeFrom.beginControlFlow("default:").beginControlFlow(ifSkipField).addStatement("return this")
-    mergeFrom.endControlFlow.addStatement(named("tag = input.readTag()")).addStatement("break").endControlFlow
+    mergeFrom.beginControlFlow("default:")
+      .beginControlFlow(ifSkipField)
+      .addStatement("return this")
+      .endControlFlow
+    if enableFallthroughOptimization then
+      mergeFrom.addStatement(named("tag = input.readTag()"))
+    mergeFrom.addStatement("break").endControlFlow
     // Generate missing non-packed cases for packable fields for compatibility reasons
     for (field <- sortedFields) {
       if (field.info.isPackable) {


### PR DESCRIPTION
In the default case (skipping an unknown field) we had a redundant call to readTag(). This should only be done in the fallthrough-optimized version, as in that case it is the case body that reads the tag. In the tableswitch version, the tag is read at the start of the loop body instead.