### PR TITLE
Fix incorrect names for Pekko-related modules in docs

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/JellyOptions.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/JellyOptions.java
@@ -127,7 +127,7 @@ public class JellyOptions {
      *   This MUST be called before any data (besides the stream options) is ingested. Otherwise, the options may
      *   request something dangerous, like allocating a very large lookup table, which could be used to perform a
      *   denial-of-service attack.
-     * - By implementations the gRPC streaming service from the jelly-grpc module to check if the client is
+     * - By implementations the gRPC streaming service from the jelly-pekko-grpc module to check if the client is
      *   requesting stream options that the server can support.
      * <p>
      * We check:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -38,7 +38,7 @@ The implementation is split into a few modules that can be used separately:
     - {{ scala_module_badges('pekko-stream') }}
 
 - `jelly-pekko-grpc` – implementation of a gRPC client and server for the [Jelly gRPC streaming protocol]({{ proto_link( 'specification/streaming' ) }}). **[:octicons-arrow-right-24: Learn more](user/grpc.md)**
-    - {{ scala_module_badges('grpc') }}
+    - {{ scala_module_badges('pekko-grpc') }}
 
 ## Plugin JARs
 

--- a/docs/docs/user/grpc.md
+++ b/docs/docs/user/grpc.md
@@ -1,6 +1,6 @@
 # User guide – gRPC
 
-This guide explains the functionalities of the `jelly-grpc` module, which implements a gRPC client and server for the [Jelly gRPC streaming protocol]({{ proto_link('specification/streaming') }}).
+This guide explains the functionalities of the `jelly-pekko-grpc` module, which implements a gRPC client and server for the [Jelly gRPC streaming protocol]({{ proto_link('specification/streaming') }}).
 
 !!! info "Prerequisites"
 
@@ -10,15 +10,15 @@ This guide explains the functionalities of the `jelly-grpc` module, which implem
 
     You may also want to first skim the **[Jelly gRPC streaming protocol specification]({{ proto_link('specification/streaming') }})** to understand the protocol's structure.
 
-As with the `jelly-stream` module, you can use `jelly-grpc` with any RDF library that has a Jelly integration, such as [Apache Jena](jena.md) (using `jelly-jena`) or [RDF4J](rdf4j.md) (using `jelly-rdf4j`). The gRPC API is generic and identical across all libraries.
+As with the `jelly-pekko-stream` module, you can use `jelly-pekko-grpc` with any RDF library that has a Jelly integration, such as [Apache Jena](jena.md) (using `jelly-jena`) or [RDF4J](rdf4j.md) (using `jelly-rdf4j`). The gRPC API is generic and identical across all libraries.
 
 ## Making a gRPC server and client
 
-`jelly-grpc` builds on the [Apache Pekko gRPC library](https://pekko.apache.org/docs/pekko-grpc/current/index.html). Jelly-JVM provides boilerplate code for setting up a gRPC server and client that can send and receive Jelly streams, as shown in the example below:
+`jelly-pekko-grpc` builds on the [Apache Pekko gRPC library](https://pekko.apache.org/docs/pekko-grpc/current/index.html). Jelly-JVM provides boilerplate code for setting up a gRPC server and client that can send and receive Jelly streams, as shown in the example below:
 
 {{ code_example('PekkoGrpc.scala') }}
 
-The classes provided in `jelly-grpc` should cover most cases, but they only serve as the boilerplate. You must yourself define the logic for handling the incoming and outgoing streams, as shown in the example above.
+The classes provided in `jelly-pekko-grpc` should cover most cases, but they only serve as the boilerplate. You must yourself define the logic for handling the incoming and outgoing streams, as shown in the example above.
 
 Of course, you can also implement the server or the client from scratch, if you want to.
 

--- a/docs/docs/user/low-level.md
+++ b/docs/docs/user/low-level.md
@@ -2,7 +2,7 @@
 
 !!! warning
 
-    This page describes a low-level API that is a bit of a hassle to use directly. It's recommended to use the higher-level abstractions provided by the [`jelly-stream` module](reactive.md), or the integrations with [Apache Jena's RIOT](jena.md) or [RDF4J's Rio](rdf4j.md) libraries. If you really want to use this, it is highly recommended that you first get a [basic understanding of how Jelly works under the hood]({{ proto_link('user-guide') }}) and take a look at the [code in the `jelly-stream` module]({{ git_link('stream') }}) to see how it's done there.
+    This page describes a low-level API that is a bit of a hassle to use directly. It's recommended to use the higher-level abstractions provided by the [`jelly-pekko-stream` module](reactive.md), or the integrations with [Apache Jena's RIOT](jena.md) or [RDF4J's Rio](rdf4j.md) libraries. If you really want to use this, it is highly recommended that you first get a [basic understanding of how Jelly works under the hood]({{ proto_link('user-guide') }}) and take a look at the [code in the `jelly-pekko-stream` module]({{ git_link('stream') }}) to see how it's done there.
 
 !!! note
 


### PR DESCRIPTION
jelly-grpc is jelly-pekko-grpc – I think now it should be all correct.