### PR TITLE
Jena: Fix issues with unregistered format variants

### DIFF
--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
@@ -18,6 +18,8 @@ public final class JellyFormatVariant extends RDFFormatVariant {
     public static final int DEFAULT_FRAME_SIZE = 256;
     public static final boolean DEFAULT_ENABLE_NAMESPACE_DECLARATIONS = false;
     public static final boolean DEFAULT_DELIMITED = true;
+    // Constant name for all variants of the Jelly format, as all writers can handle all variants.
+    public static final String VARIANT_NAME = "Variant";
 
     private final RdfStreamOptions options;
     private final boolean enableNamespaceDeclarations;
@@ -113,7 +115,7 @@ public final class JellyFormatVariant extends RDFFormatVariant {
         int frameSize
     ) {
         // Constant, because all writers can handle all variants
-        super("Variant");
+        super(VARIANT_NAME);
         this.options = options;
         this.enableNamespaceDeclarations = enableNamespaceDeclarations;
         this.isDelimited = isDelimited;

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
@@ -112,7 +112,8 @@ public final class JellyFormatVariant extends RDFFormatVariant {
         boolean isDelimited,
         int frameSize
     ) {
-        super(options.getStreamName());
+        // Constant, because all writers can handle all variants
+        super("Variant");
         this.options = options;
         this.enableNamespaceDeclarations = enableNamespaceDeclarations;
         this.isDelimited = isDelimited;

--- a/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariantSpec.scala
+++ b/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariantSpec.scala
@@ -13,7 +13,7 @@ class JellyFormatVariantSpec extends AnyWordSpec, Matchers:
         .frameSize(512)
         .enableNamespaceDeclarations(true)
         .build()
-      variant.toString should be ("Variant")
+      variant.toString should be (JellyFormatVariant.VARIANT_NAME)
       variant.getOptions.getStreamName should be ("Test")
       variant.getOptions.getRdfStar should be (true)
       variant.getFrameSize should be (512)

--- a/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariantSpec.scala
+++ b/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariantSpec.scala
@@ -1,0 +1,25 @@
+package eu.neverblink.jelly.convert.jena.riot
+
+import eu.neverblink.jelly.core.JellyOptions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class JellyFormatVariantSpec extends AnyWordSpec, Matchers:
+  "JellyFormatVariant" should {
+    "be created with custom options" in {
+      val variant = JellyFormatVariant.builder()
+        .options(JellyOptions.BIG_ALL_FEATURES.clone().setStreamName("Test"))
+        .isDelimited(false)
+        .frameSize(512)
+        .enableNamespaceDeclarations(true)
+        .build()
+      variant.toString should be ("Variant")
+      variant.getOptions.getStreamName should be ("Test")
+      variant.getOptions.getRdfStar should be (true)
+      variant.getFrameSize should be (512)
+      variant.isEnableNamespaceDeclarations should be (true)
+      variant.isDelimited should be (false)
+    }
+  }
+
+


### PR DESCRIPTION
Because we were setting the name of the variant to the stream name from the options, if you tried to pass options with a custom stream name, you would get a Jena error saying that this variant is not registered.