### PR TITLE
PatchEncoder: use MessageCollection for row buffering

### DIFF
--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/PatchEncoder.java
@@ -9,6 +9,7 @@ import eu.neverblink.jelly.core.proto.v1.RdfQuad;
 import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 import eu.neverblink.jelly.core.proto.v1.patch.RdfPatchOptions;
 import eu.neverblink.jelly.core.proto.v1.patch.RdfPatchRow;
+import eu.neverblink.protoc.java.runtime.MessageCollection;
 import java.util.Collection;
 
 /**
@@ -27,14 +28,14 @@ public abstract class PatchEncoder<TNode>
     /**
      * Parameters passed to the Jelly-Patch encoder.
      * @param options options for this patch stream
-     * @param appendableRowBuffer buffer for storing patch rows. The encoder will append the RdfPatchRows to
+     * @param rowBuffer buffer for storing patch rows. The encoder will append the RdfPatchRows to
      *                            this buffer. The caller is responsible for managing this buffer and grouping
      *                            the rows in RdfPatchFrames.
      * @param allocator allocator for proto class instances. Obtain it from {@link EncoderAllocator}.
      */
     public record Params(
         RdfPatchOptions options,
-        Collection<RdfPatchRow> appendableRowBuffer,
+        MessageCollection<RdfPatchRow, RdfPatchRow.Mutable> rowBuffer,
         EncoderAllocator allocator
     ) {
         /**
@@ -42,16 +43,16 @@ public abstract class PatchEncoder<TNode>
          */
         public static Params of(
             RdfPatchOptions options,
-            Collection<RdfPatchRow> appendableRowBuffer,
+            MessageCollection<RdfPatchRow, RdfPatchRow.Mutable> rowBuffer,
             EncoderAllocator allocator
         ) {
-            return new Params(options, appendableRowBuffer, allocator);
+            return new Params(options, rowBuffer, allocator);
         }
     }
 
     protected final RdfPatchOptions options;
 
-    protected final Collection<RdfPatchRow> rowBuffer;
+    protected final MessageCollection<RdfPatchRow, RdfPatchRow.Mutable> rowBuffer;
 
     protected final EncoderAllocator allocator;
 
@@ -66,7 +67,7 @@ public abstract class PatchEncoder<TNode>
             .clone()
             // Override the user's version setting with what is really supported by the encoder.
             .setVersion(JellyPatchConstants.PROTO_VERSION_1_0_X);
-        this.rowBuffer = params.appendableRowBuffer;
+        this.rowBuffer = params.rowBuffer;
         this.allocator = params.allocator;
     }
 

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -48,95 +48,80 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
 
     @Override
     public void appendNameEntry(RdfNameEntry nameEntry) {
-        final var row = RdfPatchRow.newInstance().setName(nameEntry);
         // Calculate the size of the row now, as all objects are likely still in L1/L2 cache.
-        row.getSerializedSize();
-        rowBuffer.add(row);
+        rowBuffer.appendMessage().setName(nameEntry).getSerializedSize();
     }
 
     @Override
     public void appendPrefixEntry(RdfPrefixEntry prefixEntry) {
-        final var row = RdfPatchRow.newInstance().setPrefix(prefixEntry);
         // Calculate the size of the row now, as all objects are likely still in L1/L2 cache.
-        row.getSerializedSize();
-        rowBuffer.add(row);
+        rowBuffer.appendMessage().setPrefix(prefixEntry).getSerializedSize();
     }
 
     @Override
     public void appendDatatypeEntry(RdfDatatypeEntry datatypeEntry) {
-        final var row = RdfPatchRow.newInstance().setDatatype(datatypeEntry);
-        row.getSerializedSize();
-        rowBuffer.add(row);
+        rowBuffer.appendMessage().setDatatype(datatypeEntry).getSerializedSize();
     }
 
     @Override
     public void addQuad(TNode subject, TNode predicate, TNode object, TNode graph) {
         emitOptions();
         final var quad = quadToProto(subject, predicate, object, graph);
-        final var mainRow = RdfPatchRow.newInstance().setStatementAdd(quad);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setStatementAdd(quad).getSerializedSize();
     }
 
     @Override
     public void deleteQuad(TNode subject, TNode predicate, TNode object, TNode graph) {
         emitOptions();
         final var quad = quadToProto(subject, predicate, object, graph);
-        final var mainRow = RdfPatchRow.newInstance().setStatementDelete(quad);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setStatementDelete(quad).getSerializedSize();
     }
 
     @Override
     public void addTriple(TNode subject, TNode predicate, TNode object) {
         emitOptions();
         final var triple = tripleInQuadToProto(subject, predicate, object);
-        final var mainRow = RdfPatchRow.newInstance().setStatementAdd(triple);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setStatementAdd(triple).getSerializedSize();
     }
 
     @Override
     public void deleteTriple(TNode subject, TNode predicate, TNode object) {
         emitOptions();
         final var triple = tripleInQuadToProto(subject, predicate, object);
-        final var mainRow = RdfPatchRow.newInstance().setStatementDelete(triple);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setStatementDelete(triple).getSerializedSize();
     }
 
     @Override
     public void transactionStart() {
         emitOptions();
+        // TODO: replace with .appendMessage() in when we introduce RowBuffer fully
         rowBuffer.add(ROW_TX_START);
     }
 
     @Override
     public void transactionCommit() {
         emitOptions();
+        // TODO: replace with .appendMessage() in when we introduce RowBuffer fully
         rowBuffer.add(ROW_TX_COMMIT);
     }
 
     @Override
     public void transactionAbort() {
         emitOptions();
+        // TODO: replace with .appendMessage() in when we introduce RowBuffer fully
         rowBuffer.add(ROW_TX_ABORT);
     }
 
     @Override
     public void addNamespace(String name, TNode iriValue, TNode graph) {
         final var namespace = encodeNamespace(name, iriValue, graph);
-        final var mainRow = RdfPatchRow.newInstance().setNamespaceAdd(namespace);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setNamespaceAdd(namespace).getSerializedSize();
     }
 
     @Override
     public void deleteNamespace(String name, TNode iriValue, TNode graph) {
         final var namespace = encodeNamespace(name, iriValue, graph);
-        final var mainRow = RdfPatchRow.newInstance().setNamespaceDelete(namespace);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setNamespaceDelete(namespace).getSerializedSize();
     }
 
     private RdfPatchNamespace encodeNamespace(String name, TNode iriValue, TNode graph) {
@@ -162,9 +147,7 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         this.currentHeaderBase = header;
         this.currentTerm = SpoTerm.HEADER;
         converter.nodeToProto(getNodeEncoder(), value);
-        final var mainRow = RdfPatchRow.newInstance().setHeader(header);
-        mainRow.getSerializedSize();
-        rowBuffer.add(mainRow);
+        rowBuffer.appendMessage().setHeader(header).getSerializedSize();
     }
 
     @Override
