### PR TITLE
Handle non-delimited cases in fromIOStream

### DIFF
--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
@@ -228,15 +228,3 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
   private def isTestEntryBlocked(testEntry: Resource): Boolean =
     testEntry.hasGeneralizedStatementsRequirement // Generalized statements are disabled
       || testEntry.hasPhysicalTypeGraphsRequirement // Graph physical type is not supported yet
-      || isTestEntryBlockedById(
-        testEntry,
-      ) // Blocked by reason of test failing in specific instances
-
-  private def isTestEntryBlockedById(testEntry: Resource): Boolean =
-    // java.lang.IllegalStateException: Expected 6 RDF elements, but got 0 elements.
-    //    at eu.neverblink.jelly.integration_tests.util.OrderedRdfCompare$.compare(OrderedRdfCompare.scala:23)
-    //    at eu.neverblink.jelly.integration_tests.rdf.ProtocolSpec.f$proxy2$1(ProtocolSpec.scala:125)
-    testEntry.extractTestUri.contains("from_jelly/triples_rdf_1_1/pos_017")
-    // Protocol message tag had invalid wire type.
-    // com.google.protobuf.InvalidProtocolBufferException$InvalidWireTypeException: Protocol message tag had invalid wire type.
-      || testEntry.extractTestUri.contains("from_jelly/triples_rdf_1_1/pos_003")

--- a/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
+++ b/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
@@ -1,6 +1,7 @@
 package eu.neverblink.jelly.pekko.stream.impl
 
 import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame
+import eu.neverblink.jelly.core.utils.IoUtils
 import eu.neverblink.jelly.pekko.stream.PekkoUtil
 import org.apache.pekko.stream.scaladsl.*
 import org.apache.pekko.util.ByteString
@@ -145,12 +146,15 @@ object JellyIoOps:
       *   Pekko Source
       */
     final def fromIoStream(is: java.io.InputStream): Source[RdfStreamFrame, NotUsed] =
-      Source
-        .fromIterator(() =>
-          Iterator
-            .continually(RdfStreamFrame.parseDelimitedFrom(is))
-            .takeWhile(_.ne(null)),
-        )
+      val response = IoUtils.autodetectDelimiting(is)
+      if response.isDelimited then
+        Source
+          .fromIterator(() =>
+            Iterator
+              .continually(RdfStreamFrame.parseDelimitedFrom(response.newInput()))
+              .takeWhile(_.ne(null)),
+          )
+      else Source.fromIterator(() => Iterator.single(RdfStreamFrame.parseFrom(response.newInput())))
 
   trait FrameSink:
     /** Write a stream of Jelly frames to an output stream. The frames will be delimited.

--- a/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
+++ b/pekko-stream/src/main/scala/eu/neverblink/jelly/pekko/stream/impl/JellyIoOps.scala
@@ -136,7 +136,7 @@ object JellyIoOps:
         .named("protobufFraming")
 
   trait FrameSource:
-    /** Read a stream of Jelly frames from an input stream. The frames are assumed be delimited.
+    /** Read a stream of Jelly frames from an input stream.
       *
       * You can safely use this method to read from a file or socket.
       *


### PR DESCRIPTION
Issue #328

`pos_017` got fixed somewhere along the line, `pos_003` failed with reactive parsers as it's non-delimited, and the parsers assumed it was delimited. 
I change them to check, and output the single frame if non-delimited.