### PR TITLE
gRPC: parse messages from ByteString if possible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -537,5 +537,5 @@ lazy val grpc = (project in file("pekko-grpc"))
     Compile / sourceManaged := sourceManaged.value / "main",
     commonSettings,
   )
-  .dependsOn(stream % "test->compile")
+  .dependsOn(stream)
   .dependsOn(core % "compile->compile;test->test")

--- a/pekko-grpc/src/main/scala/eu/neverblink/jelly/grpc/RdfStreamService.scala
+++ b/pekko-grpc/src/main/scala/eu/neverblink/jelly/grpc/RdfStreamService.scala
@@ -34,9 +34,9 @@ object RdfStreamService extends ServiceDescription {
     Grpc.getDescriptor;
 
   object Serializers {
-    val RdfStreamSubscribeSerializer = new CrunchyProtobufSerializer[RdfStreamSubscribe](RdfStreamSubscribe.parseFrom)
-    val RdfStreamFrameSerializer = new CrunchyProtobufSerializer[RdfStreamFrame](RdfStreamFrame.parseFrom)
-    val RdfStreamReceivedSerializer = new CrunchyProtobufSerializer[RdfStreamReceived](RdfStreamReceived.parseFrom)
+    val RdfStreamSubscribeSerializer = new CrunchyProtobufSerializer[RdfStreamSubscribe](RdfStreamSubscribe.getFactory)
+    val RdfStreamFrameSerializer = new CrunchyProtobufSerializer[RdfStreamFrame](RdfStreamFrame.getFactory)
+    val RdfStreamReceivedSerializer = new CrunchyProtobufSerializer[RdfStreamReceived](RdfStreamReceived.getFactory)
   }
 
   object MethodDescriptors {

--- a/pekko-grpc/src/main/scala/eu/neverblink/jelly/grpc/utils/CrunchyProtobufSerializer.scala
+++ b/pekko-grpc/src/main/scala/eu/neverblink/jelly/grpc/utils/CrunchyProtobufSerializer.scala
@@ -1,18 +1,22 @@
 package eu.neverblink.jelly.grpc.utils
 
-import eu.neverblink.protoc.java.runtime.ProtoMessage
+import eu.neverblink.jelly.pekko.stream.PekkoUtil
+import eu.neverblink.protoc.java.runtime.{MessageFactory, ProtoMessage}
 import org.apache.pekko.grpc.ProtobufSerializer
 import org.apache.pekko.util.ByteString
 
 import java.io.InputStream
 
-class CrunchyProtobufSerializer[T <: ProtoMessage[T]](parser: InputStream => T) extends ProtobufSerializer[T] {
+class CrunchyProtobufSerializer[T <: ProtoMessage[T]](factory: MessageFactory[T])
+  extends ProtobufSerializer[T] {
 
   override def serialize(t: T): ByteString =
     ByteString.fromArrayUnsafe(t.toByteArray)
 
   override def deserialize(bytes: ByteString): T =
-    parser(bytes.asInputStream)
+    // Parse directly from ByteString, avoiding the overhead of InputStream
+    PekkoUtil.parseFromByteString(bytes, factory)
+
   override def deserialize(data: InputStream): T =
-    parser(data)
+    ProtoMessage.parseFrom(data, factory)
 }

--- a/pekko-grpc/src/test/scala/eu/neverblink/jelly/grpc/GrpcSpec.scala
+++ b/pekko-grpc/src/test/scala/eu/neverblink/jelly/grpc/GrpcSpec.scala
@@ -34,13 +34,13 @@ class GrpcSpec extends AnyWordSpec, Matchers, ScalaFutures, BeforeAndAfterAll:
     """
       |pekko.http.server.preview.enable-http2 = on
       |pekko.grpc.client.jelly-no-gzip.host = 127.0.0.1
-      |pekko.grpc.client.jelly-no-gzip.port = 18080
+      |pekko.grpc.client.jelly-no-gzip.port = 8080
       |pekko.grpc.client.jelly-no-gzip.enable-gzip = false
       |pekko.grpc.client.jelly-no-gzip.use-tls = false
       |pekko.grpc.client.jelly-no-gzip.backend = netty
       |
       |pekko.grpc.client.jelly-gzip.host = 127.0.0.1
-      |pekko.grpc.client.jelly-gzip.port = 18081
+      |pekko.grpc.client.jelly-gzip.port = 8081
       |pekko.grpc.client.jelly-gzip.enable-gzip = true
       |pekko.grpc.client.jelly-gzip.use-tls = false
       |pekko.grpc.client.jelly-gzip.backend = netty

--- a/pekko-grpc/src/test/scala/eu/neverblink/jelly/grpc/GrpcSpec.scala
+++ b/pekko-grpc/src/test/scala/eu/neverblink/jelly/grpc/GrpcSpec.scala
@@ -34,13 +34,13 @@ class GrpcSpec extends AnyWordSpec, Matchers, ScalaFutures, BeforeAndAfterAll:
     """
       |pekko.http.server.preview.enable-http2 = on
       |pekko.grpc.client.jelly-no-gzip.host = 127.0.0.1
-      |pekko.grpc.client.jelly-no-gzip.port = 8080
+      |pekko.grpc.client.jelly-no-gzip.port = 18080
       |pekko.grpc.client.jelly-no-gzip.enable-gzip = false
       |pekko.grpc.client.jelly-no-gzip.use-tls = false
       |pekko.grpc.client.jelly-no-gzip.backend = netty
       |
       |pekko.grpc.client.jelly-gzip.host = 127.0.0.1
-      |pekko.grpc.client.jelly-gzip.port = 8081
+      |pekko.grpc.client.jelly-gzip.port = 18081
       |pekko.grpc.client.jelly-gzip.enable-gzip = true
       |pekko.grpc.client.jelly-gzip.use-tls = false
       |pekko.grpc.client.jelly-gzip.backend = netty

--- a/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/PekkoUtil.scala
+++ b/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/PekkoUtil.scala
@@ -1,0 +1,36 @@
+package eu.neverblink.jelly.pekko.stream
+
+import com.google.protobuf.CodedInputStream
+import eu.neverblink.protoc.java.runtime.{MessageFactory, ProtoMessage}
+import org.apache.pekko.util.ByteString
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Utilities for using Jelly-JVM together with Apache Pekko.
+ */
+object PekkoUtil:
+  /**
+   * Parses a Protobuf message from a Pekko ByteString.
+   *
+   * The input ByteString must contain a single Protobuf message, with no additional framing or length prefix.
+   *
+   * This method should be preferred over constructing an InputStream from the ByteString, as it
+   * gives the parser more direct access to the underlying data structure.
+   *
+   * @param input The ByteString containing the Protobuf message data.
+   * @param messageFactory The factory to create the message instance.
+   * @tparam T The type of the message to parse
+   * @return parsed message
+   */
+  def parseFromByteString[T <: ProtoMessage[T]](
+    input: ByteString, messageFactory: MessageFactory[T]
+  ): T =
+    val message = messageFactory.create()
+    val byteBuffers = input.asByteBuffers
+    // If the ByteString contains only one ByteBuffer, we pass it directly to CodedInputStream.
+    // CodedInputStream will then apply extra optimizations for faster parsing.
+    val codedInputStream = if byteBuffers.size == 1 then
+      CodedInputStream.newInstance(byteBuffers.head)
+    else CodedInputStream.newInstance(byteBuffers.asJava)
+    ProtoMessage.mergeFrom(message, codedInputStream, ProtoMessage.DEFAULT_MAX_RECURSION_DEPTH)

--- a/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
+++ b/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
@@ -55,12 +55,12 @@ object JellyIoOps:
     /**
      * Convert a stream of NON-DELIMITED bytes into a stream of Jelly frames. Each ByteString in the stream
      * MUST correspond to exactly one Jelly frame and contain no additional data (e.g., no length prefix).
-     * 
+     *
      * If you are reading from a file or socket, you should use the `fromByteStringsDelimited` method instead.
-     * 
+     *
      * This method is useful when you have a stream of Jelly frames that are already delimited, such as when
      * reading from Kafka or gRPC.
-     * 
+     *
      * @return Pekko Flow
      */
     final def fromByteStrings: Flow[ByteString, RdfStreamFrame, NotUsed] =
@@ -84,7 +84,7 @@ object JellyIoOps:
      *
      * Using this method you can read Jelly files from a file or socket in a fully reactive manner,
      * without any blocking operations. It's useful when combined with Pekko's `FileIO` API.
-     * 
+     *
      * @param maxMessageSize Maximum allowed size for a Protobuf message, in bytes.
      *                       If a message exceeds this size, the stage will fail.
      *                       It is highly recommended to set this to a reasonable value, like 4MB (the default).

--- a/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/ProtobufMessageFramingStage.scala
+++ b/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/ProtobufMessageFramingStage.scala
@@ -10,13 +10,13 @@ import org.apache.pekko.util.ByteString
  *
  * This stage reads a stream of ByteStrings and emits complete (non-delimited) Protobuf messages as ByteStrings.
  * It expects the Protobuf messages to be prefixed with a varint that indicates the length of the message.
- * 
+ *
  * This is largely based on `DelimiterFramingStage` from Apache Pekko.
  * Original source:
  * https://github.com/apache/pekko/blob/947ee49293dd57cb488259efac356accfb5c18d3/stream/src/main/scala/org/apache/pekko/stream/scaladsl/Framing.scala#L209
- * 
+ *
  * Original license notice:
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more * license agreements; and
  * to You under the Apache License, version 2.0: https://www.apache.org/licenses/LICENSE-2.0 This
  * file is part of the Apache Pekko project, which was derived from Akka.


### PR DESCRIPTION
Follow-up of #446

We can use the same direct ByteString parser also in the `pekko-grpc` module. I've added a utility for that in `pekko-stream`. Note that it did require me to add a dependency on `pekko-stream` from grpc... which I'm not sure why we didn't have before, the two should be used in tandem anyway.
