### PR TITLE
Native parsers: use a single CodedInputStream

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/utils/IoUtils.java
@@ -1,10 +1,16 @@
 package eu.neverblink.jelly.core.utils;
 
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.InvalidProtocolBufferException;
+import eu.neverblink.protoc.java.runtime.MessageFactory;
+import eu.neverblink.protoc.java.runtime.ProtoMessage;
 import java.io.*;
 import java.util.function.Consumer;
 
 public final class IoUtils {
+
+    private static final int DEFAULT_INPUT_STREAM_BUFFER_SIZE = 8192;
 
     private IoUtils() {}
 
@@ -65,6 +71,7 @@ public final class IoUtils {
      * @param <TFrame> the type of the frame
      */
     @FunctionalInterface
+    @Deprecated(since = "3.4.0", forRemoval = true)
     public interface FrameProcessor<TFrame> {
         TFrame apply(InputStream inputStream) throws IOException;
     }
@@ -76,6 +83,7 @@ public final class IoUtils {
      * @param frameConsumer the consumer to handle each processed frame
      * @param <TFrame> the type of the frame
      */
+    @Deprecated(since = "3.4.0", forRemoval = true)
     public static <TFrame> void readStream(
         InputStream inputStream,
         FrameProcessor<TFrame> frameProcessor,
@@ -89,6 +97,42 @@ public final class IoUtils {
             }
 
             frameConsumer.accept(maybeFrame);
+        }
+    }
+
+    /**
+     * Reads a stream of delimited protobuf messages (frames) from an input stream. Each frame
+     * is passed to the provided consumer for processing.
+     * <p>
+     * This method reads frames in a delimited format, where each frame is preceded by its size as a varint.
+     * Internally, it uses a single `CodedInputStream` to read the frames efficiently.
+     *
+     * @param inputStream the input stream to read from
+     * @param messageFactory the factory to create new frames
+     * @param frameConsumer the consumer to handle each processed frame
+     * @param <TFrame> the type of the frame
+     * @throws IOException if an I/O error occurs
+     */
+    public static <TFrame extends ProtoMessage<TFrame>> void readStream(
+        InputStream inputStream,
+        MessageFactory<TFrame> messageFactory,
+        Consumer<TFrame> frameConsumer
+    ) throws IOException {
+        final var codedInput = CodedInputStream.newInstance(inputStream, DEFAULT_INPUT_STREAM_BUFFER_SIZE);
+        while (!codedInput.isAtEnd()) {
+            final int frameSize = codedInput.readRawVarint32();
+            if (frameSize < 0) {
+                throw new InvalidProtocolBufferException("Invalid frame size: " + frameSize);
+            }
+            // Discard the current limit (it's always Integer.MAX_VALUE) and set a new one for the frame size
+            codedInput.pushLimit(frameSize);
+            final var frame = messageFactory.create();
+            frame.mergeFrom(codedInput, ProtoMessage.DEFAULT_MAX_RECURSION_DEPTH);
+            // Reset the size counter to avoid integer overflows
+            codedInput.resetSizeCounter();
+            // Pop the limit to be able to read the next frame's size
+            codedInput.popLimit(Integer.MAX_VALUE);
+            frameConsumer.accept(frame);
         }
     }
 }

--- a/core/src/test/scala/eu/neverblink/jelly/core/LongIoStreamSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/LongIoStreamSpec.scala
@@ -2,18 +2,19 @@ package eu.neverblink.jelly.core
 
 import eu.neverblink.jelly.core.ProtoTestCases.Triples3LongStrings
 import eu.neverblink.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamFrame}
+import eu.neverblink.jelly.core.utils.IoUtils
 import eu.neverblink.protoc.java.runtime.ProtobufUtil
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.io.{ByteArrayOutputStream, OutputStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream, OutputStream}
 
 /**
- * Tests to ensure that writing to a CodedOutputStream works correctly even for very long streams,
- * where we put more than Int.MaxValue bytes into the stream.
+ * Tests to ensure that writing to a Coded(Input|Output)Stream works correctly even for very long
+ * streams, where we put more than Int.MaxValue bytes into the stream.
  *
- * This is important for Jena, RDF4J and other integrations that allocate only one CodedOutputStream
- * per file and write all frames to it.
+ * This is important for Jena, RDF4J and other integrations that allocate only one
+ * Coded(Input|Output)Stream per file and process all frames through it.
  */
 class LongIoStreamSpec extends AnyWordSpec, Matchers {
   "CodedOutputStream" should {
@@ -73,6 +74,46 @@ class LongIoStreamSpec extends AnyWordSpec, Matchers {
       val data = byteArrayOutputStream.toByteArray
       val parsedFrame = RdfStreamFrame.parseFrom(data)
       parsedFrame should be (frame)
+    }
+  }
+
+  "IoUtils.readStream" should {
+    "read a very long (> Int.MaxValue) stream of RdfStreamFrames from InputStream" in {
+      val frame = Triples3LongStrings.encodedFull(
+        JellyOptions.SMALL_STRICT.clone().setPhysicalType(PhysicalStreamType.TRIPLES),
+        1000,
+      ).head
+
+      val bytes = frame.toByteArrayDelimited
+      val target = Int.MaxValue.toLong * 3L / 2L
+      val repeatedInput = new InputStream {
+        var pos = 0L
+
+        override def read(): Int =
+          if (pos >= target && pos % bytes.length.toLong == 0) return -1 // end of stream
+          val result = bytes((pos % bytes.length.toLong).toInt)
+          pos += 1
+          result & 0xFF // return as unsigned byte
+
+        override def read(b: Array[Byte], off: Int, len: Int): Int =
+          if (pos >= target && pos % bytes.length.toLong == 0) return -1 // end of stream
+          val bytesToRead = Math.min(len, bytes.length - (pos % bytes.length.toLong).toInt)
+          System.arraycopy(bytes, (pos % bytes.length.toLong).toInt, b, off, bytesToRead)
+          pos += bytesToRead
+          bytesToRead
+      }
+
+      // Read the stream back
+      var readFrames = 0L
+      var lastFrame: RdfStreamFrame = null
+      IoUtils.readStream(repeatedInput, RdfStreamFrame.getFactory,
+        (frame: RdfStreamFrame) => {
+          readFrames += 1
+          lastFrame = frame
+        }
+      )
+      readFrames should be ((target / bytes.length.toLong) + 1)
+      lastFrame should be (frame)
     }
   }
 }

