### PR TITLE
hotfix: fix factory return type for JenaChangesCollector

### DIFF
--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/patch/impl/JenaImplementation.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/patch/impl/JenaImplementation.scala
@@ -28,12 +28,12 @@ object JenaImplementation extends RdfPatchImplementation[JenaChangesCollector]:
   override def name: String = "Jena"
 
   override def readRdf(in: InputStream, stType: PatchStatementType): JenaChangesCollector =
-    val collector = JenaChangesCollector(stType)
+    val collector = JellyPatchOps.changesCollector(stType)
     RDFPatchReaderText(in).apply(collector)
     collector
 
   override def readRdf(files: Seq[File], stType: PatchStatementType, flat: Boolean): JenaChangesCollector =
-    val collector = JenaChangesCollector(stType)
+    val collector = JellyPatchOps.changesCollector(stType)
     for filename <- files do
       val in = new FileInputStream(filename)
       RDFPatchReaderText(in).apply(collector)
@@ -42,7 +42,7 @@ object JenaImplementation extends RdfPatchImplementation[JenaChangesCollector]:
     collector
 
   override def readJelly(in: InputStream, supportedOptions: Option[RdfPatchOptions]): JenaChangesCollector =
-    val collector = JenaChangesCollector(PatchStatementType.UNSPECIFIED)
+    val collector = JellyPatchOps.changesCollector(PatchStatementType.UNSPECIFIED)
     RdfPatchReaderJelly(
       RdfPatchReaderJelly.Options(supportedOptions.getOrElse(JellyPatchOptions.DEFAULT_SUPPORTED_OPTIONS)),
       JenaPatchConverterFactory.getInstance(),

--- a/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/JellyPatchOps.java
+++ b/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/JellyPatchOps.java
@@ -74,7 +74,7 @@ public class JellyPatchOps {
      * @param stType How to interpret the statements: TRIPLES or QUADS.
      * @return A Jena RDFChanges collector that can be used to collect changes and replay them later.
      */
-    public static RDFChanges changesCollector(PatchStatementType stType) {
+    public static JenaChangesCollector changesCollector(PatchStatementType stType) {
         return new JenaChangesCollector(stType);
     }
 }

--- a/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/JenaChangesCollector.java
+++ b/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/JenaChangesCollector.java
@@ -23,13 +23,10 @@ public final class JenaChangesCollector implements RDFChanges {
 
     /**
      * Creates a new JenaChangesCollector with the specified statement type.
-     * <p>
-     * Public only for tests, use JellyPatchOpt.changesCollector instead.
      *
      * @param stType How to interpret the statements: TRIPLES or QUADS.
      */
-    @InternalApi
-    public JenaChangesCollector(PatchStatementType stType) {
+    JenaChangesCollector(PatchStatementType stType) {
         this.stType = stType;
     }
 


### PR DESCRIPTION
I made the return type of JellyPatchOps.changesCollector into `RDFChanges`... which makes all the special methods related to collecting changes inaccessible.

(sigh)

Sorry, we'll need to make a 3.3.1 hotfix release.