### PR TITLE
JenaChangesCollector: speed up accessing internal collection 

### DIFF
--- a/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/internal/VectorDirectRead.java
+++ b/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/internal/VectorDirectRead.java
@@ -1,18 +1,18 @@
 package eu.neverblink.jelly.convert.jena.patch.internal;
 
 import eu.neverblink.jelly.core.InternalApi;
-
 import java.util.Vector;
 
 @InternalApi
 public class VectorDirectRead<E> extends Vector<E> {
+
     /**
      * Returns the internal array of the vector without copying it. Do not modify the array!
      * The array may be larger than the current size of the vector, use .size() to determine the actual size.
      * <p>
      * This method makes sense only if you are absolutely sure that the vector is not modified
      * after this call, as it returns the internal array directly.
-     * 
+     *
      * @return the internal array of the vector
      */
     public Object[] getArrayUnsafe() {

--- a/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/internal/VectorDirectRead.java
+++ b/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/internal/VectorDirectRead.java
@@ -1,0 +1,21 @@
+package eu.neverblink.jelly.convert.jena.patch.internal;
+
+import eu.neverblink.jelly.core.InternalApi;
+
+import java.util.Vector;
+
+@InternalApi
+public class VectorDirectRead<E> extends Vector<E> {
+    /**
+     * Returns the internal array of the vector without copying it. Do not modify the array!
+     * The array may be larger than the current size of the vector, use .size() to determine the actual size.
+     * <p>
+     * This method makes sense only if you are absolutely sure that the vector is not modified
+     * after this call, as it returns the internal array directly.
+     * 
+     * @return the internal array of the vector
+     */
+    public Object[] getArrayUnsafe() {
+        return elementData;
+    }
+}


### PR DESCRIPTION
ArrayList is thread-safe-y, we don't need that, so we use Vector instead. I added an extension of Vector that lets us access the underlying data array directly, which should slightly speed up iteration over it.

I'm doing this because I noticed that in a serialization benchmark, iterating the ArrayList took 7% of the total benchmark time... that's a lot.