### PR TITLE
ProtoMessage: increase OutputStream buffer size

### DIFF
--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Abstract interface implemented by Protocol Message objects.
@@ -25,6 +24,13 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      * This is used to prevent stack overflow errors when parsing deeply nested messages.
      */
     public static final int DEFAULT_MAX_RECURSION_DEPTH = 64;
+
+    /**
+     * Maximum size of the output buffer used when writing messages to an OutputStream.
+     * Set to 2x the default buffer size of CodedOutputStream to avoid allocating additional buffers
+     * for long strings that are common in RDF.
+     */
+    public static final int MAX_OUTPUT_STREAM_BUFFER_SIZE = 8096;
 
     protected ProtoMessage() {}
 
@@ -87,11 +93,11 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
 
     public final MessageType writeDelimitedTo(OutputStream output) throws IOException {
         // [X] Ensure that the serialized size is cached
-        int size = getSerializedSize();
-        int bufferSize = CodedOutputStream.computeUInt32SizeNoTag(size) + size;
-        if (bufferSize > CodedOutputStream.DEFAULT_BUFFER_SIZE) {
-            bufferSize = CodedOutputStream.DEFAULT_BUFFER_SIZE;
-        }
+        final int size = getSerializedSize();
+        final int bufferSize = Integer.min(
+            CodedOutputStream.computeUInt32SizeNoTag(size) + size,
+            MAX_OUTPUT_STREAM_BUFFER_SIZE
+        );
         final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
         codedOutput.writeUInt32NoTag(size);
         writeTo(codedOutput);
@@ -100,8 +106,13 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     }
 
     public final MessageType writeTo(OutputStream output) throws IOException {
-        final var codedOutput = CodedOutputStream.newInstance(output);
-        getSerializedSize(); // [X] Ensure that the serialized size is cached
+        // [X] Ensure that the serialized size is cached
+        final int size = getSerializedSize();
+        final int bufferSize = Integer.min(
+            CodedOutputStream.computeUInt32SizeNoTag(size),
+            MAX_OUTPUT_STREAM_BUFFER_SIZE
+        );
+        final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
         writeTo(codedOutput);
         codedOutput.flush();
         return getThis();


### PR DESCRIPTION
RDF messages quite commonly contain long strings. If we are writing these to an OutputStream, Protobuf will first try to fit the string in its fixed-size buffer (4kB by default), and, if it fails, will create a wholly new buffer for encoding the string.

This is pretty wasteful. I think the correct solution would be to change this part of the Protobuf implementation to write the string in chunks fitting the buffer, but it may be hard to reconcile with other requirements that this class has.

Instead, we can simply raise the buffer size 2x to accommodate larger strings. Note that if the message is known to be smaller than 8kB, a smaller buffer will be allocated instead.