### PR TITLE
Update the licensing info page

### DIFF
--- a/docs/docs/licensing.md
+++ b/docs/docs/licensing.md
@@ -2,34 +2,35 @@
 
 Jelly-JVM is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
-Jelly-JVM contributors: https://github.com/Jelly-RDF/jelly-jvm/graphs/contributors
+Jelly-JVM contributors: [https://github.com/Jelly-RDF/jelly-jvm/graphs/contributors](https://github.com/Jelly-RDF/jelly-jvm/graphs/contributors)
 
 ## Jelly maintainer
 
-Jelly-JVM was originally created by [Piotr Sowiński](https://ostrzyciel.eu) ([GitHub](https://github.com/Ostrzyciel)) and is currently maintained by [NeverBlink](https://neverblink.eu).
+The entire Jelly tool stack is currently maintained by [NeverBlink](https://neverblink.eu).
+
+The Jelly protocol and Jelly-JVM were originally created by [Piotr Sowiński](https://ostrzyciel.eu) ([GitHub](https://github.com/Ostrzyciel)).
 
 ## Attribution / citation
 
-If you use Jelly-JVM in your research, please cite [the most recent paper about Jelly](https://ieeexplore.ieee.org/abstract/document/10152225):
+If you use Jelly in your research, please cite [the most recent paper about it](https://doi.org/10.48550/arXiv.2506.11298):
 
-Sowiński, P., Wasielewska-Michniewska, K., Ganzha, M., & Paprzycki, M. (2022, October). Efficient RDF streaming for the edge-cloud continuum. In _2022 IEEE 8th World Forum on Internet of Things (WF-IoT)_ (pp. 1-8). IEEE.
+Sowiński, P., Bogacka, K., Danilenka, A., Kozlov, N. (2025). Jelly: a fast and convenient RDF serialization format. In _arXiv preprint arXiv:2506.11298_. DOI: [10.48550/arXiv.2506.11298](https://doi.org/10.48550/arXiv.2506.11298)
 
 Or use this BibTeX entry:
 
 ```bibtex
-@inproceedings{sowinski2022efficient,
-  title={Efficient RDF streaming for the edge-cloud continuum},
-  author={Sowi{\'n}ski, Piotr and Wasielewska-Michniewska, Katarzyna and Ganzha, Maria and Paprzycki, Marcin and others},
-  booktitle={2022 IEEE 8th World Forum on Internet of Things (WF-IoT)},
-  pages={1--8},
-  year={2022},
-  organization={IEEE},
-  doi={10.1109/WF-IoT54382.2022.10152225}
+@article{sowinski2025jelly,
+  title = {Jelly: a fast and convenient RDF serialization format},
+  author = {Sowi{\'n}ski, Piotr and Bogacka, Karolina and Danilenka, Anastasiya and Kozlov, Nikita},
+  journal = {arXiv preprint arXiv:2506.11298},
+  year = {2025},
+  doi = {10.48550/arXiv.2506.11298},
 }
 ```
 
-This paper describes an earlier version of Jelly from 2022 that is very out-of-date with the current version of Jelly, but it is still a good starting point for understanding the design of the protocol and the motivation behind it.
+You can also check out an older paper that describes an earlier version of the Jelly protocol: *[Efficient RDF streaming for the edge-cloud continuum](https://doi.org/10.1109/WF-IoT54382.2022.10152225)*.
 
 ## See also
 
 - [Contributing to Jelly-JVM](contributing/index.md)
+- [Projects and funding]({{ proto_link('licensing/projects') }})


### PR DESCRIPTION
Same as: https://github.com/Jelly-RDF/jelly-rdf.github.io/pull/52