### PR TITLE
ProtobufUtil: move constant and fix its value

### DIFF
--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -25,13 +25,6 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
      */
     public static final int DEFAULT_MAX_RECURSION_DEPTH = 64;
 
-    /**
-     * Maximum size of the output buffer used when writing messages to an OutputStream.
-     * Set to 2x the default buffer size of CodedOutputStream to avoid allocating additional buffers
-     * for long strings that are common in RDF.
-     */
-    public static final int MAX_OUTPUT_STREAM_BUFFER_SIZE = 8096;
-
     protected ProtoMessage() {}
 
     /**

--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtobufUtil.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtobufUtil.java
@@ -6,6 +6,13 @@ import java.io.OutputStream;
 public class ProtobufUtil {
 
     /**
+     * Maximum size of the output buffer used when writing messages to an OutputStream.
+     * Set to 2x the default buffer size of CodedOutputStream to avoid allocating additional buffers
+     * for long strings that are common in RDF.
+     */
+    public static final int MAX_OUTPUT_STREAM_BUFFER_SIZE = 8192;
+
+    /**
      * Creates a CodedOutputStream with a buffer size adjusted for the message to be serialized,
      * limited to the maximum buffer size. We size the buffer to include space for the
      * size of the delimiter.
@@ -17,7 +24,7 @@ public class ProtobufUtil {
     public static CodedOutputStream createCodedOutputStream(OutputStream outputStream, int messageSize) {
         final int bufferSize = Integer.min(
             CodedOutputStream.computeUInt32SizeNoTag(messageSize) + messageSize,
-            ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE
+            MAX_OUTPUT_STREAM_BUFFER_SIZE
         );
         return CodedOutputStream.newInstance(outputStream, bufferSize);
     }
@@ -31,6 +38,6 @@ public class ProtobufUtil {
      * @return a new CodedOutputStream instance with the maximum buffer size
      */
     public static CodedOutputStream createCodedOutputStream(OutputStream outputStream) {
-        return CodedOutputStream.newInstance(outputStream, ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE);
+        return CodedOutputStream.newInstance(outputStream, MAX_OUTPUT_STREAM_BUFFER_SIZE);
     }
 }

--- a/core/src/test/scala/eu/neverblink/protoc/java/runtime/ProtobufUtilSpec.scala
+++ b/core/src/test/scala/eu/neverblink/protoc/java/runtime/ProtobufUtilSpec.scala
@@ -29,7 +29,7 @@ class ProtobufUtilSpec extends AnyWordSpec, Matchers {
 
       os.writtenBuffers should have size 1
       // We expect a byte array of size equal to the default buffer size to be passed to the write method.
-      os.writtenBuffers.head should be (ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE)
+      os.writtenBuffers.head should be (ProtobufUtil.MAX_OUTPUT_STREAM_BUFFER_SIZE)
     }
 
     "create a CodedOutputStream with a reduced buffer size" in {
@@ -47,7 +47,7 @@ class ProtobufUtilSpec extends AnyWordSpec, Matchers {
     "clamp maximum CodedOutputStream buffer size" in {
       val os = new WriteTrackingOutputStream()
       val codedOutputStream = ProtobufUtil.createCodedOutputStream(
-        os, ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE * 2
+        os, ProtobufUtil.MAX_OUTPUT_STREAM_BUFFER_SIZE * 2
       )
       codedOutputStream should not be null
       codedOutputStream.writeInt32(7, 31241)
@@ -55,7 +55,7 @@ class ProtobufUtilSpec extends AnyWordSpec, Matchers {
 
       os.writtenBuffers should have size 1
       // We expect the maximum buffer size to be clamped to the maximum allowed value.
-      os.writtenBuffers.head should be (ProtoMessage.MAX_OUTPUT_STREAM_BUFFER_SIZE)
+      os.writtenBuffers.head should be (ProtobufUtil.MAX_OUTPUT_STREAM_BUFFER_SIZE)
     }
   }
 }


### PR DESCRIPTION
Follow-up of #467

Moved the constant to the class that uses it. Also, fixed its value because apparently I can't count.

This is not a breaking change because we haven't made a release yet with this.