### PR TITLE
PatchEncoder: clone provided options, override the version

### DIFF
--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
@@ -50,7 +50,10 @@ public abstract class PatchEncoder<TNode>
      */
     protected PatchEncoder(ProtoEncoderConverter<TNode> converter, Params params) {
         super(converter);
-        this.options = params.options;
+        this.options = params.options
+            .clone()
+            // Override the user's version setting with what is really supported by the encoder.
+            .setVersion(JellyPatchConstants.PROTO_VERSION_1_0_X);
         this.rowBuffer = params.appendableRowBuffer;
     }
 

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchEncoderSpec.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchEncoderSpec.scala
@@ -74,4 +74,22 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
         }
       }
     }
+
+    "clone the provided options and override the version" in {
+      val options = JellyPatchOptions.SMALL_GENERALIZED
+        .clone
+        .setStatementType(PatchStatementType.TRIPLES)
+        .setStreamType(PatchStreamType.PUNCTUATED)
+        .setVersion(123)
+      val buffer = ListBuffer[RdfPatchRow]()
+      val encoder = MockPatchConverterFactory.encoder(Pep(
+        options,
+        buffer.asJava
+      ))
+      encoder.punctuation() // write anything
+      buffer.size shouldBe 2
+      buffer.head.getOptions shouldNot be theSameInstanceAs options
+      buffer.head.getOptions.getVersion shouldBe JellyPatchConstants.PROTO_VERSION_1_0_X
+      options.getVersion shouldBe 123 // original options should not be modified
+    }
   }


### PR DESCRIPTION
The clone is to make sure that we don't modify the caller's options object accidentally – we do the same in Jelly-RDF.

We override the version to what's supported by the library – that's also the same as in Jelly-RDF.