### PR TITLE
Implement class-based dispatch for term handling

### DIFF
--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchDecoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchDecoderImpl.java
@@ -114,7 +114,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
             nsRow.getName(),
             // The value is required for the namespace add operation
             getNameDecoder().decode(valueIri.getPrefixId(), valueIri.getNameId()),
-            convertGraphTermWrapped(nsRow.getGraphFieldNumber() - RdfPatchNamespace.G_IRI, nsRow)
+            convertGraphTermWrapped(nsRow)
         );
     }
 
@@ -124,7 +124,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
             nsRow.getName(),
             // The value is not required for the namespace delete operation, null is fine
             decodeNsIri(valueIri),
-            convertGraphTermWrapped(nsRow.getGraphFieldNumber() - RdfPatchNamespace.G_IRI, nsRow)
+            convertGraphTermWrapped(nsRow)
         );
     }
 
@@ -154,10 +154,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
 
     private void handleHeader(RdfPatchHeader hRow) {
         // No support for repeated terms in the header
-        patchHandler.header(
-            hRow.getKey(),
-            convertTerm(hRow.getValueFieldNumber() - RdfPatchHeader.H_IRI, hRow.getValue())
-        );
+        patchHandler.header(hRow.getKey(), convertTerm(hRow.getValue()));
     }
 
     private void handlePunctuation() {
@@ -263,7 +260,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
                 convertSubjectTermWrapped(statement),
                 convertPredicateTermWrapped(statement),
                 convertObjectTermWrapped(statement),
-                convertGraphTermWrapped(statement.getGraphFieldNumber() - RdfQuad.G_IRI, statement)
+                convertGraphTermWrapped(statement)
             );
         }
 
@@ -273,7 +270,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
                 convertSubjectTermWrapped(statement),
                 convertPredicateTermWrapped(statement),
                 convertObjectTermWrapped(statement),
-                convertGraphTermWrapped(statement.getGraphFieldNumber() - RdfQuad.G_IRI, statement)
+                convertGraphTermWrapped(statement)
             );
         }
     }
@@ -323,7 +320,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
             switch (statementType) {
                 case TRIPLES -> patchHandler.addTriple(s, p, o);
                 case QUADS -> {
-                    final var g = convertGraphTermWrapped(statement.getGraphFieldNumber() - RdfQuad.G_IRI, statement);
+                    final var g = convertGraphTermWrapped(statement);
                     patchHandler.addQuad(s, p, o, g);
                 }
             }
@@ -343,7 +340,7 @@ public abstract class PatchDecoderImpl<TNode, TDatatype> extends DecoderBase<TNo
             switch (statementType) {
                 case TRIPLES -> patchHandler.deleteTriple(s, p, o);
                 case QUADS -> {
-                    final var g = convertGraphTermWrapped(statement.getGraphFieldNumber() - RdfQuad.G_IRI, statement);
+                    final var g = convertGraphTermWrapped(statement);
                     patchHandler.deleteQuad(s, p, o, g);
                 }
             }

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -130,7 +130,7 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         final var namespace = RdfPatchNamespace.newInstance().setName(name);
         if (iriValue != null) {
             final var encoded = converter.nodeToProto(getNodeEncoder(), iriValue);
-            namespace.setValue((RdfIri) encoded.node());
+            namespace.setValue((RdfIri) encoded);
         }
         if (graph != null) {
             this.graphNodeToProtoWrapped(namespace, graph);
@@ -143,8 +143,7 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         emitOptions();
         final var header = RdfPatchHeader.newInstance().setKey(key);
         final var encoded = converter.nodeToProto(getNodeEncoder(), value);
-        // Header's field numbers are aligned with TERM_* constants, with an offset of 1.
-        header.setValue(encoded.node(), (byte) (encoded.termType() + 1));
+        header.setValue(encoded);
         rowBuffer.appendMessage().setHeader(header).getSerializedSize();
     }
 

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -7,7 +7,6 @@ import eu.neverblink.jelly.core.proto.v1.RdfIri;
 import eu.neverblink.jelly.core.proto.v1.RdfNameEntry;
 import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntry;
 import eu.neverblink.jelly.core.proto.v1.patch.*;
-
 import java.util.function.BiConsumer;
 
 /**
@@ -131,9 +130,8 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
         emitOptions();
         final var namespace = RdfPatchNamespace.newInstance().setName(name);
         if (iriValue != null) {
-            final BiConsumer<Object, Byte> consumer = (Object encoded, Byte kind) ->
-                namespace.setValue((RdfIri) encoded);
-            converter.nodeToProto(getNodeEncoder(), iriValue, consumer);
+            final var encoded = converter.nodeToProto(getNodeEncoder(), iriValue);
+            namespace.setValue((RdfIri) encoded.node());
         }
         if (graph != null) {
             this.graphNodeToProtoWrapped(namespace, graph);
@@ -145,10 +143,9 @@ public class PatchEncoderImpl<TNode> extends PatchEncoder<TNode> {
     public void header(String key, TNode value) {
         emitOptions();
         final var header = RdfPatchHeader.newInstance().setKey(key);
+        final var encoded = converter.nodeToProto(getNodeEncoder(), value);
         // Header's field numbers are aligned with TERM_* constants, with an offset of 1.
-        final BiConsumer<Object, Byte> consumer = (Object encoded, Byte kind) ->
-            header.setValue(encoded, (byte) (kind + 1));
-        converter.nodeToProto(getNodeEncoder(), value, consumer);
+        header.setValue(encoded.node(), (byte) (encoded.termType() + 1));
         rowBuffer.appendMessage().setHeader(header).getSerializedSize();
     }
 

--- a/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
+++ b/core-patch/src/main/java/eu/neverblink/jelly/core/patch/internal/PatchEncoderImpl.java
@@ -7,7 +7,6 @@ import eu.neverblink.jelly.core.proto.v1.RdfIri;
 import eu.neverblink.jelly.core.proto.v1.RdfNameEntry;
 import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntry;
 import eu.neverblink.jelly.core.proto.v1.patch.*;
-import java.util.function.BiConsumer;
 
 /**
  * Implementation of PatchEncoder.

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchAdapter.scala
@@ -70,22 +70,22 @@ object PatchAdapter:
   def rdfPatchHeader(key: String, value: RdfIri): RdfPatchHeader =
     RdfPatchHeader.newInstance()
       .setKey(key)
-      .setHIri(value)
+      .setValue(value)
 
   def rdfPatchHeader(key: String, value: String): RdfPatchHeader =
     RdfPatchHeader.newInstance()
       .setKey(key)
-      .setHBnode(value)
+      .setValue(value)
 
   def rdfPatchHeader(key: String, value: RdfLiteral): RdfPatchHeader =
     RdfPatchHeader.newInstance()
       .setKey(key)
-      .setHLiteral(value)
+      .setValue(value)
 
   def rdfPatchHeader(key: String, value: RdfTriple): RdfPatchHeader =
     RdfPatchHeader.newInstance()
       .setKey(key)
-      .setHTripleTerm(value)
+      .setValue(value)
 
   // Set the graph yourself on the returned object
   def rdfPatchNamespace(name: String, value: RdfIri = null): RdfPatchNamespace.Mutable =

--- a/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchTestCases.scala
+++ b/core-patch/src/test/scala/eu/neverblink/jelly/core/patch/helpers/PatchTestCases.scala
@@ -241,8 +241,8 @@ object PatchTestCases:
       rdfPatchRow(rdfPatchTransactionStart()),
       rdfPatchRow(rdfPrefixEntry(0, "https://test.org/test/")),
       rdfPatchRow(rdfNameEntry(0, "")),
-      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(1, 0)).setGIri(rdfIri(0, 1))),
-      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(0, 1)).setGDefaultGraph(rdfDefaultGraph())),
+      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(1, 0)).setGraph(rdfIri(0, 1))),
+      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(0, 1)).setGraph(rdfDefaultGraph())),
       rdfPatchRowAdd(rdfPatchNamespace("test2", rdfIri(0, 1))),
       rdfPatchRow(rdfNameEntry(0, "subject")),
       rdfPatchRow(rdfNameEntry(0, "predicate")),
@@ -286,8 +286,8 @@ object PatchTestCases:
         null,
         rdfLiteral("test"),
       )),
-      rdfPatchRowDelete(rdfPatchNamespace("test", null).setGIri(rdfIri(1, 1))),
-      rdfPatchRowDelete(rdfPatchNamespace("test", null).setGDefaultGraph(rdfDefaultGraph())),
+      rdfPatchRowDelete(rdfPatchNamespace("test", null).setGraph(rdfIri(1, 1))),
+      rdfPatchRowDelete(rdfPatchNamespace("test", null).setGraph(rdfDefaultGraph())),
       rdfPatchRowDelete(rdfPatchNamespace("test2", null)),
       rdfPatchRow(rdfPatchTransactionAbort()),
     )
@@ -324,9 +324,9 @@ object PatchTestCases:
       rdfPatchRow(opt),
       rdfPatchRow(rdfPrefixEntry(0, "https://test.org/test/")),
       rdfPatchRow(rdfNameEntry(0, "")),
-      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(1, 0)).setGDefaultGraph(rdfDefaultGraph())),
-      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(0, 1)).setGIri(rdfIri(0, 1))),
-      rdfPatchRowAdd(rdfPatchNamespace("test2", rdfIri(0, 1)).setGBnode("b1")),
+      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(1, 0)).setGraph(rdfDefaultGraph())),
+      rdfPatchRowAdd(rdfPatchNamespace("test", rdfIri(0, 1)).setGraph(rdfIri(0, 1))),
+      rdfPatchRowAdd(rdfPatchNamespace("test2", rdfIri(0, 1)).setGraph("b1")),
       rdfPatchRowAdd(rdfQuad(
         rdfIri(0, 1),
         rdfIri(0, 1),
@@ -335,11 +335,11 @@ object PatchTestCases:
       )),
       rdfPatchRowDelete(rdfPatchNamespace("test2", rdfIri(0, 1))),
       rdfPatchRow(rdfPrefixEntry(0, "https://test.org/test7/")),
-      rdfPatchRowAdd(rdfPatchNamespace("test7", rdfIri(2, 1)).setGLiteral(rdfLiteral("test", "en-gb"))),
+      rdfPatchRowAdd(rdfPatchNamespace("test7", rdfIri(2, 1)).setGraph(rdfLiteral("test", "en-gb"))),
       rdfPatchRow(rdfDatatypeEntry(0, "https://test.org/test7/")),
       rdfPatchRowDelete(rdfPatchNamespace(
         "test7", rdfIri(0, 1)
-      ).setGLiteral(rdfLiteral("test", 1))),
+      ).setGraph(rdfLiteral("test", 1))),
       rdfPatchRowDelete(rdfPatchNamespace("test7", null)),
     )
 

--- a/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
@@ -1,5 +1,10 @@
 package eu.neverblink.jelly.core;
 
+import eu.neverblink.jelly.core.proto.v1.RdfDefaultGraph;
+import eu.neverblink.jelly.core.proto.v1.RdfIri;
+import eu.neverblink.jelly.core.proto.v1.RdfLiteral;
+import eu.neverblink.jelly.core.proto.v1.RdfTriple;
+
 /**
  * Interface exposed to RDF library interop modules for encoding RDF terms.
  * @param <TNode> The type of RDF nodes used by the RDF library.
@@ -9,19 +14,19 @@ public interface NodeEncoder<TNode> {
      * Encode an IRI node.
      * @param iri The IRI to encode.
      */
-    RdfBufferAppender.Encoded makeIri(String iri);
+    RdfIri makeIri(String iri);
 
     /**
      * Encode a blank node.
      * @param label The label of the blank node.
      */
-    RdfBufferAppender.Encoded makeBlankNode(String label);
+    String makeBlankNode(String label);
 
     /**
      * Encode a simple literal (of type xsd:string).
      * @param lex The lexical form of the literal.
      */
