### PR TITLE
Add JMH benchmarks and a failed RdfIri optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val titaniumApiV = "1.0.0"
 lazy val titaniumNqV = "1.0.2"
 lazy val protobufV = "4.31.0"
 lazy val javapoetV = "0.7.0"
+lazy val jmhV = "1.37"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
@@ -420,3 +421,17 @@ lazy val examples = (project in file("examples"))
     rdf4j,
     titaniumRdfApi
   )
+
+lazy val jmh = (project in file("jmh"))
+  .enablePlugins(JmhPlugin)
+  .settings(
+    publishArtifact := false,
+    name := "jelly-jmh",
+    description := "JMH benchmarks for Jelly-JVM.",
+    libraryDependencies ++= Seq(
+      "org.openjdk.jmh" % "jmh-core" % jmhV,
+      "org.openjdk.jmh" % "jmh-generator-annprocess" % jmhV,
+    ),
+    commonSettings,
+  )
+  .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -432,6 +432,7 @@ lazy val jmh = (project in file("jmh"))
       "org.openjdk.jmh" % "jmh-core" % jmhV,
       "org.openjdk.jmh" % "jmh-generator-annprocess" % jmhV,
     ),
+    publishArtifact := false,
     commonSettings,
   )
   .dependsOn(core)

--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -243,7 +243,8 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
         return msg;
     }
 
