### PR TITLE
Fix reactive implementations swallowing errors in conformance tests

### DIFF
--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
@@ -192,11 +192,8 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
   private def isTestEntryBlockedById(testEntry: Resource): Boolean =
     // Unknown error
     // eu.neverblink.jelly.core.RdfProtoDeserializationError: Prefix entry with ID 0 is out of bounds of the prefix lookup table.
+    // This is caused by an invalid test case: https://github.com/Jelly-RDF/jelly-protobuf/issues/82
     testEntry.extractTestUri.contains("to_jelly/quads_rdf_1_1/pos_005")
-    // Does not fail
-    || testEntry.extractTestUri.contains("to_jelly/triples_rdf_1_1/neg_001")
-    // Does not fail
-    || testEntry.extractTestUri.contains("to_jelly/triples_rdf_1_1/neg_002")
     // java.lang.IllegalStateException: Expected 6 RDF elements, but got 0 elements.
     //    at eu.neverblink.jelly.integration_tests.util.OrderedRdfCompare$.compare(OrderedRdfCompare.scala:23)
     //    at eu.neverblink.jelly.integration_tests.rdf.ProtocolSpec.f$proxy2$1(ProtocolSpec.scala:125)

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
@@ -41,6 +41,7 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
     val f = JellyIo.fromIoStream(is)
       .via(DecoderFlow.decodeAny.asFlatStream(supportedOptions.getOrElse(JellyOptions.DEFAULT_SUPPORTED_OPTIONS)))
       .runWith(Sink.seq)
+    // Use Await.result to rethrow any exceptions that occur during the stream processing
     Await.result(f, 10.seconds)
 
   override def readTriplesJelly(file: File, supportedOptions: Option[RdfStreamOptions]): Seq[Triple] =
@@ -62,7 +63,7 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
         .flow
       )
       .runWith(JellyIo.toIoStream(os))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
 
   override def writeTriplesJelly
   (os: OutputStream, model: Model, opt: Option[RdfStreamOptions], frameSize: Int): Unit =
@@ -73,7 +74,7 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
         .flow
       )
       .runWith(JellyIo.toIoStream(os))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
 
 
   override def writeTriplesJelly(file: File, triples: Seq[Triple], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
@@ -85,7 +86,7 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
         .flow
       )
       .runWith(JellyIo.toIoStream(fileOs))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
     fileOs.close()
 
   override def writeQuadsJelly(file: File, quads: Seq[Quad], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
@@ -97,7 +98,7 @@ class JenaReactiveSerDes(implicit mat: Materializer) extends NativeSerDes[Model,
         .flow
       )
       .runWith(JellyIo.toIoStream(fileOs))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
     fileOs.close()
 
   override def isBlank(node: Node): Boolean = JenaStreamSerDes.isBlank(node)

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/Rdf4jReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/Rdf4jReactiveSerDes.scala
@@ -62,7 +62,8 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
         .flow
       )
       .runWith(JellyIo.toIoStream(os))
-    Await.ready(f, 10.seconds)
+    // Use Await.result to rethrow any exceptions that occur during the stream processing
+    Await.result(f, 10.seconds)
 
   override def writeTriplesJelly(file: File, triples: Seq[Statement], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val fileOs = new FileOutputStream(file)
@@ -73,7 +74,7 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
         .flow
       )
       .runWith(JellyIo.toIoStream(fileOs))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
     fileOs.close()
 
   override def writeQuadsJelly(os: OutputStream, dataset: Seq[Statement], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
@@ -84,7 +85,7 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
         .flow
       )
       .runWith(JellyIo.toIoStream(os))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
 
   override def writeQuadsJelly(file: File, quads: Seq[Statement], opt: Option[RdfStreamOptions], frameSize: Int): Unit =
     val fileOs = new FileOutputStream(file)
@@ -95,7 +96,7 @@ class Rdf4jReactiveSerDes(using Materializer) extends NativeSerDes[Seq[Statement
         .flow
       )
       .runWith(JellyIo.toIoStream(fileOs))
-    Await.ready(f, 10.seconds)
+    Await.result(f, 10.seconds)
     fileOs.close()
 
   override def isBlank(node: Value): Boolean = Rdf4jSerDes.isBlank(node)

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/JellyCli.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/JellyCli.scala
@@ -22,6 +22,7 @@ object JellyCli:
     val command = Seq(
       jellyCliFile.getAbsolutePath,
       "rdf", "validate",
+      "--debug",
       s"--compare-to-rdf-file=${expectedJelly.getAbsolutePath}",
       "--compare-ordered=true",
       frameIndexToCompare.map(i => s"--compare-frame-index=$i").getOrElse(""),


### PR DESCRIPTION
Issue #328 

Requires #420 to be merged first – hence this is a draft.

By using Await.ready we will not rethrow any exceptions that may have occurred within the Pekko Stream. Using Await.result fixes this issue.

I've also added a note about the cause for one conformance test's failures.