@@ -173,6 +156,7 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         if (options.getStreamType() != PatchStreamType.PUNCTUATED) {
             throw new RdfProtoSerializationError("Punctuation is not allowed in this stream type.");
         }
+        // TODO: replace with .appendMessage() in when we introduce RowBuffer fully
         rowBuffer.add(ROW_PUNCTUATION);
     }
 
@@ -182,8 +166,6 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         }
 
         hasEmittedOptions = true;
-        final var row = RdfPatchRow.newInstance().setOptions(options);
-        row.getSerializedSize();
-        rowBuffer.add(row);
+        rowBuffer.appendMessage().setOptions(options).getSerializedSize();
     }
 }

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyStreamWriter.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyStreamWriter.java
@@ -100,7 +100,6 @@ public final class JellyStreamWriter implements StreamRDF {
         // Flush the buffer and finish the stream
         if (!formatVariant.isDelimited()) {
             // Non-delimited variant – whole stream in one frame
-            reusableFrame.resetCachedSize();
             try {
                 reusableFrame.writeTo(codedOutput);
             } catch (IOException e) {

--- a/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyWriterSpec.scala
+++ b/jena/src/test/scala/eu/neverblink/jelly/convert/jena/riot/JellyWriterSpec.scala
@@ -75,6 +75,8 @@ class JellyWriterSpec extends AnyWordSpec, Matchers, JenaTest:
         bytes.size should be > 10
         val response = IoUtils.autodetectDelimiting(ByteArrayInputStream(bytes))
         response.isDelimited should be (false)
+        val parsed = RdfStreamFrame.parseFrom(bytes)
+        parsed.getRows.size should be (6) // 1 options + 1 prefix + 3 names + 1 triple
       }
 
       "split stream in multiple frames if it's delimited" in {

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
@@ -143,7 +143,6 @@ public final class JellyWriter extends AbstractRDFWriter {
         checkWritingStarted();
         if (!isDelimited) {
             // Non-delimited variant – whole stream in one frame
-            reusableFrame.resetCachedSize();
             try {
                 reusableFrame.writeTo(codedOutput);
             } catch (Exception e) {
@@ -159,7 +158,7 @@ public final class JellyWriter extends AbstractRDFWriter {
             codedOutput.flush();
             outputStream.flush();
         } catch (IOException e) {
-            throw new RDFHandlerException("Error writing flushing output", e);
+            throw new RDFHandlerException("Error flushing output", e);
         }
     }
 


### PR DESCRIPTION
First step towards using reusable row buffers – use the MessageCollection class to avoid copying the buffer to RdfPatchFrame. This also allows us to use a reusable frame in the Jena writer, which should also speed things up a little bit.

As a side-quest I double-checked if non-delimited Jelly data is correctly written by native writers and yeah, it is. I also removed a redundant cached size reset, as in non-delimited serialization the cached size is not used for anything.