### PR TITLE
Add benchmark for decoding RdfIri

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NameDecoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NameDecoderImpl.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
  * @param <TIri> The type of the IRI in the target RDF library.
  */
 @InternalApi
-final class NameDecoderImpl<TIri> implements NameDecoder<TIri> {
+public final class NameDecoderImpl<TIri> implements NameDecoder<TIri> {
 
     private static final class NameLookupEntry {
 

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriDecodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriDecodeBench.scala
@@ -1,0 +1,58 @@
+package eu.neverblink.jelly.jmh
+
+import eu.neverblink.jelly.core.internal.NameDecoderImpl
+import eu.neverblink.jelly.core.proto.v1.*
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.compiletime.uninitialized
+import scala.jdk.CollectionConverters.*
+
+object RdfIriDecodeBench:
+  @State(Scope.Benchmark)
+  class BenchInput:
+    var toDecode: Array[Object] = uninitialized
+    var nameTableSize: Int = 0
+    var prefixTableSize: Int = 0
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      val is = getClass.getResourceAsStream("/assist-iot-weather_100kt.jelly.gz")
+      val gzis = new java.util.zip.GZIPInputStream(is)
+      toDecode = Iterator
+        .continually(RdfStreamFrame.parseDelimitedFrom(gzis))
+        .takeWhile(_ != null)
+        .flatMap(_.getRows.asScala)
+        .flatMap(row => {
+          if row.hasOptions then
+            val opt = row.getOptions
+            nameTableSize = opt.getMaxNameTableSize
+            prefixTableSize = opt.getMaxPrefixTableSize
+            Seq()
+          else if row.hasPrefix then Some(row.getPrefix)
+          else if row.hasName then Seq(row.getName)
+          else if row.hasTriple then
+            val t = row.getTriple
+            Seq(t.getSubject, t.getPredicate, t.getObject)
+              .collect { case i: RdfIri => i }
+          else Seq()
+        })
+        .toArray
+
+
+class RdfIriDecodeBench:
+  import RdfIriDecodeBench.*
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def currentImplementation(blackhole: Blackhole, input: BenchInput): Unit =
+    val decoder = NameDecoderImpl[String](
+      input.prefixTableSize, input.nameTableSize, iri => iri
+    )
+    input.toDecode.foreach {
+      case iri: RdfIri => blackhole.consume(decoder.decode(iri.getPrefixId, iri.getNameId))
+      case name: RdfNameEntry => decoder.updateNames(name)
+      case prefix: RdfPrefixEntry => decoder.updatePrefixes(prefix)
+    }


### PR DESCRIPTION
Issue: #406 

I did that for testing a failed optimization in NameDecoderImpl. The optimization flattened `PrefixLookupEntry[] prefixLookup` into 2 separate arrays. This does save 50% of memory, but unfortunately it does result in not-so-optimal memory layout, so the results are negative:

```
# JMH version: 1.37
# VM version: JDK 23.0.1, OpenJDK 64-Bit Server VM, 23.0.1+11-39
# VM invoker: /home/piotr/.jdks/openjdk-23.0.1/bin/java
# VM options: <none>
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 10 iterations, 10 s each
# Measurement: 10 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op

Benchmark                                Mode  Cnt    Score    Error  Units
RdfIriDecodeBench.currentImplementation  avgt   50  903.803 ± 21.013  us/op
RdfIriDecodeBench.newImplementation      avgt   50  975.154 ± 10.191  us/op
```

So yeah, it's not working, but at least we have a new benchmark.