### PR TITLE
Fix javac options (Java version, warnings->errors)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,9 @@ lazy val commonSettings = Seq(
     "-Werror",
     // TODO: enable more warnings
   ),
+  // Explicitly specify the options for javadoc, otherwise sbt will pass all javacOptions to it
+  // which will cause an error.
+  Compile / doc / javacOptions := Seq("-source", "17"),
   assemblyJarName := s"${name.value}.jar",
   assemblyMergeStrategy := {
     case x if x.endsWith("module-info.class") => MergeStrategy.concat


### PR DESCRIPTION
I fixed two things here.

- If you used a JDK newer than 17 to compile the project and had JAVA_HOME pointed to 17, you would receive an error when trying to compile the project, because we are using the system-default java version to run the crunchy protoc plugin. I added `-target 17` so that it always works.

- We had `-Werror` disabled only because of Google's proto classes being ugly. I've re-enabled it, with it disabled only for the core-protos-google module.