### PR TITLE
Fix neo4j plugin initialization

### DIFF
--- a/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/JellyInitializationHook.java
+++ b/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/JellyInitializationHook.java
@@ -1,0 +1,17 @@
+package eu.neverblink.jelly.convert.neo4j;
+
+import org.neo4j.configuration.SettingsDeclaration;
+
+/**
+ * A class that ensures the JellyPlugin is initialized when Neo4j is starting up.
+ * We pretend to be a SettingsDeclaration, which is loaded via ServiceLoader,
+ * to get our static initializer called.
+ * <p>
+ * This is a bit of a hack, but Neo4j does not provide a better way to hook into its startup process.
+ */
+public class JellyInitializationHook implements SettingsDeclaration {
+    static {
+        // Call the initializer of the plugin to ensure any setup is done
+        JellyPlugin.getInstance().initialize();
+    }
+}

--- a/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/JellyTripleCollector.java
+++ b/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/JellyTripleCollector.java
@@ -6,6 +6,10 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.UserAggregationFunction;
 
 public class JellyTripleCollector {
+    static {
+        // Call the initializer of the plugin to ensure any setup is done
+        JellyPlugin.getInstance().initialize();
+    }
 
     @UserAggregationFunction(name = "n10s.rdf.collect.jelly_base64")
     @Description(

--- a/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64ParserFactory.java
+++ b/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64ParserFactory.java
@@ -1,15 +1,10 @@
 package eu.neverblink.jelly.convert.neo4j.rio;
 
-import eu.neverblink.jelly.convert.neo4j.JellyPlugin;
 import eu.neverblink.jelly.convert.rdf4j.rio.JellyParserFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
 
 public final class JellyBase64ParserFactory implements RDFParserFactory {
-    static {
-        // Leech off of RDF4J's registration mechanism and register our plugin in Neo4j.
-        JellyPlugin.getInstance().initialize();
-    }
 
     private final JellyParserFactory innerFactory = new JellyParserFactory();
 

--- a/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64WriterFactory.java
+++ b/neo4j-plugin/src/main/java/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64WriterFactory.java
@@ -2,7 +2,6 @@ package eu.neverblink.jelly.convert.neo4j.rio;
 
 import static eu.neverblink.jelly.convert.neo4j.rio.JellyBase64Format.JELLY_BASE64;
 
-import eu.neverblink.jelly.convert.neo4j.JellyPlugin;
 import eu.neverblink.jelly.convert.rdf4j.rio.JellyWriterFactory;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -14,10 +13,6 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 
 public class JellyBase64WriterFactory implements RDFWriterFactory {
-    static {
-        // Leech off of RDF4J's registration mechanism and register our plugin in Neo4j.
-        JellyPlugin.getInstance().initialize();
-    }
 
     private final JellyWriterFactory innerFactory = new JellyWriterFactory();
 

--- a/neo4j-plugin/src/main/resources/META-INF/services/org.neo4j.configuration.SettingsDeclaration
+++ b/neo4j-plugin/src/main/resources/META-INF/services/org.neo4j.configuration.SettingsDeclaration
@@ -1,0 +1,1 @@
+eu.neverblink.jelly.convert.neo4j.JellyInitializationHook

--- a/neo4j-plugin/src/test/scala/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64Spec.scala
+++ b/neo4j-plugin/src/test/scala/eu/neverblink/jelly/convert/neo4j/rio/JellyBase64Spec.scala
@@ -64,7 +64,7 @@ class JellyBase64Spec extends AnyWordSpec, Matchers {
   }
 
   "JellyBase64Reader" should {
-    "factor have correct RDF format" in {
+    "factory have correct RDF format" in {
       JellyBase64ParserFactory().getRDFFormat shouldBe JellyBase64Format.JELLY_BASE64
     }
 


### PR DESCRIPTION
Previously it only worked after a call to `jelly.version()`. This is not great, so I added a small hack to get the plugin initialized earlier. Unfortunately I don't have a better idea because neither Neo4j nor Neosemantics provide APIs that could help with this.