--- a/core/src/test/scala/eu/neverblink/jelly/core/utils/IoUtilsSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/utils/IoUtilsSpec.scala
@@ -2,7 +2,6 @@ package eu.neverblink.jelly.core.utils
 
 import eu.neverblink.jelly.core.helpers.RdfAdapter.*
 import eu.neverblink.jelly.core.proto.v1.*
-import eu.neverblink.protoc.java.runtime.ProtoMessage
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -143,12 +142,27 @@ class IoUtilsSpec extends AnyWordSpec, Matchers:
         var out: RdfStreamFrame = null
         IoUtils.readStream(
           in,
-          input => ProtoMessage.parseDelimitedFrom(input, RdfStreamFrame.getFactory),
+          RdfStreamFrame.getFactory,
           frame => out = frame
         )
 
         out should not be null
         out shouldBe frameLarge
+      }
+
+      "input stream is empty" in {
+        val in = new ByteArrayInputStream(Array.emptyByteArray)
+        var out: RdfStreamFrame = null
+        IoUtils.readStream(
+          in,
+          RdfStreamFrame.getFactory,
+          frame => {
+            frame should not be null
+            out = frame
+          }
+        )
+
+        out shouldBe null // No frames should be read from an empty stream
       }
     }
   }

--- a/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/RdfPatchReaderJelly.java
+++ b/jena-patch/src/main/java/eu/neverblink/jelly/convert/jena/patch/RdfPatchReaderJelly.java
@@ -53,7 +53,7 @@ public final class RdfPatchReaderJelly implements PatchProcessor {
                 decoder.ingestFrame(RdfPatchFrame.parseFrom(delimitingResponse.newInput()));
             } else {
                 // Delimited Jelly-Patch file, we can read multiple frames
-                readStream(delimitingResponse.newInput(), RdfPatchFrame::parseDelimitedFrom, decoder::ingestFrame);
+                readStream(delimitingResponse.newInput(), RdfPatchFrame.getFactory(), decoder::ingestFrame);
             }
         } catch (IOException e) {
             throw new IllegalStateException(e);

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyReader.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyReader.java
@@ -69,11 +69,7 @@ public final class JellyReader implements ReaderRIOT {
             if (delimitingResponse.isDelimited()) {
                 // Delimited Jelly file
                 // In this case, we can read multiple frames
-                readStream(
-                    delimitingResponse.newInput(),
-                    inputStream -> ProtoMessage.parseDelimitedFrom(inputStream, getReusableFrame),
-                    frame -> buffer.clear()
-                );
+                readStream(delimitingResponse.newInput(), getReusableFrame, frame -> buffer.clear());
             } else {
                 // Non-delimited Jelly file
                 // In this case, we can only read one frame

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
@@ -113,11 +113,7 @@ public final class JellyParser extends AbstractRDFParser {
             if (delimitingResponse.isDelimited()) {
                 // Delimited Jelly file
                 // In this case, we can read multiple frames
-                readStream(
-                    delimitingResponse.newInput(),
-                    inputStream -> ProtoMessage.parseDelimitedFrom(inputStream, getReusableFrame),
-                    frame -> buffer.clear()
-                );
+                readStream(delimitingResponse.newInput(), getReusableFrame, frame -> buffer.clear());
             } else {
                 // Non-delimited Jelly file
                 // In this case, we can only read one frame

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReaderImpl.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyReaderImpl.java
@@ -71,10 +71,6 @@ final class TitaniumJellyReaderImpl implements TitaniumJellyReader {
         }
 
         // May contain multiple frames
-        readStream(
-            delimitingResponse.newInput(),
-            is -> ProtoMessage.parseDelimitedFrom(is, getReusableFrame),
-            frame -> buffer.clear()
-        );
+        readStream(delimitingResponse.newInput(), getReusableFrame, frame -> buffer.clear());
     }
 }


### PR DESCRIPTION
Very similar optimization to #467

We allocate only one CodedInputStream for the entire delimited stream.

This allows us to make a more efficient use of the buffer (having multiple messages in the buffer are fine). We also remove the need to allocate a new buffer for each frame. Finally, we can also remove the LimitedInputStream wrapper, as the parser is free to consume the entire input stream.

I've marked the old `readStream` method as deprecated, because this implementation is both simpler and faster.

I did benchmark this (entire parsing process as a whole), and while it does seem to be a tiny bit faster, the difference is smaller than the error of the measurement, so... yeah. In any case, it definitely saves on allocations (this I could verify with a profiler), so that's a win.