### PR TITLE
Fix parsing always-empty 0-length messages

### DIFF
--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
@@ -136,6 +136,19 @@ class ProtoAuxiliarySpec extends AnyWordSpec, Matchers:
     }
   }
 
+  "RdfGraphEnd" should {
+    "round-trip an empty message, non-delimited" in {
+      // This test is also applicable to other always-empty messages
+      // (e.g., transactions in Jelly-Patch, ACK messages in gRPC)
+      val end = RdfGraphEnd.newInstance()
+      // This will be an empty array
+      val bytes = end.toByteArray
+      // Parsing this 0-length array should yield the same empty message
+      val parsedEnd = RdfGraphEnd.parseFrom(bytes)
+      parsedEnd should be(end)
+    }
+  }
+
   // Tests for the core-protos-google module
   "proto.google.v1.RdfStreamFrame" should {
     "round-trip with non-delimited bytes" when {

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
@@ -226,6 +226,9 @@ class MessageGenerator(val info: MessageInfo):
       mergeFrom
         .beginControlFlow("while (true)")
         .addStatement(named("int tag = input.readTag()"))
+        .beginControlFlow(named("if (tag == 0)"))
+        .addStatement("return 0")
+        .endControlFlow()
         .beginControlFlow(ifSkipField)
         .addStatement("return tag")
         .endControlFlow


### PR DESCRIPTION
spin-off of #426, issue #381

We had trouble there with parsing non-delimited always empty messages. This was because of an unhandled case in a special version of the parsing code that's generated only for messages that don't have any fields.

I've added a regrtest for this. I've also checked this on top of #426 and it fixes the issue there.