-    protected static <T extends ProtoMessage<T>> void mergeDelimitedFrom(T msg, LimitedCodedInputStream inputLimited)
+    @InternalApi
+    public static <T extends ProtoMessage<T>> void mergeDelimitedFrom(T msg, LimitedCodedInputStream inputLimited)
         throws IOException {
         inputLimited.checkRecursionDepth();
         inputLimited.incrementRecursionDepth();

--- a/jmh/README.md
+++ b/jmh/README.md
@@ -1,0 +1,19 @@
+See the README here: https://github.com/sbt/sbt-jmh
+
+Run all benchmarks with:
+
+```bash
+sbt jmh/Jmh/run
+```
+
+Or an individual benchmark, in this case with 10 warmup iterations and 10 iterations:
+
+```bash
+jmh/Jmh/run -wi 10 -i 10 .*RdfIriParseBench.*
+```
+
+To run with the perfasm profiler, use:
+
+```bash
+sbt jmh/Jmh/run -f1 -prof "perfasm:intelSyntax=true;tooBigThreshold=1500;top=3" .*RdfIriParseBench.*
+```

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/impl/RdfIriParseFallthrough.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/impl/RdfIriParseFallthrough.java
@@ -1,0 +1,277 @@
+package eu.neverblink.jelly.jmh.impl;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
+import eu.neverblink.protoc.java.runtime.LimitedCodedInputStream;
+import eu.neverblink.protoc.java.runtime.MessageFactory;
+import eu.neverblink.protoc.java.runtime.ProtoMessage;
+import java.io.IOException;
+import java.io.InputStream;
+
+public abstract class RdfIriParseFallthrough extends ProtoMessage<RdfIriParseFallthrough> implements Cloneable {
+
+    /**
+     * An empty instance of this message type.
+     */
+    public static final RdfIriParseFallthrough EMPTY = newInstance();
+
+    /**
+     * <code>optional uint32 prefix_id = 1;</code>
+     */
+    protected int prefixId;
+
+    /**
+     * <code>optional uint32 name_id = 2;</code>
+     */
+    protected int nameId;
+
+    protected int cachedSize = -1;
+
+    private RdfIriParseFallthrough() {}
+
+    /**
+     * @return a new empty instance of {@code Mutable}
+     */
+    public static RdfIriParseFallthrough.Mutable newInstance() {
+        return new RdfIriParseFallthrough.Mutable();
+    }
+
+    /**
+     * <code>optional uint32 prefix_id = 1;</code>
+     * @return the prefixId
+     */
+    public int getPrefixId() {
+        return prefixId;
+    }
+
+    /**
+     * <code>optional uint32 name_id = 2;</code>
+     * @return the nameId
+     */
+    public int getNameId() {
+        return nameId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof RdfIriParseFallthrough)) {
+            return false;
+        }
+        RdfIriParseFallthrough other = (RdfIriParseFallthrough) o;
+        return prefixId == other.prefixId && nameId == other.nameId;
+    }
+
+    @Override
+    public final void writeTo(final CodedOutputStream output) throws IOException {
+        if (prefixId != 0) {
+            output.writeRawByte((byte) 8);
+            output.writeUInt32NoTag(prefixId);
+        }
+        if (nameId != 0) {
+            output.writeRawByte((byte) 16);
+            output.writeUInt32NoTag(nameId);
+        }
+    }
+
+    @Override
+    public final int getSerializedSize() {
+        if (cachedSize < 0) {
+            cachedSize = computeSerializedSize();
+        }
+        return cachedSize;
+    }
+
+    @Override
+    protected final int computeSerializedSize() {
+        int size = 0;
+        if (prefixId != 0) {
+            size += 1 + CodedOutputStream.computeUInt32SizeNoTag(prefixId);
+        }
+        if (nameId != 0) {
+            size += 1 + CodedOutputStream.computeUInt32SizeNoTag(nameId);
+        }
+        return size;
+    }
+
+    @Override
+    public final int getCachedSize() {
+        return cachedSize;
+    }
+
+    /**
+     * Resets the cached size of this message.
+     * Call this method if you modify the message after it was serialized.
+     * NOTE: this is a SHALLOW operation! It will not reset the size of nested messages.
+     */
+    @Override
+    public final void resetCachedSize() {
+        cachedSize = -1;
+    }
+
+    @Override
+    public final RdfIriParseFallthrough.Mutable clone() {
+        return newInstance().copyFrom(this);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a byte array.
+     * This assumes that the message spans the entire array.
+     */
+    public static RdfIriParseFallthrough parseFrom(final byte[] data) throws InvalidProtocolBufferException {
+        return ProtoMessage.mergeFrom(newInstance(), data);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a {@link LimitedCodedInputStream}.
+     * This assumes that the message spans the entire input stream.
+     */
+    public static RdfIriParseFallthrough parseFrom(final LimitedCodedInputStream input) throws IOException {
+        return ProtoMessage.mergeFrom(newInstance(), input);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a Java {@link InputStream}.
+     * This assumes that the message spans the entire input stream.
+     */
+    public static RdfIriParseFallthrough parseFrom(final InputStream input) throws IOException {
+        return ProtoMessage.parseFrom(input, RdfIriParseFallthrough.getFactory());
+    }
+
+    /**
+     * Parse this message in DELIMITED form from a Java {@link InputStream}.
+     * If there is no message to be read, null will be returned.
+     * To read all delimited messages in the stream, call this method
+     * repeatedly until null is returned.
+     */
+    public static RdfIriParseFallthrough parseDelimitedFrom(final InputStream input) throws IOException {
+        return ProtoMessage.parseDelimitedFrom(input, RdfIriParseFallthrough.getFactory());
+    }
+
+    /**
+     * @return factory for creating RdfIriFastParse messages
+     */
+    public static MessageFactory<RdfIriParseFallthrough> getFactory() {
+        return RdfIriParseFallthrough.RdfIriFactory.INSTANCE;
+    }
+
+    /**
+     * @return this type's descriptor.
+     */
+    public static Descriptors.Descriptor getDescriptor() {
+        return null;
+    }
+
+    private enum RdfIriFactory implements MessageFactory<RdfIriParseFallthrough> {
+        INSTANCE;
+
+        @Override
+        public final RdfIriParseFallthrough create() {
+            return RdfIriParseFallthrough.newInstance();
+        }
+    }
+
+    /**
+     * Mutable subclass of the parent class.
+     * You can call setters on this class to set the values.
+     * When passing the constructed message to the serializer,
+     * you should use the parent class (using .asImmutable()) to
+     * ensure the message won't be modified by accident.
+     */
+    public static final class Mutable extends RdfIriParseFallthrough {
+
+        private Mutable() {}
+
+        /**
+         * <code>optional uint32 prefix_id = 1;</code>
+         * @param value the prefixId to set
+         * @return this
+         */
+        public Mutable setPrefixId(final int value) {
+            prefixId = value;
+            return this;
+        }
+
+        /**
+         * <code>optional uint32 name_id = 2;</code>
+         * @param value the nameId to set
+         * @return this
+         */
+        public Mutable setNameId(final int value) {
+            nameId = value;
+            return this;
+        }
+
+        @Override
+        public final Mutable copyFrom(final RdfIriParseFallthrough other) {
+            cachedSize = other.cachedSize;
+            prefixId = other.prefixId;
+            nameId = other.nameId;
+            return this;
+        }
+
+        @Override
+        public final Mutable mergeFrom(final RdfIriParseFallthrough other) {
+            cachedSize = -1;
+            setPrefixId(other.prefixId);
+            setNameId(other.nameId);
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("fallthrough")
+        public final Mutable mergeFrom(final LimitedCodedInputStream inputLimited) throws IOException {
+            final CodedInputStream input = inputLimited.in();
+            int tag = input.readTag();
+            while (true) {
+                switch (tag) {
+                    case 8: {
+                        // prefixId
+                        prefixId = input.readUInt32();
+                        tag = input.readTag();
+                        if (tag != 16) {
+                            break;
+                        }
+                    }
+                    case 16: {
+                        // nameId
+                        nameId = input.readUInt32();
+                        tag = input.readTag();
+                        if (tag != 0) {
+                            break;
+                        }
+                    }
+                    case 0: {
+                        return this;
+                    }
+                    default: {
+                        if (!input.skipField(tag)) {
+                            return this;
+                        }
+                        tag = input.readTag();
+                        break;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public final Mutable clear() {
+            prefixId = 0;
+            nameId = 0;
+            cachedSize = -1;
+            return this;
+        }
+
+        /**
+         * Returns this message as an immutable message, without any copies.
+         */
+        public RdfIriParseFallthrough asImmutable() {
+            return this;
+        }
+    }
+}

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/impl/RdfIriParseTableswitch.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/impl/RdfIriParseTableswitch.java
@@ -1,0 +1,270 @@
+package eu.neverblink.jelly.jmh.impl;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
+import eu.neverblink.protoc.java.runtime.LimitedCodedInputStream;
+import eu.neverblink.protoc.java.runtime.MessageFactory;
+import eu.neverblink.protoc.java.runtime.ProtoMessage;
+import java.io.IOException;
+import java.io.InputStream;
+
+public abstract class RdfIriParseTableswitch extends ProtoMessage<RdfIriParseTableswitch> implements Cloneable {
+
+    /**
+     * An empty instance of this message type.
+     */
+    public static final RdfIriParseTableswitch EMPTY = newInstance();
+
+    /**
+     * <code>optional uint32 prefix_id = 1;</code>
+     */
+    protected int prefixId;
+
+    /**
+     * <code>optional uint32 name_id = 2;</code>
+     */
+    protected int nameId;
+
+    protected int cachedSize = -1;
+
+    private RdfIriParseTableswitch() {}
+
+    /**
+     * @return a new empty instance of {@code Mutable}
+     */
+    public static RdfIriParseTableswitch.Mutable newInstance() {
+        return new RdfIriParseTableswitch.Mutable();
+    }
+
+    /**
+     * <code>optional uint32 prefix_id = 1;</code>
+     * @return the prefixId
+     */
+    public int getPrefixId() {
+        return prefixId;
+    }
+
+    /**
+     * <code>optional uint32 name_id = 2;</code>
+     * @return the nameId
+     */
+    public int getNameId() {
+        return nameId;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof RdfIriParseTableswitch)) {
+            return false;
+        }
+        RdfIriParseTableswitch other = (RdfIriParseTableswitch) o;
+        return prefixId == other.prefixId && nameId == other.nameId;
+    }
+
+    @Override
+    public final void writeTo(final CodedOutputStream output) throws IOException {
+        if (prefixId != 0) {
+            output.writeRawByte((byte) 8);
+            output.writeUInt32NoTag(prefixId);
+        }
+        if (nameId != 0) {
+            output.writeRawByte((byte) 16);
+            output.writeUInt32NoTag(nameId);
+        }
+    }
+
+    @Override
+    public final int getSerializedSize() {
+        if (cachedSize < 0) {
+            cachedSize = computeSerializedSize();
+        }
+        return cachedSize;
+    }
+
+    @Override
+    protected final int computeSerializedSize() {
+        int size = 0;
+        if (prefixId != 0) {
+            size += 1 + CodedOutputStream.computeUInt32SizeNoTag(prefixId);
+        }
+        if (nameId != 0) {
+            size += 1 + CodedOutputStream.computeUInt32SizeNoTag(nameId);
+        }
+        return size;
+    }
+
+    @Override
+    public final int getCachedSize() {
+        return cachedSize;
+    }
+
+    /**
+     * Resets the cached size of this message.
+     * Call this method if you modify the message after it was serialized.
+     * NOTE: this is a SHALLOW operation! It will not reset the size of nested messages.
+     */
+    @Override
+    public final void resetCachedSize() {
+        cachedSize = -1;
+    }
+
+    @Override
+    public final RdfIriParseTableswitch.Mutable clone() {
+        return newInstance().copyFrom(this);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a byte array.
+     * This assumes that the message spans the entire array.
+     */
+    public static RdfIriParseTableswitch parseFrom(final byte[] data) throws InvalidProtocolBufferException {
+        return ProtoMessage.mergeFrom(newInstance(), data);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a {@link LimitedCodedInputStream}.
+     * This assumes that the message spans the entire input stream.
+     */
+    public static RdfIriParseTableswitch parseFrom(final LimitedCodedInputStream input) throws IOException {
+        return ProtoMessage.mergeFrom(newInstance(), input);
+    }
+
+    /**
+     * Parse this message in NON-delimited form from a Java {@link InputStream}.
+     * This assumes that the message spans the entire input stream.
+     */
+    public static RdfIriParseTableswitch parseFrom(final InputStream input) throws IOException {
+        return ProtoMessage.parseFrom(input, RdfIriParseTableswitch.getFactory());
+    }
+
+    /**
+     * Parse this message in DELIMITED form from a Java {@link InputStream}.
+     * If there is no message to be read, null will be returned.
+     * To read all delimited messages in the stream, call this method
+     * repeatedly until null is returned.
+     */
+    public static RdfIriParseTableswitch parseDelimitedFrom(final InputStream input) throws IOException {
+        return ProtoMessage.parseDelimitedFrom(input, RdfIriParseTableswitch.getFactory());
+    }
+
+    /**
+     * @return factory for creating RdfIriFastParse messages
+     */
+    public static MessageFactory<RdfIriParseTableswitch> getFactory() {
+        return RdfIriParseTableswitch.RdfIriFactory.INSTANCE;
+    }
+
+    /**
+     * @return this type's descriptor.
+     */
+    public static Descriptors.Descriptor getDescriptor() {
+        return null;
+    }
+
+    private enum RdfIriFactory implements MessageFactory<RdfIriParseTableswitch> {
+        INSTANCE;
+
+        @Override
+        public final RdfIriParseTableswitch create() {
+            return RdfIriParseTableswitch.newInstance();
+        }
+    }
+
+    /**
+     * Mutable subclass of the parent class.
+     * You can call setters on this class to set the values.
+     * When passing the constructed message to the serializer,
+     * you should use the parent class (using .asImmutable()) to
+     * ensure the message won't be modified by accident.
+     */
+    public static final class Mutable extends RdfIriParseTableswitch {
+
+        private Mutable() {}
+
+        /**
+         * <code>optional uint32 prefix_id = 1;</code>
+         * @param value the prefixId to set
+         * @return this
+         */
+        public Mutable setPrefixId(final int value) {
+            prefixId = value;
+            return this;
+        }
+
+        /**
+         * <code>optional uint32 name_id = 2;</code>
+         * @param value the nameId to set
+         * @return this
+         */
+        public Mutable setNameId(final int value) {
+            nameId = value;
+            return this;
+        }
+
+        @Override
+        public final Mutable copyFrom(final RdfIriParseTableswitch other) {
+            cachedSize = other.cachedSize;
+            prefixId = other.prefixId;
+            nameId = other.nameId;
+            return this;
+        }
+
+        @Override
+        public final Mutable mergeFrom(final RdfIriParseTableswitch other) {
+            cachedSize = -1;
+            setPrefixId(other.prefixId);
+            setNameId(other.nameId);
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("fallthrough")
+        public final Mutable mergeFrom(final LimitedCodedInputStream inputLimited) throws IOException {
+            final CodedInputStream input = inputLimited.in();
+            while (true) {
+                int tag = input.readTag();
+                switch (tag >> 3) {
+                    case 1: {
+                        // prefixId
+                        prefixId = input.readUInt32();
+                        break;
+                    }
+                    case 2: {
+                        // nameId
+                        nameId = input.readUInt32();
+                        break;
+                    }
+                    case 0: {
+                        return this;
+                    }
+                    default: {
+                        if (!input.skipField(tag)) {
+                            return this;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public final Mutable clear() {
+            prefixId = 0;
+            nameId = 0;
+            cachedSize = -1;
+            return this;
+        }
+
+        /**
+         * Returns this message as an immutable message, without any copies.
+         */
+        public RdfIriParseTableswitch asImmutable() {
+            return this;
+        }
+    }
+}

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriParseBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriParseBench.scala
@@ -1,0 +1,77 @@
+package eu.neverblink.jelly.jmh
+
+import com.google.protobuf.CodedInputStream
+import eu.neverblink.jelly.core.proto.v1.RdfIri
+import eu.neverblink.jelly.jmh.impl.{RdfIriParseFallthrough, RdfIriParseTableswitch}
+import eu.neverblink.protoc.java.runtime.{LimitedCodedInputStream, ProtoMessage}
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+
+object RdfIriParseBench:
+  @State(Scope.Benchmark)
+  class BenchInput:
+    val random = new scala.util.Random(123)
+
+    // <maxPrefixId, chancePrefixIsZero, maxNameId, chanceNameIsZero>
+    @Param(Array("16,0.5,128,0.5", "1024,0.5,2048,0.5", "1024,0.1,2048,0.6", "1024,0.6,2048,0.1"))
+    // @Param(Array("16,0.5,128,0.5"))
+    var idDistribution: String = uninitialized
+
+    var toParse: Array[Byte] = uninitialized
+
+    val size = 1000
+
+    def getInputStream: LimitedCodedInputStream =
+      val is = new java.io.ByteArrayInputStream(toParse)
+      val cis = CodedInputStream.newInstance(is)
+      cis.pushLimit(toParse.length)
+      LimitedCodedInputStream(cis)
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      val (maxPrefixId, chancePrefixIsZero, maxNameId, chanceNameIsZero) = idDistribution.split(",").map(_.toDouble) match
+        case Array(a, b, c, d) => (a.toInt, b, c.toInt, d)
+        case _ => throw new IllegalArgumentException("Invalid idDistribution format")
+
+      val os = new java.io.ByteArrayOutputStream()
+      for i <- 0 until size do
+        val iri = RdfIri.newInstance()
+        if random.nextDouble() > chancePrefixIsZero then
+          iri.setPrefixId(random.nextInt(maxPrefixId) + 1)
+        if random.nextDouble() > chanceNameIsZero then
+          iri.setNameId(random.nextInt(maxNameId) + 1)
+        iri.writeDelimitedTo(os)
+      toParse = os.toByteArray
+
+
+class RdfIriParseBench:
+  import RdfIriParseBench.*
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def currentImplementation(input: BenchInput): Unit =
+    val inputStream = input.getInputStream
+    for i <- 0 until input.size do
+      val iri = RdfIri.newInstance()
+      ProtoMessage.mergeDelimitedFrom(iri, inputStream)
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def fallthroughSwitch(input: BenchInput): Unit =
+    val inputStream = input.getInputStream
+    for i <- 0 until input.size do
+      val iri = RdfIriParseFallthrough.newInstance()
+      ProtoMessage.mergeDelimitedFrom(iri, inputStream)
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def tableSwitch(input: BenchInput): Unit =
+    val inputStream = input.getInputStream
+    for i <- 0 until input.size do
+      val iri = RdfIriParseTableswitch.newInstance()
+      ProtoMessage.mergeDelimitedFrom(iri, inputStream)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,6 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.0-RC3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-protobuf" % "0.8.2")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 
 addDependencyTreePlugin


### PR DESCRIPTION
I tried optimizing RdfIri parsing, by applying the same pattern as we use in RdfStreamRow parsing (no fallthrough switches, use tableswitch instead). Unfortunately, it is slower:

```
jmh/Jmh/run -wi 10 -i 10 .*RdfIriParseBench.*

# JMH version: 1.37
# VM version: JDK 23.0.1, OpenJDK 64-Bit Server VM, 23.0.1+11-39
# VM invoker: /home/piotr/.jdks/openjdk-23.0.1/bin/java
# VM options: <none>
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 10 iterations, 10 s each
# Measurement: 10 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op

Benchmark                                (idDistribution)  Mode  Cnt      Score     Error  Units
RdfIriParseBench.currentImplementation     16,0.5,128,0.5  avgt   50   8013.556 ± 165.799  ns/op
RdfIriParseBench.currentImplementation  1024,0.5,2048,0.5  avgt   50   9915.374 ± 140.165  ns/op
RdfIriParseBench.currentImplementation  1024,0.1,2048,0.6  avgt   50  10656.719 ±  99.072  ns/op
RdfIriParseBench.currentImplementation  1024,0.6,2048,0.1  avgt   50  10779.323 ± 161.682  ns/op
RdfIriParseBench.fallthroughSwitch         16,0.5,128,0.5  avgt   50   7955.070 ±  84.041  ns/op
RdfIriParseBench.fallthroughSwitch      1024,0.5,2048,0.5  avgt   50   9726.173 ± 107.490  ns/op
RdfIriParseBench.fallthroughSwitch      1024,0.1,2048,0.6  avgt   50  10659.187 ± 131.323  ns/op
RdfIriParseBench.fallthroughSwitch      1024,0.6,2048,0.1  avgt   50  10669.884 ± 125.925  ns/op
RdfIriParseBench.tableSwitch               16,0.5,128,0.5  avgt   50   9199.859 ± 166.052  ns/op
RdfIriParseBench.tableSwitch            1024,0.5,2048,0.5  avgt   50  10249.307 ±  87.230  ns/op
RdfIriParseBench.tableSwitch            1024,0.1,2048,0.6  avgt   50  11563.919 ± 144.036  ns/op
RdfIriParseBench.tableSwitch            1024,0.6,2048,0.1  avgt   50  11208.897 ± 176.949  ns/op
```

`currentImplementation` and `fallthroughSwitch` should be the same. `tableSwitch` is the failed challenger.

So yeah, this doesn't work, but still, I put a lot of effort into setting up the JMH benchmark. I think this will be useful down the line, so it makes sense to commit the JMH setup to the repo.