### PR TITLE
Fix parsing blocking InputStreams

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
@@ -1,7 +1,6 @@
 package eu.neverblink.jelly.core.utils;
 
 import com.google.protobuf.CodedOutputStream;
-
 import java.io.*;
 import java.util.function.Consumer;
 

--- a/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
@@ -1,6 +1,7 @@
 package eu.neverblink.jelly.core.utils;
 
 import com.google.protobuf.CodedOutputStream;
+
 import java.io.*;
 import java.util.function.Consumer;
 
@@ -82,11 +83,6 @@ public final class IoUtils {
         Consumer<TFrame> frameConsumer
     ) throws IOException {
         while (true) {
-            if (inputStream.available() == 0) {
-                // No more data available, break the loop
-                break;
-            }
-
             final var maybeFrame = frameProcessor.apply(inputStream);
             if (maybeFrame == null) {
                 // No more frames available, break the loop


### PR DESCRIPTION
I'm pretty sure I already fixed this once in the Scala implementation – we must not rely on available() to check if the stream has completed, as this only tells how many *non-blocking* bytes may be read.

I added a regrtest for this. It fails with the current implementation.