-    RdfBufferAppender.Encoded makeSimpleLiteral(String lex);
+    RdfLiteral makeSimpleLiteral(String lex);
 
     /**
      * Encode a language-tagged literal.
@@ -29,7 +34,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param lang The language tag.
      */
-    RdfBufferAppender.Encoded makeLangLiteral(TNode lit, String lex, String lang);
+    RdfLiteral makeLangLiteral(TNode lit, String lex, String lang);
 
     /**
      * Encode a datatype literal (not xsd:string and not language-tagged).
@@ -37,7 +42,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param dt The datatype IRI.
      */
-    RdfBufferAppender.Encoded makeDtLiteral(TNode lit, String lex, String dt);
+    RdfLiteral makeDtLiteral(TNode lit, String lex, String dt);
 
     /**
      * Encode a quoted triple node (RDF-star).
@@ -46,10 +51,10 @@ public interface NodeEncoder<TNode> {
      * @param p The predicate of the triple.
      * @param o The object of the triple.
      */
-    RdfBufferAppender.Encoded makeQuotedTriple(TNode s, TNode p, TNode o);
+    RdfTriple makeQuotedTriple(TNode s, TNode p, TNode o);
 
     /**
      * Encode a default graph node.
      */
-    RdfBufferAppender.Encoded makeDefaultGraph();
+    RdfDefaultGraph makeDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
@@ -1,5 +1,7 @@
 package eu.neverblink.jelly.core;
 
+import java.util.function.BiConsumer;
+
 /**
  * Interface exposed to RDF library interop modules for encoding RDF terms.
  * @param <TNode> The type of RDF nodes used by the RDF library.
@@ -9,19 +11,19 @@ public interface NodeEncoder<TNode> {
      * Encode an IRI node.
      * @param iri The IRI to encode.
      */
