### PR TITLE
ProtoEncoder: make sure sizes are really precomputed

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -57,7 +57,7 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         if (!hasEmittedOptions) {
             throw new RdfProtoSerializationError("Cannot end a delimited graph before starting one");
         }
-        rowBuffer.appendMessage().setGraphEnd(RdfGraphEnd.EMPTY);
+        rowBuffer.appendMessage().setGraphEnd(RdfGraphEnd.EMPTY).getSerializedSize();
     }
 
     @Override
@@ -72,7 +72,7 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         this.currentNsBase = ns;
         this.currentTerm = SpoTerm.NAMESPACE;
         converter.nodeToProto(getNodeEncoder(), namespace);
-        rowBuffer.appendMessage().setNamespace(ns);
+        rowBuffer.appendMessage().setNamespace(ns).getSerializedSize();
     }
 
     @Override
@@ -96,6 +96,6 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         }
 
         hasEmittedOptions = true;
-        rowBuffer.appendMessage().setOptions(options);
+        rowBuffer.appendMessage().setOptions(options).getSerializedSize();
     }
 }

--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoEncoderSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoEncoderSpec.scala
@@ -28,8 +28,12 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
         rowBuffer = buffer,
         allocator = EncoderAllocator.newHeapAllocator(),
       ))
+
       Triples1.mrl.foreach(triple => encoder.handleTriple(triple.s, triple.p, triple.o))
-      assertEncoded(buffer.getRows.asScala.toSeq, Triples1.encoded(options))
+
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Triples1.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "encode triple statements with ns decls and an external buffer" in {
@@ -50,7 +54,9 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
           case t: Triple => encoder.handleTriple(t.s, t.p, t.o)
           case ns: NamespaceDeclaration => encoder.handleNamespace(ns.prefix, Iri(ns.iri))
 
-      assertEncoded(buffer.getRows.asScala.toSeq, Triples2NsDecl.encoded(options))
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Triples2NsDecl.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "encode quad statements" in {
@@ -67,7 +73,10 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
       ))
 
       Quads1.mrl.foreach(quad => encoder.handleQuad(quad.s, quad.p, quad.o, quad.g))
-      assertEncoded(buffer.getRows.asScala.toSeq, Quads1.encoded(options))
+
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Quads1.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "encode quad statements with an external buffer" in {
@@ -86,7 +95,9 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
       for quad <- Quads1.mrl do
         encoder.handleQuad(quad.s, quad.p, quad.o, quad.g)
 
-      assertEncoded(buffer.getRows.asScala.toSeq, Quads1.encoded(options))
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Quads1.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "encode quad statements (repeated default graph)" in {
@@ -103,7 +114,10 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
       ))
 
       Quads2RepeatDefault.mrl.foreach(quad => encoder.handleQuad(quad.s, quad.p, quad.o, quad.g))
-      assertEncoded(buffer.getRows.asScala.toSeq, Quads2RepeatDefault.encoded(options))
+
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Quads2RepeatDefault.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "encode graphs with an external buffer" in {
@@ -125,7 +139,9 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
           encoder.handleTriple(triple.s, triple.p, triple.o)
         encoder.handleGraphEnd()
 
-      assertEncoded(buffer.getRows.asScala.toSeq, Graphs1.encoded(options))
+      val observed = buffer.getRows.asScala.toSeq
+      assertEncoded(observed, Graphs1.encoded(options))
+      assertSizesPrecomputed(observed)
     }
 
     "not allow to end a graph before starting one" in {

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/Assertions.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/Assertions.scala
@@ -1,6 +1,6 @@
 package eu.neverblink.jelly.core.helpers
 
-import eu.neverblink.jelly.core.helpers.Mrl.{Statement}
+import eu.neverblink.jelly.core.helpers.Mrl.Statement
 import eu.neverblink.jelly.core.helpers.RdfAdapter.extractRdfStreamRow
 import eu.neverblink.jelly.core.proto.v1.*
 import org.scalatest.matchers.should.Matchers
@@ -24,3 +24,9 @@ object Assertions extends AnyWordSpec, Matchers:
         obsRow should be(expRow)
       }
     observed.size should be(expected.size)
+
+  def assertSizesPrecomputed(observed: Seq[RdfStreamRow]): Unit =
+    for (row, ix) <- observed.zipWithIndex do
+      withClue(s"Row $ix: ${row.getRow}") {
+        row.getCachedSize should be > 0
+      }


### PR DESCRIPTION
Related to #458

Added test assertions to make sure that the sizes really are precomputed during encoding. This uncovered three cases where this was not done before, so I fixed that as well.