### PR TITLE
Fix protobuf being incorrectly removed from rdf4j-plugin assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -378,10 +378,10 @@ lazy val jenaPlugin = (project in file("jena-plugin"))
     ),
     // Excludes protobuf-java from the jar, since it's already provided in jena-core.
     // I couldn't figure out a cleaner way since it's also a dependency of jelly-core.
-    ThisBuild / assemblyMergeStrategy := {
+    assemblyMergeStrategy := {
       case PathList("com", "google", "protobuf", _*) => MergeStrategy.discard
       case PathList("google", "protobuf", _*) => MergeStrategy.discard
-      case x => (ThisBuild / assemblyMergeStrategy).value(x) // defer to old strategy
+      case x => assemblyMergeStrategy.value(x) // defer to old strategy
     },
     // Do not publish this to Maven – we will separately do sbt assembly and publish to GitHub
     publishArtifact := false,


### PR DESCRIPTION
Fix for https://github.com/Jelly-RDF/jelly-jvm/pull/487