### PR TITLE
pekko-stream: add flows for serializing to ByteStrings

### DIFF
--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
@@ -73,6 +73,14 @@ class ProtoAuxiliarySpec extends AnyWordSpec, Matchers:
         frame should be (tc)
       }
     }
+    
+    "round-trip with delimited bytes (.toByteArrayDelimited)" when {
+      for ((name, tc) <- testCases) do s"test case $name" in {
+        val bytes = tc.toByteArrayDelimited
+        val frame = RdfStreamFrame.parseDelimitedFrom(ByteArrayInputStream(bytes))
+        frame should be (tc)
+      }
+    }
 
     def makeDeepFrame(depth: Int): RdfStreamFrame = {
       var triple = RdfTriple.newInstance()

--- a/pekko-stream/src/test/scala/eu/neverblink/jelly/pekko/stream/JellyIoSpec.scala
+++ b/pekko-stream/src/test/scala/eu/neverblink/jelly/pekko/stream/JellyIoSpec.scala
@@ -72,6 +72,32 @@ class JellyIoSpec extends AnyWordSpec, Matchers, ScalaFutures:
       }
   }
 
+  "toByteStrings and fromByteStrings" should {
+    for (name, testCase) <- cases do
+      s"work for $name" in {
+        val decoded = Source.fromIterator(() => testCase.iterator)
+          .via(JellyIo.toByteStrings)
+          .via(JellyIo.fromByteStrings)
+          .runWith(Sink.seq)
+          .futureValue
+
+        decoded shouldEqual testCase
+      }
+  }
+
+  "toByteStringsDelimited and fromByteStringsDelimited" should {
+    for (name, testCase) <- cases do
+      s"work for $name" in {
+        val decoded = Source.fromIterator(() => testCase.iterator)
+          .via(JellyIo.toByteStringsDelimited)
+          .via(JellyIo.fromByteStringsDelimited())
+          .runWith(Sink.seq)
+          .futureValue
+
+        decoded shouldEqual testCase
+      }
+  }
+
   "toIoStream and fromIoStream" should {
     for (name, testCase) <- cases do
       s"work for $name" in {


### PR DESCRIPTION
Added `JellyIo.toByteStrings` and `JellyIo.toByteStringsDelimited`.

Also replaced the current implementation of `.toBytesDelimited` with a more efficient one, writing directly to a byte array, instead of going through a ByteArrayOutputStream.

This functionality is needed for our internal project.