### PR TITLE
WIP: resolving issues with codecov

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -48,18 +48,33 @@ jobs:
     - name: Build and test
       shell: bash
       run: sbt -v +test
-      if: ${{ matrix.java != env.java_latest }}
 
-    - name: Build and test (with coverage)
+  test-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ env.java_latest }}
+
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
+    - name: Build and test with coverage
       shell: bash
-      run: sbt -v coverage +test coverageReport coverageAggregate
-      if: ${{ matrix.java == env.java_latest }}
+      run: sbt -v coverage +test coverageReport coverageAggregate jacocoAggregate
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: ${{ matrix.java == env.java_latest }}
       with:
-        fail_ci_if_error: false
+        fail_ci_if_error: true # This is an independent check, so it's okay to fail
         slug: Jelly-RDF/jelly-jvm
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   java_latest: 24
   java_publish: 17
+  JELLY_TEST_SILENCE_OUTPUT: 'true'
 
 jobs:
   # Run scalatest
@@ -27,8 +28,6 @@ jobs:
           - os: ubuntu-latest
             java: 24
     runs-on: ${{ matrix.os }}
-    env:
-      JELLY_TEST_SILENCE_OUTPUT: 'true'
 
     steps:
     - name: Checkout

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: ${{ env.java_publish }}
+        java-version: 21 # coverage must run on an LTS version
 
     - name: Setup SBT
       uses: sbt/setup-sbt@v1

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: ${{ env.java_latest }}
+        java-version: 21 # coverage must run on an LTS version
 
     - name: Setup SBT
       uses: sbt/setup-sbt@v1
@@ -91,7 +91,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 21 # coverage must run on an LTS version
+        java-version: ${{ env.java_publish }}
 
     - name: Setup SBT
       uses: sbt/setup-sbt@v1

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,9 @@ lazy val commonSettings = Seq(
     case x => assemblyMergeStrategy.value(x)
   },
   crossVersion := CrossVersion.binary,
+  jacocoAggregateReportSettings := JacocoReportSettings(
+    formats = Seq(JacocoReportFormats.XML)
+  )
 )
 
 // Shared settings for all Java-only modules
@@ -500,7 +503,6 @@ lazy val jmh = (project in file("jmh"))
       "org.openjdk.jmh" % "jmh-core" % jmhV,
       "org.openjdk.jmh" % "jmh-generator-annprocess" % jmhV,
     ),
-    publishArtifact := false,
     commonSettings,
   )
   .dependsOn(core, jena)

--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,6 @@ ThisBuild / developers := List(
 )
 // Allow scalatest to control the logging output
 Test / logBuffered := false
-Test / javaOptions ++= Seq(
-  // Disable Jacoco instrumentation by default, to make test execution faster and to make it pass
-  // on JDK 22+ where Jacoco instrumentation is not supported.
-  "-Djacoco.skip=true"
-)
 
 lazy val pekkoV = "1.1.5"
 lazy val pekkoGrpcV = "1.1.1"
@@ -63,6 +58,11 @@ lazy val commonSettings = Seq(
   crossVersion := CrossVersion.binary,
   jacocoAggregateReportSettings := JacocoReportSettings(
     formats = Seq(JacocoReportFormats.XML)
+  ),
+  Test / javaOptions ++= Seq(
+    // Disable Jacoco instrumentation by default, to make test execution faster and to make it pass
+    // on JDK 22+ where Jacoco instrumentation is not supported.
+    "-Djacoco.skip=true"
   )
 )
 
@@ -287,6 +287,7 @@ lazy val coreProtosGoogle = (project in file("core-protos-google"))
     ProtobufConfig / protobufIncludeFilters := Seq(Glob(baseDirectory.value.toPath) / "**" / "rdf.proto"),
     // Don't throw errors, because Google's protoc generates code with a lot of warnings
     javacOptions := javacOptions.value.filterNot(_ == "-Werror"),
+    commonSettings,
     commonJavaSettings,
   )
 
@@ -331,6 +332,7 @@ lazy val corePatchProtosGoogle = (project in file("core-patch-protos-google"))
     Compile / compile := (Compile / compile).dependsOn(prepareGoogleProtos).value,
     ProtobufConfig / protobufRunProtoc := (ProtobufConfig / protobufRunProtoc).dependsOn(prepareGoogleProtos).value,
     ProtobufConfig / protobufIncludeFilters := Seq(Glob(baseDirectory.value.toPath) / "**" / "patch.proto"),
+    commonSettings,
     commonJavaSettings,
   ).dependsOn(coreProtosGoogle)
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,11 @@ ThisBuild / developers := List(
 )
 // Allow scalatest to control the logging output
 Test / logBuffered := false
+Test / javaOptions ++= Seq(
+  // Disable Jacoco instrumentation by default, to make test execution faster and to make it pass
+  // on JDK 22+ where Jacoco instrumentation is not supported.
+  "-Djacoco.skip=true"
+)
 
 lazy val pekkoV = "1.1.5"
 lazy val pekkoGrpcV = "1.1.1"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  - "docs"
+  - "jmh"  # benchmarks for development purposes
+  - "integration-tests"  # only tests
+  - "crunchy-protoc-plugin"  # Not shipped to users, only used for compilation

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-protobuf" % "0.8.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.5.0")
 
 addDependencyTreePlugin


### PR DESCRIPTION
This seeks to resolve *some* of the issues that we currently have with coverage reporting:

- Add coverage measurement for Java, using Jacoco
- Add excludes for a few parts of the repo that should not be included in the coverage estimate
- Clean up CI to make the coverage job separate from tests

Currently, this underreports coverage for Java, because Jacoco can't recognize cross-module coverage. I will solve that in a separate PR.