### PR TITLE
Add two missing examples to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 
 # Output files of example code
 /*.jelly
+/*.nq
 
 .metals/
 

--- a/examples/src/test/scala/eu/neverblink/jelly/examples/ExamplesSpec.scala
+++ b/examples/src/test/scala/eu/neverblink/jelly/examples/ExamplesSpec.scala
@@ -9,11 +9,13 @@ class ExamplesSpec extends AnyWordSpec, Matchers, JenaTest:
   val examples: Seq[Example] = Seq(
     JenaRiot(),
     JenaRiotStreaming(),
+    PekkoGrpc,
     PekkoStreamsDecoderFlow,
     PekkoStreamsEncoderFlow,
     PekkoStreamsEncoderSource,
     PekkoStreamsWithIo,
     Rdf4jRio(),
+    TitaniumRdfApi(),
   )
 
   for example <- examples do


### PR DESCRIPTION
We missed them by accident, should also be tested in CI.

We should not make the same mistake again, as we have codecov now – it will shout at us for doing that. Theoretically we could also use reflection to discover all examples, but I feel like that's overcomplicating things.