-    void makeIri(String iri);
+    void makeIri(String iri, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a blank node.
      * @param label The label of the blank node.
      */
-    void makeBlankNode(String label);
+    void makeBlankNode(String label, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a simple literal (of type xsd:string).
      * @param lex The lexical form of the literal.
      */
-    void makeSimpleLiteral(String lex);
+    void makeSimpleLiteral(String lex, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a language-tagged literal.
@@ -29,7 +31,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param lang The language tag.
      */
-    void makeLangLiteral(TNode lit, String lex, String lang);
+    void makeLangLiteral(TNode lit, String lex, String lang, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a datatype literal (not xsd:string and not language-tagged).
@@ -37,7 +39,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param dt The datatype IRI.
      */
-    void makeDtLiteral(TNode lit, String lex, String dt);
+    void makeDtLiteral(TNode lit, String lex, String dt, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a quoted triple node (RDF-star).
@@ -46,10 +48,10 @@ public interface NodeEncoder<TNode> {
      * @param p The predicate of the triple.
      * @param o The object of the triple.
      */
-    void makeQuotedTriple(TNode s, TNode p, TNode o);
+    void makeQuotedTriple(TNode s, TNode p, TNode o, BiConsumer<Object, Byte> consumer);
 
     /**
      * Encode a default graph node.
      */
-    void makeDefaultGraph();
+    void makeDefaultGraph(BiConsumer<Object, Byte> consumer);
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
@@ -11,19 +11,19 @@ public interface NodeEncoder<TNode> {
      * Encode an IRI node.
      * @param iri The IRI to encode.
      */
-    void makeIri(String iri, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeIri(String iri);
 
     /**
      * Encode a blank node.
      * @param label The label of the blank node.
      */
-    void makeBlankNode(String label, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeBlankNode(String label);
 
     /**
      * Encode a simple literal (of type xsd:string).
      * @param lex The lexical form of the literal.
      */
-    void makeSimpleLiteral(String lex, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeSimpleLiteral(String lex);
 
     /**
      * Encode a language-tagged literal.
@@ -31,7 +31,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param lang The language tag.
      */
-    void makeLangLiteral(TNode lit, String lex, String lang, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeLangLiteral(TNode lit, String lex, String lang);
 
     /**
      * Encode a datatype literal (not xsd:string and not language-tagged).
@@ -39,7 +39,7 @@ public interface NodeEncoder<TNode> {
      * @param lex The lexical form of the literal.
      * @param dt The datatype IRI.
      */
-    void makeDtLiteral(TNode lit, String lex, String dt, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeDtLiteral(TNode lit, String lex, String dt);
 
     /**
      * Encode a quoted triple node (RDF-star).
@@ -48,10 +48,10 @@ public interface NodeEncoder<TNode> {
      * @param p The predicate of the triple.
      * @param o The object of the triple.
      */
-    void makeQuotedTriple(TNode s, TNode p, TNode o, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeQuotedTriple(TNode s, TNode p, TNode o);
 
     /**
      * Encode a default graph node.
      */
-    void makeDefaultGraph(BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded makeDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/NodeEncoder.java
@@ -1,7 +1,5 @@
 package eu.neverblink.jelly.core;
 
-import java.util.function.BiConsumer;
-
 /**
  * Interface exposed to RDF library interop modules for encoding RDF terms.
  * @param <TNode> The type of RDF nodes used by the RDF library.

--- a/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
@@ -1,5 +1,7 @@
 package eu.neverblink.jelly.core;
 
+import java.util.function.BiConsumer;
+
 /**
  * Converter trait for translating between an RDF library's object representation and Jelly's proto objects.
  * <p>
@@ -8,6 +10,6 @@ package eu.neverblink.jelly.core;
  * @param <TNode> type of RDF nodes in the library
  */
 public interface ProtoEncoderConverter<TNode> {
-    void nodeToProto(NodeEncoder<TNode> encoder, TNode node);
-    void graphNodeToProto(NodeEncoder<TNode> encoder, TNode node);
+    void nodeToProto(NodeEncoder<TNode> encoder, TNode node, BiConsumer<Object, Byte> consumer);
+    void graphNodeToProto(NodeEncoder<TNode> encoder, TNode node, BiConsumer<Object, Byte> consumer);
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
@@ -1,7 +1,5 @@
 package eu.neverblink.jelly.core;
 
-import java.util.function.BiConsumer;
-
 /**
  * Converter trait for translating between an RDF library's object representation and Jelly's proto objects.
  * <p>

--- a/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
@@ -8,6 +8,23 @@ package eu.neverblink.jelly.core;
  * @param <TNode> type of RDF nodes in the library
  */
 public interface ProtoEncoderConverter<TNode> {
+    /**
+     * Convert a subject/predicate/object node to a Jelly proto object.
+     *
+     * @param encoder encoder to use for creating Jelly proto objects. Call its methods to create
+     *                new Jelly proto objects.
+     * @param node node to convert
+     * @return Jelly proto object representing the node, obtained from the encoder.
+     */
     Object nodeToProto(NodeEncoder<TNode> encoder, TNode node);
+
+    /**
+     * Convert a graph node to a Jelly proto object.
+     *
+     * @param encoder encoder to use for creating Jelly proto objects. Call its methods to create
+     *                new Jelly proto objects.
+     * @param node graph node to convert. If null, this represents the default graph.
+     * @return Jelly proto object representing the graph node, obtained from the encoder.
+     */
     Object graphNodeToProto(NodeEncoder<TNode> encoder, TNode node);
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
@@ -10,6 +10,6 @@ import java.util.function.BiConsumer;
  * @param <TNode> type of RDF nodes in the library
  */
 public interface ProtoEncoderConverter<TNode> {
-    void nodeToProto(NodeEncoder<TNode> encoder, TNode node, BiConsumer<Object, Byte> consumer);
-    void graphNodeToProto(NodeEncoder<TNode> encoder, TNode node, BiConsumer<Object, Byte> consumer);
+    RdfBufferAppender.Encoded nodeToProto(NodeEncoder<TNode> encoder, TNode node);
+    RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<TNode> encoder, TNode node);
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/ProtoEncoderConverter.java
@@ -8,6 +8,6 @@ package eu.neverblink.jelly.core;
  * @param <TNode> type of RDF nodes in the library
  */
 public interface ProtoEncoderConverter<TNode> {
-    RdfBufferAppender.Encoded nodeToProto(NodeEncoder<TNode> encoder, TNode node);
-    RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<TNode> encoder, TNode node);
+    Object nodeToProto(NodeEncoder<TNode> encoder, TNode node);
+    Object graphNodeToProto(NodeEncoder<TNode> encoder, TNode node);
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
@@ -2,21 +2,29 @@ package eu.neverblink.jelly.core;
 
 import eu.neverblink.jelly.core.proto.v1.*;
 
+import java.util.function.BiConsumer;
+
 /**
  * Interface for appending lookup entries to the row buffer and RDF terms to statements.
  * <p>
  * This is used by NodeEncoder.
  */
 public interface RdfBufferAppender<TNode> {
+    byte TERM_IRI = 1;
+    byte TERM_BNODE = 2;
+    byte TERM_LITERAL = 3;
+    byte TERM_TRIPLE = 4;
+    byte TERM_DEFAULT_GRAPH = 5;
+
     // Lookup entries
     void appendNameEntry(RdfNameEntry nameEntry);
     void appendPrefixEntry(RdfPrefixEntry prefixEntry);
     void appendDatatypeEntry(RdfDatatypeEntry datatypeEntry);
 
-    // RDF terms
-    void appendIri(RdfIri iri);
-    void appendBlankNode(String label);
-    void appendLiteral(RdfLiteral literal);
-    void appendQuotedTriple(TNode subject, TNode predicate, TNode object);
-    void appendDefaultGraph();
+    //    // RDF terms
+    //    void appendIri(RdfIri iri);
+    //    void appendBlankNode(String label);
+    //    void appendLiteral(RdfLiteral literal);
+    void appendQuotedTriple(TNode subject, TNode predicate, TNode object, BiConsumer<Object, Byte> consumer);
+    //    void appendDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
@@ -2,8 +2,6 @@ package eu.neverblink.jelly.core;
 
 import eu.neverblink.jelly.core.proto.v1.*;
 
-import java.util.function.BiConsumer;
-
 /**
  * Interface for appending lookup entries to the row buffer and RDF terms to statements.
  * <p>

--- a/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
@@ -15,6 +15,8 @@ public interface RdfBufferAppender<TNode> {
     byte TERM_LITERAL = 3;
     byte TERM_TRIPLE = 4;
     byte TERM_DEFAULT_GRAPH = 5;
+    
+    record Encoded(Object node, byte termType) { }
 
     // Lookup entries
     void appendNameEntry(RdfNameEntry nameEntry);
@@ -25,6 +27,6 @@ public interface RdfBufferAppender<TNode> {
     //    void appendIri(RdfIri iri);
     //    void appendBlankNode(String label);
     //    void appendLiteral(RdfLiteral literal);
-    void appendQuotedTriple(TNode subject, TNode predicate, TNode object, BiConsumer<Object, Byte> consumer);
+    Encoded appendQuotedTriple(TNode subject, TNode predicate, TNode object);
     //    void appendDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
@@ -8,13 +8,11 @@ import eu.neverblink.jelly.core.proto.v1.*;
  * This is used by NodeEncoder.
  */
 public interface RdfBufferAppender<TNode> {
-    byte TERM_IRI = 1;
-    byte TERM_BNODE = 2;
-    byte TERM_LITERAL = 3;
-    byte TERM_TRIPLE = 4;
-    byte TERM_DEFAULT_GRAPH = 5;
-    
-    record Encoded(Object node, byte termType) { }
+    //    byte TERM_IRI = 1;
+    //    byte TERM_BNODE = 2;
+    //    byte TERM_LITERAL = 3;
+    //    byte TERM_TRIPLE = 4;
+    //    byte TERM_DEFAULT_GRAPH = 5;
 
     // Lookup entries
     void appendNameEntry(RdfNameEntry nameEntry);
@@ -25,6 +23,6 @@ public interface RdfBufferAppender<TNode> {
     //    void appendIri(RdfIri iri);
     //    void appendBlankNode(String label);
     //    void appendLiteral(RdfLiteral literal);
-    Encoded appendQuotedTriple(TNode subject, TNode predicate, TNode object);
+    RdfTriple appendQuotedTriple(TNode subject, TNode predicate, TNode object);
     //    void appendDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/RdfBufferAppender.java
@@ -8,21 +8,11 @@ import eu.neverblink.jelly.core.proto.v1.*;
  * This is used by NodeEncoder.
  */
 public interface RdfBufferAppender<TNode> {
-    //    byte TERM_IRI = 1;
-    //    byte TERM_BNODE = 2;
-    //    byte TERM_LITERAL = 3;
-    //    byte TERM_TRIPLE = 4;
-    //    byte TERM_DEFAULT_GRAPH = 5;
-
     // Lookup entries
     void appendNameEntry(RdfNameEntry nameEntry);
     void appendPrefixEntry(RdfPrefixEntry prefixEntry);
     void appendDatatypeEntry(RdfDatatypeEntry datatypeEntry);
 
-    //    // RDF terms
-    //    void appendIri(RdfIri iri);
-    //    void appendBlankNode(String label);
-    //    void appendLiteral(RdfLiteral literal);
+    // Recursive RDF terms
     RdfTriple appendQuotedTriple(TNode subject, TNode predicate, TNode object);
-    //    void appendDefaultGraph();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
@@ -61,13 +61,13 @@ public abstract class DecoderBase<TNode, TDatatype> {
         }
 
         try {
-            if (graph instanceof RdfIri iri) {
+            if (graph instanceof RdfIri.Mutable iri) {
                 return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
             } else if (graph instanceof String bnode) {
                 return converter.makeBlankNode(bnode);
-            } else if (graph instanceof RdfDefaultGraph) {
+            } else if (graph instanceof RdfDefaultGraph.Mutable) {
                 return converter.makeDefaultGraphNode();
-            } else if (graph instanceof RdfLiteral literal) {
+            } else if (graph instanceof RdfLiteral.Mutable literal) {
                 return convertLiteral(literal);
             } else {
                 throw new RdfProtoDeserializationError(
@@ -89,13 +89,16 @@ public abstract class DecoderBase<TNode, TDatatype> {
             throw new RdfProtoDeserializationError("Term value is not set inside a quoted triple.");
         }
         try {
-            if (term instanceof RdfIri iri) {
+            // Optimization: check against the final class to lower overhead.
+            // This looks like a case that the JVM would optimize anyway, but OpenJDK 23 doesn't do it.
+            // Checking against the final class guarantees that the check is just 1 load + 1 compare.
+            if (term instanceof RdfIri.Mutable iri) {
                 return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
             } else if (term instanceof String bNode) {
                 return converter.makeBlankNode(bNode);
-            } else if (term instanceof RdfLiteral literal) {
+            } else if (term instanceof RdfLiteral.Mutable literal) {
                 return convertLiteral(literal);
-            } else if (term instanceof RdfTriple triple) {
+            } else if (term instanceof RdfTriple.Mutable triple) {
                 return converter.makeTripleNode(
                     convertTerm(triple.getSubject()),
                     convertTerm(triple.getPredicate()),

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
@@ -51,33 +51,28 @@ public abstract class DecoderBase<TNode, TDatatype> {
 
     /**
      * Convert a GraphTerm message to a node.
-     * @param kind field number of the term, normalized to 0, 1, 2, 3
      * @param graph graph term to convert
      * @return converted node
      * @throws RdfProtoDeserializationError if the graph term can't be decoded
      */
-    protected final TNode convertGraphTerm(int kind, Object graph) {
+    protected final TNode convertGraphTerm(Object graph) {
         if (graph == null) {
             throw new RdfProtoDeserializationError("Empty graph term encountered in a GRAPHS stream.");
         }
 
         try {
-            switch (kind) {
-                case 0 -> {
-                    final var iri = (RdfIri) graph;
-                    return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
-                }
-                case 1 -> {
-                    final var bnode = (String) graph;
-                    return converter.makeBlankNode(bnode);
-                }
-                case 2 -> {
-                    return converter.makeDefaultGraphNode();
-                }
-                case 3 -> {
-                    return convertLiteral((RdfLiteral) graph);
-                }
-                default -> throw new RdfProtoDeserializationError("Unknown graph term type");
+            if (graph instanceof RdfIri iri) {
+                return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
+            } else if (graph instanceof String bnode) {
+                return converter.makeBlankNode(bnode);
+            } else if (graph instanceof RdfDefaultGraph) {
+                return converter.makeDefaultGraphNode();
+            } else if (graph instanceof RdfLiteral literal) {
+                return convertLiteral(literal);
+            } else {
+                throw new RdfProtoDeserializationError(
+                    "Unknown graph term type: %s".formatted(graph.getClass().getName())
+                );
             }
         } catch (Exception e) {
             throw new RdfProtoDeserializationError("Error while decoding graph term %s".formatted(e), e);
@@ -86,36 +81,28 @@ public abstract class DecoderBase<TNode, TDatatype> {
 
     /**
      * Convert a SpoTerm message to a node.
-     * @param kind field number of the term, normalized to 0, 1, 2, 3
      * @param term term to convert
      * @throws RdfProtoDeserializationError if the term can't be decoded
      */
-    protected final TNode convertTerm(int kind, Object term) {
+    protected final TNode convertTerm(Object term) {
         if (term == null) {
             throw new RdfProtoDeserializationError("Term value is not set inside a quoted triple.");
         }
         try {
-            switch (kind) {
-                case 0 -> {
-                    final var iri = (RdfIri) term;
-                    return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
-                }
-                case 1 -> {
-                    final var bnode = (String) term;
-                    return converter.makeBlankNode(bnode);
-                }
-                case 2 -> {
-                    return convertLiteral((RdfLiteral) term);
-                }
-                case 3 -> {
-                    final var triple = (RdfTriple) term;
-                    return converter.makeTripleNode(
-                        convertTerm(triple.getSubjectFieldNumber() - RdfTriple.S_IRI, triple.getSubject()),
-                        convertTerm(triple.getPredicateFieldNumber() - RdfTriple.P_IRI, triple.getPredicate()),
-                        convertTerm(triple.getObjectFieldNumber() - RdfTriple.O_IRI, triple.getObject())
-                    );
-                }
-                default -> throw new RdfProtoDeserializationError("Unknown term type");
+            if (term instanceof RdfIri iri) {
+                return getNameDecoder().decode(iri.getPrefixId(), iri.getNameId());
+            } else if (term instanceof String bNode) {
+                return converter.makeBlankNode(bNode);
+            } else if (term instanceof RdfLiteral literal) {
+                return convertLiteral(literal);
+            } else if (term instanceof RdfTriple triple) {
+                return converter.makeTripleNode(
+                    convertTerm(triple.getSubject()),
+                    convertTerm(triple.getPredicate()),
+                    convertTerm(triple.getObject())
+                );
+            } else {
+                throw new RdfProtoDeserializationError("Unknown term type: %s".formatted(term.getClass().getName()));
             }
         } catch (Exception e) {
             throw new RdfProtoDeserializationError("Error while decoding term %s".formatted(e), e);
@@ -139,12 +126,11 @@ public abstract class DecoderBase<TNode, TDatatype> {
     /**
      * Convert the subject from an SPO-like message to a node, while respecting repeated terms.
      * <p>
-     * The logic here is repeated in the other SPO methods for permance reasons (avoiding additional reference passing).
+     * The logic here is repeated in the other SPO methods for performance reasons (avoiding additional reference passing).
      * @param spo SPO-like message to extract the subject from
      * @return converted node
      */
     protected final TNode convertSubjectTermWrapped(SpoBase spo) {
-        int kind = spo.getSubjectFieldNumber() - RdfTriple.S_IRI;
         final var term = spo.getSubject();
         if (term == null && lastSubject == null) {
             throw new RdfProtoDeserializationError("Empty subject term without previous term.");
@@ -154,7 +140,7 @@ public abstract class DecoderBase<TNode, TDatatype> {
             return lastSubject;
         }
 
-        final var node = convertTerm(kind, term);
+        final var node = convertTerm(term);
         lastSubject = node;
         return node;
     }
@@ -167,7 +153,6 @@ public abstract class DecoderBase<TNode, TDatatype> {
      * @return converted node
      */
     protected final TNode convertPredicateTermWrapped(SpoBase spo) {
-        int kind = spo.getPredicateFieldNumber() - RdfTriple.P_IRI;
         final var term = spo.getPredicate();
         if (term == null && lastPredicate == null) {
             throw new RdfProtoDeserializationError("Empty subject term without previous term.");
@@ -177,7 +162,7 @@ public abstract class DecoderBase<TNode, TDatatype> {
             return lastPredicate;
         }
 
-        final var node = convertTerm(kind, term);
+        final var node = convertTerm(term);
         lastPredicate = node;
         return node;
     }
@@ -190,7 +175,6 @@ public abstract class DecoderBase<TNode, TDatatype> {
      * @return converted node
      */
     protected final TNode convertObjectTermWrapped(SpoBase spo) {
-        int kind = spo.getObjectFieldNumber() - RdfTriple.O_IRI;
         final var term = spo.getObject();
         if (term == null && lastObject == null) {
             throw new RdfProtoDeserializationError("Empty subject term without previous term.");
@@ -200,18 +184,17 @@ public abstract class DecoderBase<TNode, TDatatype> {
             return lastObject;
         }
 
-        final var node = convertTerm(kind, term);
+        final var node = convertTerm(term);
         lastObject = node;
         return node;
     }
 
     /**
      * Convert a GraphTerm message to a node, while respecting repeated terms.
-     * @param kind field number of the term, normalized to 0, 1, 2, 3
      * @param graph GraphBase message to convert
      * @return converted node
      */
-    protected final TNode convertGraphTermWrapped(int kind, GraphBase graph) {
+    protected final TNode convertGraphTermWrapped(GraphBase graph) {
         if (graph.getGraph() == null && lastGraph == null) {
             // Special case: Jena and RDF4J allow null graph terms in the input,
             // so we do not treat them as errors.
@@ -222,7 +205,7 @@ public abstract class DecoderBase<TNode, TDatatype> {
             return lastGraph;
         }
 
-        final var node = convertGraphTerm(kind, graph.getGraph());
+        final var node = convertGraphTerm(graph.getGraph());
         lastGraph = node;
         return node;
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/DecoderBase.java
@@ -89,7 +89,7 @@ public abstract class DecoderBase<TNode, TDatatype> {
             throw new RdfProtoDeserializationError("Term value is not set inside a quoted triple.");
         }
         try {
-            // Optimization: check against the final class to lower overhead.
+            // Optimization: do instanceof check against the final class for better performance.
             // This looks like a case that the JVM would optimize anyway, but OpenJDK 23 doesn't do it.
             // Checking against the final class guarantees that the check is just 1 load + 1 compare.
             if (term instanceof RdfIri.Mutable iri) {
@@ -129,7 +129,8 @@ public abstract class DecoderBase<TNode, TDatatype> {
     /**
      * Convert the subject from an SPO-like message to a node, while respecting repeated terms.
      * <p>
-     * The logic here is repeated in the other SPO methods for performance reasons (avoiding additional reference passing).
+     * The logic here is repeated in the other SPO methods for performance reasons
+     * (avoiding additional reference passing).
      * @param spo SPO-like message to extract the subject from
      * @return converted node
      */
@@ -151,7 +152,8 @@ public abstract class DecoderBase<TNode, TDatatype> {
     /**
      * Convert the predicate from an SPO-like message to a node, while respecting repeated terms.
      * <p>
-     * The logic here is repeated in the other SPO methods for permance reasons (avoiding additional reference passing).
+     * The logic here is repeated in the other SPO methods for performance reasons
+     * (avoiding additional reference passing).
      * @param spo SPO-like message to extract the predicate from
      * @return converted node
      */
@@ -173,7 +175,8 @@ public abstract class DecoderBase<TNode, TDatatype> {
     /**
      * Convert the object from an SPO-like message to a node, while respecting repeated terms.
      * <p>
-     * The logic here is repeated in the other SPO methods for permance reasons (avoiding additional reference passing).
+     * The logic here is repeated in the other SPO methods for performance reasons
+     * (avoiding additional reference passing).
      * @param spo SPO-like message to extract the object from
      * @return converted node
      */

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderBase.java
@@ -3,7 +3,6 @@ package eu.neverblink.jelly.core.internal;
 import eu.neverblink.jelly.core.*;
 import eu.neverblink.jelly.core.internal.proto.*;
 import eu.neverblink.jelly.core.proto.v1.*;
-import java.util.function.BiConsumer;
 
 /**
  * Base interface for Jelly proto encoders. Only for internal use.

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -6,7 +6,6 @@ import eu.neverblink.jelly.core.*;
 import eu.neverblink.jelly.core.proto.v1.*;
 import java.util.LinkedHashMap;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 
 /**
  * Encodes RDF nodes native to the used RDF library (e.g., Apache Jena, RDF4J) into Jelly's protobuf objects.

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoDecoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoDecoderImpl.java
@@ -220,7 +220,7 @@ public sealed class ProtoDecoderImpl<TNode, TDatatype> extends ProtoDecoder<TNod
                 convertSubjectTermWrapped(quad),
                 convertPredicateTermWrapped(quad),
                 convertObjectTermWrapped(quad),
-                convertGraphTermWrapped(quad.getGraphFieldNumber() - RdfQuad.G_IRI, quad)
+                convertGraphTermWrapped(quad)
             );
         }
     }
@@ -260,10 +260,7 @@ public sealed class ProtoDecoderImpl<TNode, TDatatype> extends ProtoDecoder<TNod
         @Override
         protected void handleGraphStart(RdfGraphStart graphStart) {
             currentGraphStarted = true;
-            currentGraph = convertGraphTerm(
-                graphStart.getGraphFieldNumber() - RdfGraphStart.G_IRI,
-                graphStart.getGraph()
-            );
+            currentGraph = convertGraphTerm(graphStart.getGraph());
         }
 
         @Override
@@ -318,10 +315,7 @@ public sealed class ProtoDecoderImpl<TNode, TDatatype> extends ProtoDecoder<TNod
 
         @Override
         protected void handleGraphStart(RdfGraphStart graphStart) {
-            currentGraph = convertGraphTerm(
-                graphStart.getGraphFieldNumber() - RdfGraphStart.G_IRI,
-                graphStart.getGraph()
-            );
+            currentGraph = convertGraphTerm(graphStart.getGraph());
             protoHandler.handleGraphStart(currentGraph);
         }
 

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -6,8 +6,6 @@ import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.proto.v1.*;
 
-import java.util.function.BiConsumer;
-
 /**
  * Stateful encoder of a protobuf RDF stream.
  * <p>

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -70,7 +70,7 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
 
         final var ns = RdfNamespaceDeclaration.newInstance().setName(prefix);
         final var encoded = converter.nodeToProto(getNodeEncoder(), namespace);
-        ns.setValue((RdfIri) encoded.node());
+        ns.setValue((RdfIri) encoded);
         rowBuffer.appendMessage().setNamespace(ns).getSerializedSize();
     }
 

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -6,6 +6,8 @@ import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.proto.v1.*;
 
+import java.util.function.BiConsumer;
+
 /**
  * Stateful encoder of a protobuf RDF stream.
  * <p>
@@ -69,9 +71,9 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         emitOptions();
 
         final var ns = RdfNamespaceDeclaration.newInstance().setName(prefix);
-        this.currentNsBase = ns;
-        this.currentTerm = SpoTerm.NAMESPACE;
-        converter.nodeToProto(getNodeEncoder(), namespace);
+        final BiConsumer<Object, Byte> consumer = (Object encoded, Byte kind) -> 
+            ns.setValue((RdfIri) encoded);
+        converter.nodeToProto(getNodeEncoder(), namespace, consumer);
         rowBuffer.appendMessage().setNamespace(ns).getSerializedSize();
     }
 

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoEncoderImpl.java
@@ -71,9 +71,8 @@ public class ProtoEncoderImpl<TNode> extends ProtoEncoder<TNode> {
         emitOptions();
 
         final var ns = RdfNamespaceDeclaration.newInstance().setName(prefix);
-        final BiConsumer<Object, Byte> consumer = (Object encoded, Byte kind) -> 
-            ns.setValue((RdfIri) encoded);
-        converter.nodeToProto(getNodeEncoder(), namespace, consumer);
+        final var encoded = converter.nodeToProto(getNodeEncoder(), namespace);
+        ns.setValue((RdfIri) encoded.node());
         rowBuffer.appendMessage().setNamespace(ns).getSerializedSize();
     }
 

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoTranscoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoTranscoderImpl.java
@@ -133,19 +133,16 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
         this.hasChangedTerms = false;
         final var triple = row.getTriple();
 
-        final var s1 = handleSpoTerm(triple.getSubjectFieldNumber() - RdfTriple.S_IRI, triple.getSubject());
-        final var p1 = handleSpoTerm(triple.getPredicateFieldNumber() - RdfTriple.P_IRI, triple.getPredicate());
-        final var o1 = handleSpoTerm(triple.getObjectFieldNumber() - RdfTriple.O_IRI, triple.getObject());
+        final var s1 = handleSpoTerm(triple.getSubject());
+        final var p1 = handleSpoTerm(triple.getPredicate());
+        final var o1 = handleSpoTerm(triple.getObject());
 
         if (!hasChangedTerms) {
             rowBuffer.add(row);
             return;
         }
 
-        final var newTriple = RdfTriple.newInstance()
-            .setSubject(s1, triple.getSubjectFieldNumber())
-            .setPredicate(p1, triple.getPredicateFieldNumber())
-            .setObject(o1, triple.getObjectFieldNumber());
+        final var newTriple = RdfTriple.newInstance().setSubject(s1).setPredicate(p1).setObject(o1);
         rowBuffer.add(RdfStreamRow.newInstance().setTriple(newTriple));
     }
 
@@ -153,21 +150,17 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
         this.hasChangedTerms = false;
         final var quad = row.getQuad();
 
-        final var s1 = handleSpoTerm(quad.getSubjectFieldNumber() - RdfQuad.S_IRI, quad.getSubject());
-        final var p1 = handleSpoTerm(quad.getPredicateFieldNumber() - RdfQuad.P_IRI, quad.getPredicate());
-        final var o1 = handleSpoTerm(quad.getObjectFieldNumber() - RdfQuad.O_IRI, quad.getObject());
-        final var g1 = handleGraphTerm(quad.getGraphFieldNumber() - RdfQuad.G_IRI, quad.getGraph());
+        final var s1 = handleSpoTerm(quad.getSubject());
+        final var p1 = handleSpoTerm(quad.getPredicate());
+        final var o1 = handleSpoTerm(quad.getObject());
+        final var g1 = handleGraphTerm(quad.getGraph());
 
         if (!hasChangedTerms) {
             rowBuffer.add(row);
             return;
         }
 
-        final var newQuad = RdfQuad.newInstance()
-            .setSubject(s1, quad.getSubjectFieldNumber())
-            .setPredicate(p1, quad.getPredicateFieldNumber())
-            .setObject(o1, quad.getObjectFieldNumber())
-            .setGraph(g1, quad.getGraphFieldNumber());
+        final var newQuad = RdfQuad.newInstance().setSubject(s1).setPredicate(p1).setObject(o1).setGraph(g1);
         rowBuffer.add(RdfStreamRow.newInstance().setQuad(newQuad));
     }
 
@@ -175,13 +168,14 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
         this.hasChangedTerms = false;
         final var graphStart = row.getGraphStart();
 
-        final var g1 = handleGraphTerm(graphStart.getGraphFieldNumber() - RdfGraphStart.G_IRI, graphStart.getGraph());
+        final var g1 = handleGraphTerm(graphStart.getGraph());
         if (!hasChangedTerms) {
             rowBuffer.add(row);
             return;
         }
 
-        final var newGraphStart = RdfGraphStart.newInstance().setGraph(g1, graphStart.getGraphFieldNumber());
+        final var newGraphStart = RdfGraphStart.newInstance();
+        newGraphStart.setGraph(g1);
         rowBuffer.add(RdfStreamRow.newInstance().setGraphStart(newGraphStart));
     }
 
@@ -200,49 +194,35 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
         rowBuffer.add(RdfStreamRow.newInstance().setNamespace(namespace));
     }
 
-    private Object handleSpoTerm(int kind, Object term) {
-        if (kind < 0) {
+    private Object handleSpoTerm(Object term) {
+        if (term == null) {
             return null;
-        }
-        switch (kind) {
-            case 0 -> {
-                return handleIri((RdfIri) term);
-            }
-            case 1 -> {
-                return term; // blank node
-            }
-            case 2 -> {
-                return handleLiteral((RdfLiteral) term);
-            }
-            case 3 -> {
-                return handleTripleTerm((RdfTriple) term);
-            }
-            default -> {
-                throw new RdfProtoTranscodingError("Unknown term type");
-            }
+        } else if (term instanceof RdfIri iri) {
+            return handleIri(iri);
+        } else if (term instanceof String blankNode) {
+            return blankNode;
+        } else if (term instanceof RdfLiteral literal) {
+            return handleLiteral(literal);
+        } else if (term instanceof RdfTriple triple) {
+            return handleTripleTerm(triple);
+        } else {
+            throw new RdfProtoTranscodingError("Unknown term type");
         }
     }
 
-    private Object handleGraphTerm(int kind, Object graph) {
-        if (kind < 0) {
+    private Object handleGraphTerm(Object graph) {
+        if (graph == null) {
             return null;
-        }
-        switch (kind) {
-            case 0 -> {
-                return handleIri((RdfIri) graph);
-            }
-            case 1 -> {
-                return graph; // blank node
-            }
-            case 2 -> {
-                return graph; // default graph
-            }
-            case 3 -> {
-                return handleLiteral((RdfLiteral) graph);
-            }
-            default -> {
-                throw new RdfProtoTranscodingError("Unknown graph term type");
-            }
+        } else if (graph instanceof RdfIri iri) {
+            return handleIri(iri);
+        } else if (graph instanceof String blankNode) {
+            return blankNode; // blank node
+        } else if (graph instanceof RdfDefaultGraph) {
+            return graph; // default graph
+        } else if (graph instanceof RdfLiteral literal) {
+            return handleLiteral(literal);
+        } else {
+            throw new RdfProtoTranscodingError("Unknown graph term type");
         }
     }
 
@@ -274,16 +254,13 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
     }
 
     private RdfTriple handleTripleTerm(RdfTriple triple) {
-        var s1 = handleSpoTerm(triple.getSubjectFieldNumber() - RdfTriple.S_IRI, triple.getSubject());
-        var p1 = handleSpoTerm(triple.getPredicateFieldNumber() - RdfTriple.P_IRI, triple.getPredicate());
-        var o1 = handleSpoTerm(triple.getObjectFieldNumber() - RdfTriple.O_IRI, triple.getObject());
+        var s1 = handleSpoTerm(triple.getSubject());
+        var p1 = handleSpoTerm(triple.getPredicate());
+        var o1 = handleSpoTerm(triple.getObject());
         // Reference comparison is fine here, as the term objects should be reused directly if possible.
         if (s1 != triple.getSubject() || p1 != triple.getPredicate() || o1 != triple.getObject()) {
             hasChangedTerms = true;
-            return RdfTriple.newInstance()
-                .setSubject(s1, triple.getSubjectFieldNumber())
-                .setPredicate(p1, triple.getPredicateFieldNumber())
-                .setObject(o1, triple.getObjectFieldNumber());
+            return RdfTriple.newInstance().setSubject(s1).setPredicate(p1).setObject(o1);
         }
         return triple;
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoTranscoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/ProtoTranscoderImpl.java
@@ -197,13 +197,13 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
     private Object handleSpoTerm(Object term) {
         if (term == null) {
             return null;
-        } else if (term instanceof RdfIri iri) {
+        } else if (term instanceof RdfIri.Mutable iri) {
             return handleIri(iri);
         } else if (term instanceof String blankNode) {
             return blankNode;
-        } else if (term instanceof RdfLiteral literal) {
+        } else if (term instanceof RdfLiteral.Mutable literal) {
             return handleLiteral(literal);
-        } else if (term instanceof RdfTriple triple) {
+        } else if (term instanceof RdfTriple.Mutable triple) {
             return handleTripleTerm(triple);
         } else {
             throw new RdfProtoTranscodingError("Unknown term type");
@@ -213,13 +213,13 @@ public class ProtoTranscoderImpl implements ProtoTranscoder {
     private Object handleGraphTerm(Object graph) {
         if (graph == null) {
             return null;
-        } else if (graph instanceof RdfIri iri) {
+        } else if (graph instanceof RdfIri.Mutable iri) {
             return handleIri(iri);
         } else if (graph instanceof String blankNode) {
             return blankNode; // blank node
-        } else if (graph instanceof RdfDefaultGraph) {
+        } else if (graph instanceof RdfDefaultGraph.Mutable) {
             return graph; // default graph
-        } else if (graph instanceof RdfLiteral literal) {
+        } else if (graph instanceof RdfLiteral.Mutable literal) {
             return handleLiteral(literal);
         } else {
             throw new RdfProtoTranscodingError("Unknown graph term type");

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/proto/GraphBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/proto/GraphBase.java
@@ -8,13 +8,8 @@ import eu.neverblink.jelly.core.proto.v1.RdfLiteral;
 @InternalApi
 public interface GraphBase {
     interface Setters extends GraphBase {
-        GraphBase setGIri(RdfIri gIri);
-        GraphBase setGBnode(String gBnode);
-        GraphBase setGDefaultGraph(RdfDefaultGraph gDefaultGraph);
-        GraphBase setGLiteral(RdfLiteral gLiteral);
+        GraphBase setGraph(Object graph);
     }
 
     Object getGraph();
-
-    byte getGraphFieldNumber();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/proto/HeaderBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/proto/HeaderBase.java
@@ -8,9 +8,6 @@ import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 @InternalApi
 public interface HeaderBase {
     interface Setters extends HeaderBase {
-        HeaderBase setHIri(RdfIri hIri);
-        HeaderBase setHBnode(String hBnode);
-        HeaderBase setHLiteral(RdfLiteral hLiteral);
-        HeaderBase setHTripleTerm(RdfTriple hTripleTerm);
+        HeaderBase setValue(Object header);
     }
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/proto/SpoBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/proto/SpoBase.java
@@ -8,30 +8,12 @@ import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 @InternalApi
 public interface SpoBase {
     interface Setters extends SpoBase {
-        SpoBase setSubject(Object subject, byte number);
-        SpoBase setSIri(RdfIri sIri);
-        SpoBase setSBnode(String sBnode);
-        SpoBase setSLiteral(RdfLiteral sLiteral);
-        SpoBase setSTripleTerm(RdfTriple sTripleTerm);
-
-        SpoBase setPredicate(Object predicate, byte number);
-        SpoBase setPIri(RdfIri pIri);
-        SpoBase setPBnode(String pBnode);
-        SpoBase setPLiteral(RdfLiteral pLiteral);
-        SpoBase setPTripleTerm(RdfTriple pTripleTerm);
-
-        SpoBase setObject(Object object, byte number);
-        SpoBase setOIri(RdfIri oIri);
-        SpoBase setOBnode(String oBnode);
-        SpoBase setOLiteral(RdfLiteral oLiteral);
-        SpoBase setOTripleTerm(RdfTriple oTripleTerm);
+        SpoBase setSubject(Object subject);
+        SpoBase setPredicate(Object predicate);
+        SpoBase setObject(Object object);
     }
 
     Object getSubject();
     Object getPredicate();
     Object getObject();
-
-    byte getSubjectFieldNumber();
-    byte getPredicateFieldNumber();
-    byte getObjectFieldNumber();
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/proto/SpoBase.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/proto/SpoBase.java
@@ -8,16 +8,19 @@ import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 @InternalApi
 public interface SpoBase {
     interface Setters extends SpoBase {
+        SpoBase setSubject(Object subject, byte number);
         SpoBase setSIri(RdfIri sIri);
         SpoBase setSBnode(String sBnode);
         SpoBase setSLiteral(RdfLiteral sLiteral);
         SpoBase setSTripleTerm(RdfTriple sTripleTerm);
 
+        SpoBase setPredicate(Object predicate, byte number);
         SpoBase setPIri(RdfIri pIri);
         SpoBase setPBnode(String pBnode);
         SpoBase setPLiteral(RdfLiteral pLiteral);
         SpoBase setPTripleTerm(RdfTriple pTripleTerm);
 
+        SpoBase setObject(Object object, byte number);
         SpoBase setOIri(RdfIri oIri);
         SpoBase setOBnode(String oBnode);
         SpoBase setOLiteral(RdfLiteral oLiteral);

--- a/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/ProtoAuxiliarySpec.scala
@@ -86,7 +86,7 @@ class ProtoAuxiliarySpec extends AnyWordSpec, Matchers:
       var triple = RdfTriple.newInstance()
       for (_ <- 1 to depth) {
         triple = RdfTriple.newInstance()
-          .setSTripleTerm(triple)
+          .setSubject(triple)
       }
       RdfStreamFrame.newInstance()
         .addRows(RdfStreamRow.newInstance().setTriple(triple))

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
@@ -1,21 +1,14 @@
 package eu.neverblink.jelly.core.helpers
 
-import eu.neverblink.jelly.core.{NodeEncoder, ProtoEncoderConverter, RdfProtoSerializationError}
-import eu.neverblink.jelly.core.*
 import eu.neverblink.jelly.core.RdfBufferAppender.Encoded
 import eu.neverblink.jelly.core.helpers.Mrl.*
-import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.core.utils.{QuadExtractor, TripleExtractor}
-
-import java.util.function.BiConsumer
-import scala.collection.mutable
+import eu.neverblink.jelly.core.*
 
 /**
  * Mock implementation of ProtoEncoderConverter
  */
 class MockProtoEncoderConverter extends ProtoEncoderConverter[Node], TripleExtractor[Node, Triple], QuadExtractor[Node, Quad]:
-  
-  type C = BiConsumer[Object, java.lang.Byte]
 
   override def nodeToProto(encoder: NodeEncoder[Node], node: Node): Encoded = node match
     case Iri(iri) => encoder.makeIri(iri)

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
@@ -1,6 +1,5 @@
 package eu.neverblink.jelly.core.helpers
 
-import eu.neverblink.jelly.core.RdfBufferAppender.Encoded
 import eu.neverblink.jelly.core.helpers.Mrl.*
 import eu.neverblink.jelly.core.utils.{QuadExtractor, TripleExtractor}
 import eu.neverblink.jelly.core.*
@@ -10,7 +9,7 @@ import eu.neverblink.jelly.core.*
  */
 class MockProtoEncoderConverter extends ProtoEncoderConverter[Node], TripleExtractor[Node, Triple], QuadExtractor[Node, Quad]:
 
-  override def nodeToProto(encoder: NodeEncoder[Node], node: Node): Encoded = node match
+  override def nodeToProto(encoder: NodeEncoder[Node], node: Node): Object = node match
     case Iri(iri) => encoder.makeIri(iri)
     case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
     case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)
@@ -19,7 +18,7 @@ class MockProtoEncoderConverter extends ProtoEncoderConverter[Node], TripleExtra
     case TripleNode(s, p, o) => encoder.makeQuotedTriple(s, p, o)
     case _ => throw RdfProtoSerializationError(s"Cannot encode node: $node")
 
-  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node): Encoded = node match
+  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node): Object = node match
     case Iri(iri) => encoder.makeIri(iri)
     case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
     case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
@@ -2,6 +2,7 @@ package eu.neverblink.jelly.core.helpers
 
 import eu.neverblink.jelly.core.{NodeEncoder, ProtoEncoderConverter, RdfProtoSerializationError}
 import eu.neverblink.jelly.core.*
+import eu.neverblink.jelly.core.RdfBufferAppender.Encoded
 import eu.neverblink.jelly.core.helpers.Mrl.*
 import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.core.utils.{QuadExtractor, TripleExtractor}
@@ -16,22 +17,22 @@ class MockProtoEncoderConverter extends ProtoEncoderConverter[Node], TripleExtra
   
   type C = BiConsumer[Object, java.lang.Byte]
 
-  override def nodeToProto(encoder: NodeEncoder[Node], node: Node, consumer: C): Unit = node match
-    case Iri(iri) => encoder.makeIri(iri, consumer)
-    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex, consumer)
-    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang, consumer)
-    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt, consumer)
-    case BlankNode(label) => encoder.makeBlankNode(label, consumer)
-    case TripleNode(s, p, o) => encoder.makeQuotedTriple(s, p, o, consumer)
+  override def nodeToProto(encoder: NodeEncoder[Node], node: Node): Encoded = node match
+    case Iri(iri) => encoder.makeIri(iri)
+    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
+    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)
+    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt)
+    case BlankNode(label) => encoder.makeBlankNode(label)
+    case TripleNode(s, p, o) => encoder.makeQuotedTriple(s, p, o)
     case _ => throw RdfProtoSerializationError(s"Cannot encode node: $node")
 
-  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node, consumer: C): Unit = node match
-    case Iri(iri) => encoder.makeIri(iri, consumer)
-    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex, consumer)
-    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang, consumer)
-    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt, consumer)
-    case BlankNode(label) => encoder.makeBlankNode(label, consumer)
-    case DefaultGraphNode() => encoder.makeDefaultGraph(consumer)
+  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node): Encoded = node match
+    case Iri(iri) => encoder.makeIri(iri)
+    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
+    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)
+    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt)
+    case BlankNode(label) => encoder.makeBlankNode(label)
+    case DefaultGraphNode() => encoder.makeDefaultGraph()
     case _ => throw RdfProtoSerializationError(s"Cannot encode graph node: $node")
 
   override def getQuadSubject(quad: Quad): Node = quad.s

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/MockProtoEncoderConverter.scala
@@ -6,29 +6,32 @@ import eu.neverblink.jelly.core.helpers.Mrl.*
 import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.core.utils.{QuadExtractor, TripleExtractor}
 
+import java.util.function.BiConsumer
 import scala.collection.mutable
 
 /**
  * Mock implementation of ProtoEncoderConverter
  */
 class MockProtoEncoderConverter extends ProtoEncoderConverter[Node], TripleExtractor[Node, Triple], QuadExtractor[Node, Quad]:
+  
+  type C = BiConsumer[Object, java.lang.Byte]
 
-  override def nodeToProto(encoder: NodeEncoder[Node], node: Node): Unit = node match
-    case Iri(iri) => encoder.makeIri(iri)
-    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
-    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)
-    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt)
-    case BlankNode(label) => encoder.makeBlankNode(label)
-    case TripleNode(s, p, o) => encoder.makeQuotedTriple(s, p, o)
+  override def nodeToProto(encoder: NodeEncoder[Node], node: Node, consumer: C): Unit = node match
+    case Iri(iri) => encoder.makeIri(iri, consumer)
+    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex, consumer)
+    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang, consumer)
+    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt, consumer)
+    case BlankNode(label) => encoder.makeBlankNode(label, consumer)
+    case TripleNode(s, p, o) => encoder.makeQuotedTriple(s, p, o, consumer)
     case _ => throw RdfProtoSerializationError(s"Cannot encode node: $node")
 
-  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node): Unit = node match
-    case Iri(iri) => encoder.makeIri(iri)
-    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex)
-    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang)
-    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt)
-    case BlankNode(label) => encoder.makeBlankNode(label)
-    case DefaultGraphNode() => encoder.makeDefaultGraph()
+  override def graphNodeToProto(encoder: NodeEncoder[Node], node: Node, consumer: C): Unit = node match
+    case Iri(iri) => encoder.makeIri(iri, consumer)
+    case SimpleLiteral(lex) => encoder.makeSimpleLiteral(lex, consumer)
+    case LangLiteral(lex, lang) => encoder.makeLangLiteral(node, lex, lang, consumer)
+    case DtLiteral(lex, dt) => encoder.makeDtLiteral(node, lex, dt.dt, consumer)
+    case BlankNode(label) => encoder.makeBlankNode(label, consumer)
+    case DefaultGraphNode() => encoder.makeDefaultGraph(consumer)
     case _ => throw RdfProtoSerializationError(s"Cannot encode graph node: $node")
 
   override def getQuadSubject(quad: Quad): Node = quad.s

--- a/core/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/helpers/RdfAdapter.scala
@@ -146,17 +146,8 @@ object RdfAdapter:
     | RdfLiteral
     | Null
 
-  def rdfGraphStart(graph: RdfGraphValue): RdfGraphStart = {
-    val graphStart = RdfGraphStart.newInstance()
-
-    graph match
-      case g: RdfIri => graphStart.setGIri(g)
-      case g: String => graphStart.setGBnode(g)
-      case g: RdfDefaultGraph => graphStart.setGDefaultGraph(g)
-      case g: RdfLiteral => graphStart.setGLiteral(g)
-
-    graphStart
-  }
+  def rdfGraphStart(graph: RdfGraphValue): RdfGraphStart =
+    RdfGraphStart.newInstance().setGraph(graph)
 
   def rdfGraphStart(): RdfGraphStart =
     RdfGraphStart.newInstance()
@@ -164,39 +155,12 @@ object RdfAdapter:
   def rdfGraphEnd(): RdfGraphEnd =
     RdfGraphEnd.EMPTY
 
-  def rdfQuad(subject: RdfSpoValue, predicate: RdfSpoValue, `object`: RdfSpoValue, graph: RdfGraphValue = null): RdfQuad = {
-    var quad = RdfQuad.newInstance()
-
-    if subject != null then
-      subject match
-        case s: RdfIri => quad = quad.setSIri(s)
-        case s: String => quad = quad.setSBnode(s)
-        case s: RdfLiteral => quad = quad.setSLiteral(s)
-        case s: RdfTriple => quad = quad.setSTripleTerm(s)
-
-    if predicate != null then
-      predicate match
-        case p: RdfIri => quad = quad.setPIri(p)
-        case p: String => quad = quad.setPBnode(p)
-        case p: RdfLiteral => quad = quad.setPLiteral(p)
-        case p: RdfTriple => quad = quad.setPTripleTerm(p)
-
-    if `object` != null then
-      `object` match
-        case o: RdfIri => quad = quad.setOIri(o)
-        case o: String => quad = quad.setOBnode(o)
-        case o: RdfLiteral => quad = quad.setOLiteral(o)
-        case o: RdfTriple => quad = quad.setOTripleTerm(o)
-
-    if graph != null then
-      graph match
-        case g: RdfIri => quad = quad.setGIri(g)
-        case g: String => quad = quad.setGBnode(g)
-        case g: RdfDefaultGraph => quad = quad.setGDefaultGraph(g)
-        case g: RdfLiteral => quad = quad.setGLiteral(g)
-
-    quad
-  }
+  def rdfQuad(subject: RdfSpoValue, predicate: RdfSpoValue, `object`: RdfSpoValue, graph: RdfGraphValue = null): RdfQuad =
+    RdfQuad.newInstance()
+      .setSubject(subject)
+      .setPredicate(predicate)
+      .setObject(`object`)
+      .setGraph(graph)
 
   type RdfSpoValue =
     RdfIri
@@ -205,32 +169,11 @@ object RdfAdapter:
     | RdfTriple
     | Null
 
-  def rdfTriple(subject: RdfSpoValue, predicate: RdfSpoValue, `object`: RdfSpoValue): RdfTriple = {
-    var triple = RdfTriple.newInstance()
-
-    if subject != null then
-      subject match
-        case s: RdfIri => triple = triple.setSIri(s)
-        case s: String => triple = triple.setSBnode(s)
-        case s: RdfLiteral => triple = triple.setSLiteral(s)
-        case s: RdfTriple => triple = triple.setSTripleTerm(s)
-
-    if predicate != null then
-      predicate match
-        case p: RdfIri => triple = triple.setPIri(p)
-        case p: String => triple = triple.setPBnode(p)
-        case p: RdfLiteral => triple = triple.setPLiteral(p)
-        case p: RdfTriple => triple = triple.setPTripleTerm(p)
-
-    if `object` != null then
-      `object` match
-        case o: RdfIri => triple = triple.setOIri(o)
-        case o: String => triple = triple.setOBnode(o)
-        case o: RdfLiteral => triple = triple.setOLiteral(o)
-        case o: RdfTriple => triple = triple.setOTripleTerm(o)
-
-    triple
-  }
+  def rdfTriple(subject: RdfSpoValue, predicate: RdfSpoValue, `object`: RdfSpoValue): RdfTriple =
+    RdfTriple.newInstance()
+      .setSubject(subject)
+      .setPredicate(predicate)
+      .setObject(`object`)
 
   def extractRdfStreamRow(row: RdfStreamRow): RdfStreamRowValue =
     if row.hasOptions then

--- a/core/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/internal/NodeEncoderSpec.scala
@@ -9,7 +9,6 @@ import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.util.function.BiConsumer
 import scala.collection.mutable.ListBuffer
 import scala.util.Random
 
@@ -21,7 +20,6 @@ class NodeEncoderSpec extends AnyWordSpec, Inspectors, Matchers:
   )
 
   type RdfTerm = RdfIri | String | RdfLiteral | (Mrl.Node, Mrl.Node, Mrl.Node) | RdfDefaultGraph
-  type Consumer = BiConsumer[Object, java.lang.Byte]
 
   private def getEncoder(prefixTableSize: Int = 8): 
   (NodeEncoderImpl[Mrl.Node], ListBuffer[RdfStreamRow]) =

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/MessageGenerator.scala
@@ -162,8 +162,8 @@ class MessageGenerator(val info: MessageInfo):
       .addParameter(classOf[AnyRef], "o")
     // Reference equality check
     equals.beginControlFlow("if (o == this)").addStatement("return true").endControlFlow
-    // Type check
-    equals.beginControlFlow("if (!(o instanceof $T))", info.typeName)
+    // Type check -- check against the final subclass for better performance
+    equals.beginControlFlow("if (!(o instanceof $T))", info.mutableTypeName)
       .addStatement("return false")
       .endControlFlow
     equals.addStatement("$1T other = ($1T) o", info.typeName)

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/PluginOptions.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/PluginOptions.scala
@@ -51,6 +51,7 @@ class PluginOptions(request: PluginProtos.CodeGeneratorRequest):
   val generateDescriptors: Boolean = parseBoolean(map.getOrDefault("gen_descriptors", "true"))
   val implements: Map[String, Seq[String]] = parseImplements(map)
   val fastOneofMerge: Set[String] = map.getOrDefault("fast_oneof_merge", "").split(";").toSet
+  val classBasedOneof: Set[String] = map.getOrDefault("class_based_oneof", "").split(";").toSet
 
   private def parseReplacePackage(replaceOption: String): String => String =
     // leave as is

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/RequestInfo.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/RequestInfo.scala
@@ -163,9 +163,10 @@ object RequestInfo:
     ).collect(Collectors.toList)
 
     private val oneOfCount: Int = descriptor.getOneofDeclCount
+    val usesClassBasedOneof: Boolean = options.classBasedOneof.contains(typeName.simpleName())
     val oneOfs: IndexedSeq[OneOfInfo] = for i <- 0 until oneOfCount yield
       new RequestInfo.OneOfInfo(
-        parentFile, this, typeName, descriptor.getOneofDecl(i), i
+        parentFile, this, typeName, descriptor.getOneofDecl(i), i, usesClassBasedOneof
       )
 
     val isEmptyMessage: Boolean = fieldCount == 0 && oneOfCount == 0
@@ -388,7 +389,8 @@ object RequestInfo:
     val parentTypeInfo: RequestInfo.MessageInfo, 
     val parentType: ClassName,
     val descriptor: DescriptorProtos.OneofDescriptorProto,
-    val oneOfIndex: Int
+    val oneOfIndex: Int,
+    val usesClassBasedOneof: Boolean,
   ) {
 
     val upperName: String = NamingUtil.toUpperCamel(descriptor.getName)

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
@@ -2,6 +2,7 @@ package eu.neverblink.jelly.convert.jena;
 
 import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
+import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
@@ -15,13 +16,13 @@ public final class JenaEncoderConverter
     implements ProtoEncoderConverter<Node>, TripleExtractor<Node, Triple>, QuadExtractor<Node, Quad> {
 
     @Override
-    public void nodeToProto(NodeEncoder<Node> encoder, Node node, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Node> encoder, Node node) {
         // URI/IRI
         if (node.isURI()) {
-            encoder.makeIri(node.getURI(), consumer);
+            return encoder.makeIri(node.getURI());
         } else if (node.isBlank()) {
             // Blank node
-            encoder.makeBlankNode(node.getBlankNodeLabel(), consumer);
+            return encoder.makeBlankNode(node.getBlankNodeLabel());
         } else if (node.isLiteral()) {
             // Literal
             final var lang = node.getLiteralLanguage();
@@ -29,38 +30,37 @@ public final class JenaEncoderConverter
                 // RDF 1.1 spec: language tag MUST be non-empty. So, this is a plain or datatype literal.
                 // We compare by reference, because the datatype is a singleton.
                 if (node.getLiteralDatatype() == XSDDatatype.XSDstring) {
-                    encoder.makeSimpleLiteral(node.getLiteralLexicalForm(), consumer);
+                    return encoder.makeSimpleLiteral(node.getLiteralLexicalForm());
                 } else {
-                    encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI(), consumer);
+                    return encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI());
                 }
             } else {
-                encoder.makeLangLiteral(node, node.getLiteralLexicalForm(), lang, consumer);
+                return encoder.makeLangLiteral(node, node.getLiteralLexicalForm(), lang);
             }
         } else if (node.isNodeTriple()) {
             // RDF-star node
             final var t = node.getTriple();
-            encoder.makeQuotedTriple(t.getSubject(), t.getPredicate(), t.getObject(), consumer);
+            return encoder.makeQuotedTriple(t.getSubject(), t.getPredicate(), t.getObject());
         } else {
             throw new IllegalArgumentException("Cannot encode node: " + node);
         }
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<Node> encoder, Node node, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Node> encoder, Node node) {
         // Default graph
         if (node == null) {
-            encoder.makeDefaultGraph(consumer);
-            return;
+            return encoder.makeDefaultGraph();
         } else if (node.isURI()) {
             // URI/IRI
             if (Quad.isDefaultGraph(node)) {
-                encoder.makeDefaultGraph(consumer);
+                return encoder.makeDefaultGraph();
             } else {
-                encoder.makeIri(node.getURI(), consumer);
+                return encoder.makeIri(node.getURI());
             }
         } else if (node.isBlank()) {
             // Blank node
-            encoder.makeBlankNode(node.getBlankNodeLabel(), consumer);
+            return encoder.makeBlankNode(node.getBlankNodeLabel());
         } else if (node.isLiteral()) {
             // Literal
             final var lang = node.getLiteralLanguage();
@@ -68,12 +68,12 @@ public final class JenaEncoderConverter
                 // RDF 1.1 spec: language tag MUST be non-empty. So, this is a plain or datatype literal.
                 // We compare by reference, because the datatype is a singleton.
                 if (node.getLiteralDatatype() == XSDDatatype.XSDstring) {
-                    encoder.makeSimpleLiteral(node.getLiteralLexicalForm(), consumer);
+                    return encoder.makeSimpleLiteral(node.getLiteralLexicalForm());
                 } else {
-                    encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI(), consumer);
+                    return encoder.makeDtLiteral(node, node.getLiteralLexicalForm(), node.getLiteralDatatypeURI());
                 }
             } else {
-                encoder.makeLangLiteral(node, node.getLiteralLexicalForm(), lang, consumer);
+                return encoder.makeLangLiteral(node, node.getLiteralLexicalForm(), lang);
             }
         } else {
             throw new IllegalArgumentException("Cannot encode graph node: " + node);

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
@@ -14,7 +14,7 @@ public final class JenaEncoderConverter
     implements ProtoEncoderConverter<Node>, TripleExtractor<Node, Triple>, QuadExtractor<Node, Quad> {
 
     @Override
-    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Node> encoder, Node node) {
+    public Object nodeToProto(NodeEncoder<Node> encoder, Node node) {
         // URI/IRI
         if (node.isURI()) {
             return encoder.makeIri(node.getURI());
@@ -45,7 +45,7 @@ public final class JenaEncoderConverter
     }
 
     @Override
-    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Node> encoder, Node node) {
+    public Object graphNodeToProto(NodeEncoder<Node> encoder, Node node) {
         // Default graph
         if (node == null) {
             return encoder.makeDefaultGraph();

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/JenaEncoderConverter.java
@@ -10,8 +10,6 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Quad;
 
-import java.util.function.BiConsumer;
-
 public final class JenaEncoderConverter
     implements ProtoEncoderConverter<Node>, TripleExtractor<Node, Triple>, QuadExtractor<Node, Quad> {
 

--- a/jena/src/test/scala/eu/neverblink/jelly/convert/jena/JenaProtoEncoderSpec.scala
+++ b/jena/src/test/scala/eu/neverblink/jelly/convert/jena/JenaProtoEncoderSpec.scala
@@ -20,7 +20,7 @@ class JenaProtoEncoderSpec extends AnyWordSpec, Matchers, JenaTest:
 
   private val encodedDefaultGraph = RdfStreamRow.newInstance
     .setGraphStart(
-      RdfGraphStart.newInstance.setGDefaultGraph(RdfDefaultGraph.EMPTY)
+      RdfGraphStart.newInstance.setGraph(RdfDefaultGraph.EMPTY)
     )
   
   "JenaProtoEncoder" should {
@@ -67,7 +67,7 @@ class JenaProtoEncoderSpec extends AnyWordSpec, Matchers, JenaTest:
       )
       buffer.size should be (2) // 1 for the options, 1 for the triple
       val row = buffer.getRows.get(1)
-      row.getQuad.getOLiteral.getLiteralKind should be (null)
-      row.getQuad.getGLiteral.getLiteralKind should be (null)
+      row.getQuad.getObject.asInstanceOf[RdfLiteral].getLiteralKind should be (null)
+      row.getQuad.getGraph.asInstanceOf[RdfLiteral].getLiteralKind should be (null)
     }
   }

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfTripleRecursiveBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfTripleRecursiveBench.scala
@@ -26,11 +26,11 @@ object RdfTripleRecursiveBench:
         triple
       else
         if random.nextBoolean() then
-          triple.setSTripleTerm(makeNestedTriple(depth - 1))
+          triple.setSubject(makeNestedTriple(depth - 1))
         if random.nextBoolean() then
-          triple.setPTripleTerm(makeNestedTriple(depth - 1))
+          triple.setPredicate(makeNestedTriple(depth - 1))
         if random.nextBoolean() then
-          triple.setOTripleTerm(makeNestedTriple(depth - 1))
+          triple.setObject(makeNestedTriple(depth - 1))
         triple
 
     @Setup(Level.Trial)

--- a/rdf-protos/src/main/args.txt
+++ b/rdf-protos/src/main/args.txt
@@ -17,4 +17,5 @@ implements_RdfPatchHeader=eu.neverblink.jelly.core.internal.proto.HeaderBase,
 implements_RdfPatchHeader.Mutable=eu.neverblink.jelly.core.internal.proto.HeaderBase.Setters,
 implements_RdfPatchOptions=eu.neverblink.jelly.core.internal.proto.OptionsBase,
 fast_oneof_merge=RdfStreamRow,
+class_based_oneof=RdfTriple;RdfQuad;RdfGraphStart;RdfPatchNamespace;RdfPatchHeader,
 replace_package=eu.ostrzyciel=eu.neverblink

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -2,6 +2,7 @@ package eu.neverblink.jelly.convert.rdf4j;
 
 import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
+import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;
@@ -13,52 +14,52 @@ public class Rdf4jEncoderConverter
     implements ProtoEncoderConverter<Value>, TripleExtractor<Value, Statement>, QuadExtractor<Value, Statement> {
 
     @Override
-    public void nodeToProto(NodeEncoder<Value> encoder, Value value, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Value> encoder, Value value) {
         if (value instanceof IRI iri) {
-            encoder.makeIri(iri.stringValue(), consumer);
+            return encoder.makeIri(iri.stringValue());
         } else if (value instanceof BNode bNode) {
-            encoder.makeBlankNode(bNode.getID(), consumer);
+            return encoder.makeBlankNode(bNode.getID());
         } else if (value instanceof Literal literal) {
             final var lex = literal.getLabel();
             final var lang = literal.getLanguage();
             if (lang.isPresent()) {
-                encoder.makeLangLiteral(literal, lex, lang.get(), consumer);
+                return encoder.makeLangLiteral(literal, lex, lang.get());
             } else {
                 final var dt = literal.getDatatype();
                 if (!dt.equals(XSD.STRING)) {
-                    encoder.makeDtLiteral(literal, lex, dt.stringValue(), consumer);
+                    return encoder.makeDtLiteral(literal, lex, dt.stringValue());
                 } else {
-                    encoder.makeSimpleLiteral(lex, consumer);
+                    return encoder.makeSimpleLiteral(lex);
                 }
             }
         } else if (value instanceof Triple triple) {
-            encoder.makeQuotedTriple(triple.getSubject(), triple.getPredicate(), triple.getObject(), consumer);
+            return encoder.makeQuotedTriple(triple.getSubject(), triple.getPredicate(), triple.getObject());
         } else {
             throw new RdfProtoSerializationError("Cannot encode node: %s".formatted(value));
         }
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<Value> encoder, Value value, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Value> encoder, Value value) {
         if (value instanceof IRI iri) {
-            encoder.makeIri(iri.stringValue(), consumer);
+            return encoder.makeIri(iri.stringValue());
         } else if (value instanceof BNode bNode) {
-            encoder.makeBlankNode(bNode.getID(), consumer);
+            return encoder.makeBlankNode(bNode.getID());
         } else if (value instanceof Literal literal) {
             final var lex = literal.getLabel();
             final var lang = literal.getLanguage();
             if (lang.isPresent()) {
-                encoder.makeLangLiteral(literal, lex, lang.get(), consumer);
+                return encoder.makeLangLiteral(literal, lex, lang.get());
             } else {
                 final var dt = literal.getDatatype();
                 if (!dt.equals(XSD.STRING)) {
-                    encoder.makeDtLiteral(literal, lex, dt.stringValue(), consumer);
+                    return encoder.makeDtLiteral(literal, lex, dt.stringValue());
                 } else {
-                    encoder.makeSimpleLiteral(lex, consumer);
+                    return encoder.makeSimpleLiteral(lex);
                 }
             }
         } else if (value == null) {
-            encoder.makeDefaultGraph(consumer);
+            return encoder.makeDefaultGraph();
         } else {
             throw new RdfProtoSerializationError("Cannot encode graph node: %s".formatted(value));
         }

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -13,7 +13,7 @@ public class Rdf4jEncoderConverter
     implements ProtoEncoderConverter<Value>, TripleExtractor<Value, Statement>, QuadExtractor<Value, Statement> {
 
     @Override
-    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Value> encoder, Value value) {
+    public Object nodeToProto(NodeEncoder<Value> encoder, Value value) {
         if (value instanceof IRI iri) {
             return encoder.makeIri(iri.stringValue());
         } else if (value instanceof BNode bNode) {
@@ -39,7 +39,7 @@ public class Rdf4jEncoderConverter
     }
 
     @Override
-    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Value> encoder, Value value) {
+    public Object graphNodeToProto(NodeEncoder<Value> encoder, Value value) {
         if (value instanceof IRI iri) {
             return encoder.makeIri(iri.stringValue());
         } else if (value instanceof BNode bNode) {

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -6,7 +6,6 @@ import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;
-import java.util.function.BiConsumer;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -5,6 +5,7 @@ import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;
+import java.util.function.BiConsumer;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
@@ -12,52 +13,52 @@ public class Rdf4jEncoderConverter
     implements ProtoEncoderConverter<Value>, TripleExtractor<Value, Statement>, QuadExtractor<Value, Statement> {
 
     @Override
-    public void nodeToProto(NodeEncoder<Value> encoder, Value value) {
+    public void nodeToProto(NodeEncoder<Value> encoder, Value value, BiConsumer<Object, Byte> consumer) {
         if (value instanceof IRI iri) {
-            encoder.makeIri(iri.stringValue());
+            encoder.makeIri(iri.stringValue(), consumer);
         } else if (value instanceof BNode bNode) {
-            encoder.makeBlankNode(bNode.getID());
+            encoder.makeBlankNode(bNode.getID(), consumer);
         } else if (value instanceof Literal literal) {
             final var lex = literal.getLabel();
             final var lang = literal.getLanguage();
             if (lang.isPresent()) {
-                encoder.makeLangLiteral(literal, lex, lang.get());
+                encoder.makeLangLiteral(literal, lex, lang.get(), consumer);
             } else {
                 final var dt = literal.getDatatype();
                 if (!dt.equals(XSD.STRING)) {
-                    encoder.makeDtLiteral(literal, lex, dt.stringValue());
+                    encoder.makeDtLiteral(literal, lex, dt.stringValue(), consumer);
                 } else {
-                    encoder.makeSimpleLiteral(lex);
+                    encoder.makeSimpleLiteral(lex, consumer);
                 }
             }
         } else if (value instanceof Triple triple) {
-            encoder.makeQuotedTriple(triple.getSubject(), triple.getPredicate(), triple.getObject());
+            encoder.makeQuotedTriple(triple.getSubject(), triple.getPredicate(), triple.getObject(), consumer);
         } else {
             throw new RdfProtoSerializationError("Cannot encode node: %s".formatted(value));
         }
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<Value> encoder, Value value) {
+    public void graphNodeToProto(NodeEncoder<Value> encoder, Value value, BiConsumer<Object, Byte> consumer) {
         if (value instanceof IRI iri) {
-            encoder.makeIri(iri.stringValue());
+            encoder.makeIri(iri.stringValue(), consumer);
         } else if (value instanceof BNode bNode) {
-            encoder.makeBlankNode(bNode.getID());
+            encoder.makeBlankNode(bNode.getID(), consumer);
         } else if (value instanceof Literal literal) {
             final var lex = literal.getLabel();
             final var lang = literal.getLanguage();
             if (lang.isPresent()) {
-                encoder.makeLangLiteral(literal, lex, lang.get());
+                encoder.makeLangLiteral(literal, lex, lang.get(), consumer);
             } else {
                 final var dt = literal.getDatatype();
                 if (!dt.equals(XSD.STRING)) {
-                    encoder.makeDtLiteral(literal, lex, dt.stringValue());
+                    encoder.makeDtLiteral(literal, lex, dt.stringValue(), consumer);
                 } else {
-                    encoder.makeSimpleLiteral(lex);
+                    encoder.makeSimpleLiteral(lex, consumer);
                 }
             }
         } else if (value == null) {
-            encoder.makeDefaultGraph();
+            encoder.makeDefaultGraph(consumer);
         } else {
             throw new RdfProtoSerializationError("Cannot encode graph node: %s".formatted(value));
         }

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
@@ -27,9 +27,9 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     ))
     frame.addRows(RdfStreamRow.newInstance().setTriple(
       RdfTriple.newInstance()
-        .setSIri(RdfIri.newInstance())
-        .setPIri(RdfIri.newInstance().setNameId(1))
-        .setOLiteral(RdfLiteral.newInstance().setLex("test"))
+        .setSubject(RdfIri.newInstance())
+        .setPredicate(RdfIri.newInstance().setNameId(1))
+        .setObject(RdfLiteral.newInstance().setLex("test"))
     ))
     frame.toByteArrayDelimited
   }

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -5,6 +5,8 @@ import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 
+import java.util.function.BiConsumer;
+
 /**
  * Converter for translating between Titanium RDF API nodes/terms and Jelly proto objects.
  */
@@ -12,21 +14,24 @@ import eu.neverblink.jelly.core.RdfProtoSerializationError;
 public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Object> {
 
     @Override
-    public void nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
+    public void nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode, BiConsumer<Object, Byte> consumer) {
         try {
             switch (TitaniumNode.typeOf(titaniumNode)) {
-                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
-                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2)); // remove "_:"
-                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(TitaniumNode.simpleLiteralOf(titaniumNode).lex());
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode), consumer);
+                // remove "_:"
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2), consumer);
+                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(TitaniumNode.simpleLiteralOf(titaniumNode).lex(), consumer);
                 case LANG_LITERAL -> encoder.makeLangLiteral(
                     titaniumNode,
                     TitaniumNode.langLiteralOf(titaniumNode).lex(),
-                    TitaniumNode.langLiteralOf(titaniumNode).lang()
+                    TitaniumNode.langLiteralOf(titaniumNode).lang(), 
+                    consumer
                 );
                 case DT_LITERAL -> encoder.makeDtLiteral(
                     titaniumNode,
                     TitaniumNode.dtLiteralOf(titaniumNode).lex(),
-                    TitaniumNode.dtLiteralOf(titaniumNode).dt()
+                    TitaniumNode.dtLiteralOf(titaniumNode).dt(), 
+                    consumer
                 );
                 default -> throw new IllegalStateException("Cannot encode null as S/P/O term.");
             }
@@ -36,16 +41,17 @@ public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Obj
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
+    public void graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode, BiConsumer<Object, Byte> consumer) {
         try {
             if (titaniumNode == null) {
-                encoder.makeDefaultGraph();
+                encoder.makeDefaultGraph(consumer);
                 return;
             }
 
             switch (TitaniumNode.typeOf(titaniumNode)) {
-                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
-                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2)); // remove "_:"
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode), consumer);
+                // remove "_:"
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2), consumer);
                 default -> throw new RdfProtoSerializationError(
                     "Cannot encode null as graph node: %s".formatted(titaniumNode)
                 );

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -9,7 +9,7 @@ import eu.neverblink.jelly.core.*;
 public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Object> {
 
     @Override
-    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
+    public Object nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
             return switch (TitaniumNode.typeOf(titaniumNode)) {
                 case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
@@ -34,7 +34,7 @@ public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Obj
     }
 
     @Override
-    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
+    public Object graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
             if (titaniumNode == null) {
                 return encoder.makeDefaultGraph();

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -1,10 +1,6 @@
 package eu.neverblink.jelly.convert.titanium.internal;
 
-import eu.neverblink.jelly.core.InternalApi;
-import eu.neverblink.jelly.core.NodeEncoder;
-import eu.neverblink.jelly.core.ProtoEncoderConverter;
-import eu.neverblink.jelly.core.RdfProtoSerializationError;
-
+import eu.neverblink.jelly.core.*;
 import java.util.function.BiConsumer;
 
 /**
@@ -14,48 +10,45 @@ import java.util.function.BiConsumer;
 public final class TitaniumEncoderConverter implements ProtoEncoderConverter<Object> {
 
     @Override
-    public void nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded nodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
-            switch (TitaniumNode.typeOf(titaniumNode)) {
-                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode), consumer);
+            return switch (TitaniumNode.typeOf(titaniumNode)) {
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
                 // remove "_:"
-                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2), consumer);
-                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(TitaniumNode.simpleLiteralOf(titaniumNode).lex(), consumer);
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2));
+                case SIMPLE_LITERAL -> encoder.makeSimpleLiteral(TitaniumNode.simpleLiteralOf(titaniumNode).lex());
                 case LANG_LITERAL -> encoder.makeLangLiteral(
                     titaniumNode,
                     TitaniumNode.langLiteralOf(titaniumNode).lex(),
-                    TitaniumNode.langLiteralOf(titaniumNode).lang(), 
-                    consumer
+                    TitaniumNode.langLiteralOf(titaniumNode).lang()
                 );
                 case DT_LITERAL -> encoder.makeDtLiteral(
                     titaniumNode,
                     TitaniumNode.dtLiteralOf(titaniumNode).lex(),
-                    TitaniumNode.dtLiteralOf(titaniumNode).dt(), 
-                    consumer
+                    TitaniumNode.dtLiteralOf(titaniumNode).dt()
                 );
                 default -> throw new IllegalStateException("Cannot encode null as S/P/O term.");
-            }
+            };
         } catch (Exception e) {
             throw new RdfProtoSerializationError(e.getMessage(), e);
         }
     }
 
     @Override
-    public void graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode, BiConsumer<Object, Byte> consumer) {
+    public RdfBufferAppender.Encoded graphNodeToProto(NodeEncoder<Object> encoder, Object titaniumNode) {
         try {
             if (titaniumNode == null) {
-                encoder.makeDefaultGraph(consumer);
-                return;
+                return encoder.makeDefaultGraph();
             }
 
-            switch (TitaniumNode.typeOf(titaniumNode)) {
-                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode), consumer);
+            return switch (TitaniumNode.typeOf(titaniumNode)) {
+                case IRI -> encoder.makeIri(TitaniumNode.iriLikeOf(titaniumNode));
                 // remove "_:"
-                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2), consumer);
+                case BLANK -> encoder.makeBlankNode(TitaniumNode.iriLikeOf(titaniumNode).substring(2));
                 default -> throw new RdfProtoSerializationError(
                     "Cannot encode null as graph node: %s".formatted(titaniumNode)
                 );
-            }
+            };
         } catch (Exception e) {
             throw new RdfProtoSerializationError(e.getMessage(), e);
         }

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/internal/TitaniumEncoderConverter.java
@@ -1,7 +1,6 @@
 package eu.neverblink.jelly.convert.titanium.internal;
 
 import eu.neverblink.jelly.core.*;
-import java.util.function.BiConsumer;
 
 /**
  * Converter for translating between Titanium RDF API nodes/terms and Jelly proto objects.


### PR DESCRIPTION
RDF terms are polymorphic – each may be an IRI, blank node, a literal, or a triple term. To decide which logic route should we execute for a given term, we've used a separate `byte` field that stored the number of the proto message that was currently set. The actual value is stored in an `Object` field and casted to the appropriate subclass, based on the set field number.

However, this introduces extra overhead in maintaining the field number:

- It takes up one extra slot in objects. For example, on modern JVMs with default settings, this increases the size of `RdfQuad` from 32 to 40 bytes. This leads to less efficient cache usage.
- It forces us to maintain additional state in `ProtoEncoder`, to keep track of the currently encoded term, so that we can update it correctly. This adds computational overhead (extra load/store ops) and also increases the size of ProtoEncoder. Because this class will *always* be in L1, we want it to take up at most one cache line. With these fields, encoders take up between 72 and 80 bytes, which is more than one cache line (64B).
- It doesn't actually save us from casting. The field number lets us quickly decide which polymorphic implementation we should use, but type checks have to be performed afterwards regardless.

I tried fixing this in a few ways – here is my third take. Previous approaches can be found in commit history.

This is a similar solution to how it was implemented in Scala (Jelly-JVM 2.x). We have one field of type `Object` that stores the term's value, and we do dispatch using `instanceof` checks. A few things to note:

- No, we can't have anything more specific than `Object`. One of the possible values for terms is `String`, which is outside of our control. In Scala we could use union types, this is really not an option in Java.
- In Scala we used virtual method dispatch, but that's complicated to implement in Java... and instanceof checks are also fast.
- instanceof checks were optimized to check against the final subclasses of proto message classes – so, we do `term instanceof RdfIri.Mutable` instead of `term instanceof RdfIri`.
  - This doesn't sound like it should make a difference, because the JVM should be able to figure out that RdfIri has only one concrete subclass. But, surprisingly, it does. The optimized version generates three x86 instructions (load klass, compare to constant, jump), while the other generates 9 (!!) instructions including 4 loads. Yuck. At least this is what happens on OpenJDK 23.
- This also happens to simplify encoding/decoding code by a lot, which is nice.

## Performance

I tested deserialization performance on built-in JMH benchmarks (separately: parsing and decoding). Serialization was tested on the Jelly-Patch benchmark ([source code](https://github.com/Jelly-RDF/jvm-benchmarks/tree/6cfcafbabcf3c02a2b8861ac34d992a3cba1aa0e)).

Parameters:

```
jmh/Jmh/run -f5 -wi 10 -i 15 .*RdfStreamFrameDecodeBench.*
jmh/Jmh/run -f5 -wi 10 -i 15 .*RdfTripleRecursiveBench.*
Jmh/run -f5 -wi 15 -i 15 --jvmArgs "-Djelly.patch.input-file=data/bsbm-cdc.jellyp -Djelly.patch.statement-type=TRIPLES -Djelly.patch.max-segments=75000" .*SerBench.*
```

Note that for serialization I used the BSBM dataset which is a *very* pessimistic scenario for Jelly, with a lot of entropy and long strings. So, don't expect huge gains.

**Baseline:**

```
[info] Benchmark                                        Mode  Cnt     Score    Error  Units
[info] RdfStreamFrameDecodeBench.currentImplementation  avgt   75  3006.332 ± 23.781  us/op

[info] Benchmark                                      Mode  Cnt      Score     Error  Units
[info] RdfTripleRecursiveBench.currentImplementation  avgt   75  28614.504 ± 155.930  ns/op

[info] Benchmark       (implementation)  Mode  Cnt           Score          Error  Units
[info] SerBench.jelly             jelly    ss   75  1647186185.000 ± 14971742.690  ns/op
```

**With these changes:**

```
[info] Benchmark                                        Mode  Cnt     Score    Error  Units
[info] RdfStreamFrameDecodeBench.currentImplementation  avgt   75  3064.291 ± 32.155  us/op

[info] Benchmark                                      Mode  Cnt      Score     Error  Units
[info] RdfTripleRecursiveBench.currentImplementation  avgt   75  28594.090 ± 409.779  ns/op

[info] Benchmark       (implementation)  Mode  Cnt           Score          Error  Units
[info] SerBench.jelly             jelly    ss   75  1603908657.720 ± 16467636.911  ns/op
```

Parsing is more or less the same (the difference is within the margin of error). Serialization is decidedly faster.
