### PR TITLE
Native writers: use a single CodedOutputStream

### DIFF
--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -94,11 +94,7 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     public final MessageType writeDelimitedTo(OutputStream output) throws IOException {
         // [X] Ensure that the serialized size is cached
         final int size = getSerializedSize();
-        final int bufferSize = Integer.min(
-            CodedOutputStream.computeUInt32SizeNoTag(size) + size,
-            MAX_OUTPUT_STREAM_BUFFER_SIZE
-        );
-        final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
+        final var codedOutput = ProtobufUtil.createCodedOutputStream(output, size);
         codedOutput.writeUInt32NoTag(size);
         writeTo(codedOutput);
         codedOutput.flush();
@@ -108,11 +104,7 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     public final MessageType writeTo(OutputStream output) throws IOException {
         // [X] Ensure that the serialized size is cached
         final int size = getSerializedSize();
-        final int bufferSize = Integer.min(
-            CodedOutputStream.computeUInt32SizeNoTag(size),
-            MAX_OUTPUT_STREAM_BUFFER_SIZE
-        );
-        final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
+        final var codedOutput = ProtobufUtil.createCodedOutputStream(output, size);
         writeTo(codedOutput);
         codedOutput.flush();
         return getThis();

--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Abstract interface implemented by Protocol Message objects.
@@ -25,6 +24,13 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      * This is used to prevent stack overflow errors when parsing deeply nested messages.
      */
     public static final int DEFAULT_MAX_RECURSION_DEPTH = 64;
+
+    /**
+     * Maximum size of the output buffer used when writing messages to an OutputStream.
+     * Set to 2x the default buffer size of CodedOutputStream to avoid allocating additional buffers
+     * for long strings that are common in RDF.
+     */
+    public static final int MAX_OUTPUT_STREAM_BUFFER_SIZE = 8096;
 
     protected ProtoMessage() {}
 
@@ -87,11 +93,11 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
 
     public final MessageType writeDelimitedTo(OutputStream output) throws IOException {
         // [X] Ensure that the serialized size is cached
-        int size = getSerializedSize();
-        int bufferSize = CodedOutputStream.computeUInt32SizeNoTag(size) + size;
-        if (bufferSize > CodedOutputStream.DEFAULT_BUFFER_SIZE) {
-            bufferSize = CodedOutputStream.DEFAULT_BUFFER_SIZE;
-        }
+        final int size = getSerializedSize();
+        final int bufferSize = Integer.min(
+            CodedOutputStream.computeUInt32SizeNoTag(size) + size,
+            MAX_OUTPUT_STREAM_BUFFER_SIZE
+        );
         final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
         codedOutput.writeUInt32NoTag(size);
         writeTo(codedOutput);
@@ -100,8 +106,13 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
     }
 
     public final MessageType writeTo(OutputStream output) throws IOException {
-        final var codedOutput = CodedOutputStream.newInstance(output);
-        getSerializedSize(); // [X] Ensure that the serialized size is cached
+        // [X] Ensure that the serialized size is cached
+        final int size = getSerializedSize();
+        final int bufferSize = Integer.min(
+            CodedOutputStream.computeUInt32SizeNoTag(size),
+            MAX_OUTPUT_STREAM_BUFFER_SIZE
+        );
+        final var codedOutput = CodedOutputStream.newInstance(output, bufferSize);
         writeTo(codedOutput);
         codedOutput.flush();
         return getThis();

--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtobufUtil.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtobufUtil.java
@@ -1,0 +1,36 @@
+package eu.neverblink.protoc.java.runtime;
+
+import com.google.protobuf.CodedOutputStream;
+import java.io.OutputStream;
+
+public class ProtobufUtil {
+
+    /**
+     * Creates a CodedOutputStream with a buffer size adjusted for the message to be serialized,
+     * limited to the maximum buffer size. We size the buffer to include space for the
+     * size of the delimiter.
+     *
+     * @param outputStream the output stream to write to
+     * @param messageSize  the size of the message to be written
+     * @return a new CodedOutputStream instance
+     */
+    public static CodedOutputStream createCodedOutputStream(OutputStream outputStream, int messageSize) {
+        final int bufferSize = Integer.min(
+            CodedOutputStream.computeUInt32SizeNoTag(messageSize) + messageSize,
+            ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE
+        );
+        return CodedOutputStream.newInstance(outputStream, bufferSize);
+    }
+
+    /**
+     * Creates a CodedOutputStream with a default (maximum) buffer size. Use this method when
+     * you want to reuse the CodedOutputStream for multiple messages and you don't know the
+     * size of the messages in advance.
+     *
+     * @param outputStream the output stream to write to
+     * @return a new CodedOutputStream instance with the maximum buffer size
+     */
+    public static CodedOutputStream createCodedOutputStream(OutputStream outputStream) {
+        return CodedOutputStream.newInstance(outputStream, ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE);
+    }
+}

--- a/core/src/test/scala/eu/neverblink/jelly/core/LongIoStreamSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/LongIoStreamSpec.scala
@@ -1,0 +1,78 @@
+package eu.neverblink.jelly.core
+
+import eu.neverblink.jelly.core.ProtoTestCases.Triples3LongStrings
+import eu.neverblink.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamFrame}
+import eu.neverblink.protoc.java.runtime.ProtobufUtil
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{ByteArrayOutputStream, OutputStream}
+
+/**
+ * Tests to ensure that writing to a CodedOutputStream works correctly even for very long streams,
+ * where we put more than Int.MaxValue bytes into the stream.
+ *
+ * This is important for Jena, RDF4J and other integrations that allocate only one CodedOutputStream
+ * per file and write all frames to it.
+ */
+class LongIoStreamSpec extends AnyWordSpec, Matchers {
+  "CodedOutputStream" should {
+    "write a very long (> Int.MaxValue) stream of RdfStreamFrames to OutputStream" in {
+      val frame = Triples3LongStrings.encodedFull(
+        JellyOptions.SMALL_STRICT.clone().setPhysicalType(PhysicalStreamType.TRIPLES),
+        1000,
+      ).head
+
+      // For the first X frames, we discard the writes and simply count the bytes written.
+      // For the last frame, we write to a ByteArrayOutputStream to verify the output.
+      var discardWrites = true
+      var bytesWritten = 0L
+      val countingStream = new OutputStream {
+        def write(b: Int): Unit = bytesWritten += 1
+        override def write(b: Array[Byte], off: Int, len: Int): Unit = bytesWritten += len
+      }
+      val byteArrayOutputStream = new ByteArrayOutputStream()
+      val wrapperStream = new OutputStream {
+        def write(b: Int): Unit =
+          if discardWrites then countingStream.write(b)
+          else byteArrayOutputStream.write(b)
+
+        override def write(b: Array[Byte], off: Int, len: Int): Unit =
+          if discardWrites then countingStream.write(b, off, len)
+          else byteArrayOutputStream.write(b, off, len)
+      }
+      val codedOutputStream = ProtobufUtil.createCodedOutputStream(wrapperStream)
+
+      val target1 = Int.MaxValue.toLong * 3L / 2L
+      var writtenFrames = 0L
+
+      // 1. write one frame to make sure we can write at least one frame
+      // We must pre-calculate the size of the frame here, as ProtoMessage demands.
+      frame.getSerializedSize
+      frame.writeTo(codedOutputStream)
+      writtenFrames += 1
+      codedOutputStream.flush()
+
+      bytesWritten should be (frame.getSerializedSize.toLong)
+
+      // 2. now write enough frames to overflow the Int.MaxValue limit
+      while (bytesWritten < target1) {
+        frame.writeTo(codedOutputStream)
+        writtenFrames += 1
+      }
+      codedOutputStream.flush()
+
+      codedOutputStream.getTotalBytesWritten should be < 0 // should overflow
+      bytesWritten should be (writtenFrames * frame.getSerializedSize.toLong)
+
+      // 3. now write the last frame to the ByteArrayOutputStream
+      discardWrites = false
+      frame.writeTo(codedOutputStream)
+      codedOutputStream.flush()
+
+      val data = byteArrayOutputStream.toByteArray
+      val parsedFrame = RdfStreamFrame.parseFrom(data)
+      parsedFrame should be (frame)
+    }
+  }
+}

--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoEncoderSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoEncoderSpec.scala
@@ -16,25 +16,31 @@ class ProtoEncoderSpec extends AnyWordSpec, Matchers:
 
   // Test body
   "a ProtoEncoder" should {
-    "encode triple statements" in {
-      val buffer = RowBuffer.newLazyImmutable()
-      val options = JellyOptions.SMALL_GENERALIZED.clone
-        .setPhysicalType(PhysicalStreamType.TRIPLES)
-        .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
+    val tripleBasicCases = Seq(
+      ("Triples1", Triples1),
+      ("Triples3LongStrings", Triples3LongStrings),
+    )
 
-      val encoder = MockConverterFactory.encoder(Pep(
-        options,
-        enableNamespaceDeclarations = false,
-        rowBuffer = buffer,
-        allocator = EncoderAllocator.newHeapAllocator(),
-      ))
+    for (name, testCase) <- tripleBasicCases do
+      s"encode triple statements ($name)" in {
+        val buffer = RowBuffer.newLazyImmutable()
+        val options = JellyOptions.SMALL_GENERALIZED.clone
+          .setPhysicalType(PhysicalStreamType.TRIPLES)
+          .setVersion(JellyConstants.PROTO_VERSION_1_0_X)
 
-      Triples1.mrl.foreach(triple => encoder.handleTriple(triple.s, triple.p, triple.o))
+        val encoder = MockConverterFactory.encoder(Pep(
+          options,
+          enableNamespaceDeclarations = false,
+          rowBuffer = buffer,
+          allocator = EncoderAllocator.newHeapAllocator(),
+        ))
 
-      val observed = buffer.getRows.asScala.toSeq
-      assertEncoded(observed, Triples1.encoded(options))
-      assertSizesPrecomputed(observed)
-    }
+        testCase.mrl.foreach(triple => encoder.handleTriple(triple.s, triple.p, triple.o))
+
+        val observed = buffer.getRows.asScala.toSeq
+        assertEncoded(observed, testCase.encoded(options))
+        assertSizesPrecomputed(observed)
+      }
 
     "encode triple statements with ns decls and an external buffer" in {
       val buffer = RowBuffer.newLazyImmutable()

--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoTestCases.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoTestCases.scala
@@ -129,6 +129,37 @@ object ProtoTestCases:
       ),
     ))
 
+  object Triples3LongStrings extends TestCase[Triple]:
+    val mrl = Seq(
+      Triple(
+        Iri("https://test.org/test/subject"),
+        Iri("https://test.org/test/predicate"),
+        SimpleLiteral("a" * 1000),
+      ),
+      Triple(
+        Iri("https://test.org/test/subject"),
+        Iri("https://test.org/test/predicate"),
+        SimpleLiteral("b" * 1000),
+      ),
+    )
+
+    def encoded(opt: RdfStreamOptions) = wrapEncoded(Seq(
+      opt,
+      rdfPrefixEntry(0, "https://test.org/test/"),
+      rdfNameEntry(0, "subject"),
+      rdfNameEntry(0, "predicate"),
+      rdfTriple(
+        rdfIri(1, 0),
+        rdfIri(0, 0),
+        rdfLiteral("a" * 1000),
+      ),
+      rdfTriple(
+        null,
+        null,
+        rdfLiteral("b" * 1000),
+      ),
+    ))
+
   object Quads1 extends TestCase[Quad]:
     val mrl = Seq(
       Quad(

--- a/core/src/test/scala/eu/neverblink/protoc/java/runtime/ProtobufUtilSpec.scala
+++ b/core/src/test/scala/eu/neverblink/protoc/java/runtime/ProtobufUtilSpec.scala
@@ -1,0 +1,61 @@
+package eu.neverblink.protoc.java.runtime
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.OutputStream
+import scala.collection.mutable.ListBuffer
+
+class ProtobufUtilSpec extends AnyWordSpec, Matchers {
+  final class WriteTrackingOutputStream extends OutputStream {
+    val writtenBuffers = ListBuffer[Int]()
+
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      // We measure the size of the actual buffer passed to the write method.
+      writtenBuffers += b.length
+    }
+
+    override def write(b: Int): Unit =
+      writtenBuffers += 1
+  }
+
+  "ProtobufUtil" should {
+    "create a CodedOutputStream with default buffer size" in {
+      val os = new WriteTrackingOutputStream()
+      val codedOutputStream = ProtobufUtil.createCodedOutputStream(os)
+      codedOutputStream should not be null
+      codedOutputStream.writeInt32(7, 31241)
+      codedOutputStream.flush()
+
+      os.writtenBuffers should have size 1
+      // We expect a byte array of size equal to the default buffer size to be passed to the write method.
+      os.writtenBuffers.head should be (ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE)
+    }
+
+    "create a CodedOutputStream with a reduced buffer size" in {
+      val os = new WriteTrackingOutputStream()
+      val codedOutputStream = ProtobufUtil.createCodedOutputStream(os, 123)
+      codedOutputStream should not be null
+      codedOutputStream.writeInt32(7, 31241)
+      codedOutputStream.flush()
+
+      os.writtenBuffers should have size 1
+      // +1 byte for delimiter
+      os.writtenBuffers.head should be(123 + 1)
+    }
+
+    "clamp maximum CodedOutputStream buffer size" in {
+      val os = new WriteTrackingOutputStream()
+      val codedOutputStream = ProtobufUtil.createCodedOutputStream(
+        os, ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE * 2
+      )
+      codedOutputStream should not be null
+      codedOutputStream.writeInt32(7, 31241)
+      codedOutputStream.flush()
+
+      os.writtenBuffers should have size 1
+      // We expect the maximum buffer size to be clamped to the maximum allowed value.
+      os.writtenBuffers.head should be (ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE)
+    }
+  }
+}

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
@@ -2,6 +2,7 @@ package eu.neverblink.jelly.convert.rdf4j.rio;
 
 import static eu.neverblink.jelly.convert.rdf4j.rio.JellyFormat.JELLY;
 
+import com.google.protobuf.CodedOutputStream;
 import eu.neverblink.jelly.convert.rdf4j.Rdf4jConverterFactory;
 import eu.neverblink.jelly.core.ProtoEncoder;
 import eu.neverblink.jelly.core.memory.EncoderAllocator;
@@ -11,6 +12,8 @@ import eu.neverblink.jelly.core.proto.v1.LogicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.PhysicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
 import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
+import eu.neverblink.protoc.java.runtime.ProtobufUtil;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import org.eclipse.rdf4j.model.Statement;
@@ -34,6 +37,7 @@ public final class JellyWriter extends AbstractRDFWriter {
     private final Rdf4jConverterFactory converterFactory;
     private final ValueFactory valueFactory;
     private final OutputStream outputStream;
+    private final CodedOutputStream codedOutput;
     // Initialized in startRDF()
     private ReusableRowBuffer buffer = null;
     private EncoderAllocator allocator = null;
@@ -56,6 +60,7 @@ public final class JellyWriter extends AbstractRDFWriter {
         this.converterFactory = converterFactory;
         this.valueFactory = valueFactory;
         this.outputStream = outputStream;
+        this.codedOutput = ProtobufUtil.createCodedOutputStream(outputStream);
         this.reusableFrame = RdfStreamFrame.newInstance();
     }
 
@@ -140,12 +145,21 @@ public final class JellyWriter extends AbstractRDFWriter {
             // Non-delimited variant – whole stream in one frame
             reusableFrame.resetCachedSize();
             try {
-                reusableFrame.writeTo(outputStream);
+                reusableFrame.writeTo(codedOutput);
             } catch (Exception e) {
                 throw new RDFHandlerException("Error writing frame", e);
             }
         } else if (!buffer.isEmpty()) {
             flushBuffer();
+        }
+
+        try {
+            // !!! CodedOutputStream.flush() does not flush the underlying OutputStream,
+            // so we need to do it explicitly.
+            codedOutput.flush();
+            outputStream.flush();
+        } catch (IOException e) {
+            throw new RDFHandlerException("Error writing flushing output", e);
         }
     }
 
@@ -169,7 +183,7 @@ public final class JellyWriter extends AbstractRDFWriter {
     private void flushBuffer() {
         reusableFrame.resetCachedSize();
         try {
-            reusableFrame.writeDelimitedTo(outputStream);
+            reusableFrame.writeDelimitedTo(codedOutput);
         } catch (Exception e) {
             throw new RDFHandlerException("Error writing frame", e);
         } finally {


### PR DESCRIPTION
Two things are going on here:

## Increase OutputStream buffer size

*(this replaces earlier PR #466, this time with more tests)*

RDF messages quite commonly contain long strings. If we are writing these to an OutputStream, Protobuf will first try to fit the string in its fixed-size buffer (4kB by default), and, if it fails, will create a wholly new buffer for encoding the string.

This is pretty wasteful. I think the correct solution would be to change this part of the Protobuf implementation to write the string in chunks fitting the buffer, but it may be hard to reconcile with other requirements that this class has.

Instead, we can simply raise the buffer size 2x to accommodate larger strings. Note that if the message is known to be smaller than 8kB, a smaller buffer will be allocated instead.

## Reuse a single CodedOutputStream in writers

If we are writing a stream of many frames, we are likely going to need the large buffers at some point anyway. In the current setup, for each frame we are allocating a new CodedOutputStream, along with its 4kB buffer (now: will be 8kB). But, it turns out we can simply reuse the CodedOutputStream to write multiple messages, and nothing wrong happens.

CodedOutputStream does use an int32 counter to keep track of bytes written, but as far as I understand the code, it's fine if it overflows, because Java handles overflow arithmetics correctly (e.g., `x = Int.MaxValue; y = x + 20; y - x == 20` without problems). To be 100% sure, I wrote a test (`LongIoStreamSpec`) to check that and yeah, it works.