### PR TITLE
Eliminate calls to checkLastTagWas

### DIFF
--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -150,10 +150,10 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      * Parse {@code input} as a message of this type and merge it with the
      * message being built.
      *
-     * @return this
+     * @return last read tag or 0 if the end of the message was reached.
      */
     @InternalApi
-    public abstract MessageType mergeFrom(CodedInputStream input, int remainingDepth) throws IOException;
+    public abstract int mergeFrom(CodedInputStream input, int remainingDepth) throws IOException;
 
     /**
      * Merge {@code other} into the message being built. {@code other} must have the exact same type
@@ -247,8 +247,9 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     @InternalApi
     public static <T extends ProtoMessage<T>> T mergeFrom(T msg, CodedInputStream input, int remainingDepth)
         throws IOException {
-        msg.mergeFrom(input, remainingDepth - 1);
-        input.checkLastTagWas(0);
+        if (msg.mergeFrom(input, remainingDepth - 1) != 0) {
+            throw new InvalidProtocolBufferException("Protocol message end-group tag did not match expected tag.");
+        }
         return msg;
     }
 
@@ -263,8 +264,9 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
         }
         final int length = input.readRawVarint32();
         final int oldLimit = input.pushLimit(length);
-        msg.mergeFrom(input, remainingDepth - 1);
-        input.checkLastTagWas(0);
+        if (msg.mergeFrom(input, remainingDepth - 1) != 0) {
+            throw new InvalidProtocolBufferException("Protocol message end-group tag did not match expected tag.");
+        }
         input.popLimit(oldLimit);
     }
 


### PR DESCRIPTION
Issue: #406 

Instead of accessing the last-read tag from memory, we pass it as the return value of the mergeFrom method.

This is a tiny bit faster:

```
running (fork) org.openjdk.jmh.Main -f5 -wi 10 -i 15 .*RdfTripleRecursiveBench.*
# JMH version: 1.37
# VM version: JDK 23.0.1, OpenJDK 64-Bit Server VM, 23.0.1+11-39
# VM invoker: /home/piotr/.jdks/openjdk-23.0.1/bin/java
# VM options: <none>
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 10 iterations, 10 s each
# Measurement: 15 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations


Benchmark
RdfTripleRecursiveBench.currentImplementation    avgt   75  31447.941 ± 532.946  ns/op
RdfTripleRecursiveBench.candidateImplementation  avgt   75  29820.133 ± 458.034  ns/op
```

I've also noticed that the skipField implementation for always-empty messages is incorrect, so I fixed that as well, to be able to skip more than one field.