### PR TITLE
PatchEncoder: use message allocators to reduce heap pressure

### DIFF
--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
@@ -4,6 +4,7 @@ import eu.neverblink.jelly.core.ExperimentalApi;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.internal.EncoderBase;
+import eu.neverblink.jelly.core.memory.EncoderAllocator;
 import eu.neverblink.jelly.core.proto.v1.RdfQuad;
 import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 import eu.neverblink.jelly.core.proto.v1.patch.RdfPatchOptions;
@@ -29,19 +30,30 @@ public abstract class PatchEncoder<TNode>
      * @param appendableRowBuffer buffer for storing patch rows. The encoder will append the RdfPatchRows to
      *                            this buffer. The caller is responsible for managing this buffer and grouping
      *                            the rows in RdfPatchFrames.
+     * @param allocator allocator for proto class instances. Obtain it from {@link EncoderAllocator}.
      */
-    public record Params(RdfPatchOptions options, Collection<RdfPatchRow> appendableRowBuffer) {
+    public record Params(
+        RdfPatchOptions options,
+        Collection<RdfPatchRow> appendableRowBuffer,
+        EncoderAllocator allocator
+    ) {
         /**
          * Creates a new Params instance.
          */
-        public static Params of(RdfPatchOptions options, Collection<RdfPatchRow> appendableRowBuffer) {
-            return new Params(options, appendableRowBuffer);
+        public static Params of(
+            RdfPatchOptions options,
+            Collection<RdfPatchRow> appendableRowBuffer,
+            EncoderAllocator allocator
+        ) {
+            return new Params(options, appendableRowBuffer, allocator);
         }
     }
 
     protected final RdfPatchOptions options;
 
     protected final Collection<RdfPatchRow> rowBuffer;
+
+    protected final EncoderAllocator allocator;
 
     /**
      * Creates a new PatchEncoder instance.
@@ -55,6 +67,7 @@ public abstract class PatchEncoder<TNode>
             // Override the user's version setting with what is really supported by the encoder.
             .setVersion(JellyPatchConstants.PROTO_VERSION_1_0_X);
         this.rowBuffer = params.appendableRowBuffer;
+        this.allocator = params.allocator;
     }
 
     @Override
@@ -79,6 +92,6 @@ public abstract class PatchEncoder<TNode>
 
     @Override
     protected RdfQuad.Mutable newQuad() {
-        return RdfQuad.newInstance();
+        return allocator.newQuad();
     }
 }

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchEncoderSpec.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/PatchEncoderSpec.scala
@@ -7,6 +7,7 @@ import eu.neverblink.jelly.core.proto.v1.patch.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import eu.neverblink.jelly.core.helpers.RdfAdapter.*
+import eu.neverblink.jelly.core.memory.EncoderAllocator
 import eu.neverblink.jelly.core.patch.helpers.PatchAdapter.*
 
 import scala.annotation.experimental
@@ -30,7 +31,8 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
             JellyPatchOptions.SMALL_GENERALIZED.clone
               .setStatementType(statementType)
               .setStreamType(streamType),
-            buffer.asJava
+            buffer.asJava,
+            EncoderAllocator.newHeapAllocator()
           ))
           testCase.mrl.foreach(_.apply(encoder))
           assertEncoded(buffer.toSeq, testCase.encoded(encoder.options))
@@ -42,7 +44,8 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
             JellyPatchOptions.SMALL_GENERALIZED.clone
               .setStatementType(statementType)
               .setStreamType(streamType),
-            buffer.asJava
+            buffer.asJava,
+            EncoderAllocator.newHeapAllocator()
           ))
           testCase.mrl.foreach(_.apply(encoder))
           for (row, ix) <- buffer.zipWithIndex do
@@ -61,7 +64,8 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
             JellyPatchOptions.SMALL_GENERALIZED.clone
               .setStatementType(PatchStatementType.TRIPLES)
               .setStreamType(st),
-            buffer.asJava
+            buffer.asJava,
+            EncoderAllocator.newHeapAllocator()
           ))
           val e = intercept[RdfProtoSerializationError] {
             encoder.punctuation()
@@ -78,7 +82,8 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
             JellyPatchOptions.SMALL_STRICT.clone
               .setStatementType(statementType)
               .setStreamType(PatchStreamType.PUNCTUATED),
-            buffer.asJava
+            buffer.asJava,
+            EncoderAllocator.newHeapAllocator()
           ))
           testCase.mrl.foreach(_.apply(encoder))
           encoder.punctuation()
@@ -99,7 +104,8 @@ class PatchEncoderSpec extends AnyWordSpec, Matchers:
       val buffer = ListBuffer[RdfPatchRow]()
       val encoder = MockPatchConverterFactory.encoder(Pep(
         options,
-        buffer.asJava
+        buffer.asJava,
+        EncoderAllocator.newHeapAllocator()
       ))
       encoder.punctuation() // write anything
       buffer.size shouldBe 2


### PR DESCRIPTION
Same optimization as in #373

Should speed up the serializer by a significant margin.