### PR TITLE
Ensure RDF4J datatypes are reference-equal

### DIFF
--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
@@ -49,8 +49,13 @@ public final class Rdf4jDecoderConverter
 
     @Override
     public Rdf4jDatatype makeDatatype(String dt) {
-        final var coreDatatype = CoreDatatype.from(vf.createIRI(dt));
-        return new Rdf4jDatatype(coreDatatype.getIri(), coreDatatype);
+        var iri = vf.createIRI(dt);
+        final var coreDatatype = CoreDatatype.from(iri);
+        if (coreDatatype != CoreDatatype.NONE) {
+            // If it's a core datatype, use the core IRI to allow for reference equality checks.
+            iri = coreDatatype.getIri();
+        }
+        return new Rdf4jDatatype(iri, coreDatatype);
     }
 
     @Override

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
@@ -49,8 +49,8 @@ public final class Rdf4jDecoderConverter
 
     @Override
     public Rdf4jDatatype makeDatatype(String dt) {
-        final var iri = vf.createIRI(dt);
-        return new Rdf4jDatatype(iri, CoreDatatype.from(iri));
+        final var coreDatatype = CoreDatatype.from(vf.createIRI(dt));
+        return new Rdf4jDatatype(coreDatatype.getIri(), coreDatatype);
     }
 
     @Override

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverterSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverterSpec.scala
@@ -1,0 +1,21 @@
+package eu.neverblink.jelly.convert.rdf4j
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Rdf4jDecoderConverterSpec extends AnyWordSpec, Matchers {
+  "Rdf4jDecoderConverter" should {
+    "construct datatypes that have reference-equal IRIs" in {
+      val converter = Rdf4jDecoderConverter()
+      val dt1 = converter.makeDatatype("http://www.w3.org/2001/XMLSchema#string")
+
+      // This assertion is called in RDF4J when creating typed literals...
+      dt1.dt() should be theSameInstanceAs dt1.coreDatatype().getIri
+
+      // Subsequent calls with the same IRI should return the same datatype instance
+      val dt2 = converter.makeDatatype("http://www.w3.org/2001/XMLSchema#string")
+      dt2.dt() should be theSameInstanceAs dt1.dt()
+      dt2.coreDatatype().getIri should be theSameInstanceAs dt1.coreDatatype.getIri
+    }
+  }
+}

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverterSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverterSpec.scala
@@ -1,11 +1,12 @@
 package eu.neverblink.jelly.convert.rdf4j
 
+import org.eclipse.rdf4j.model.base.CoreDatatype
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class Rdf4jDecoderConverterSpec extends AnyWordSpec, Matchers {
   "Rdf4jDecoderConverter" should {
-    "construct datatypes that have reference-equal IRIs" in {
+    "construct core datatypes that have reference-equal IRIs" in {
       val converter = Rdf4jDecoderConverter()
       val dt1 = converter.makeDatatype("http://www.w3.org/2001/XMLSchema#string")
 
@@ -16,6 +17,14 @@ class Rdf4jDecoderConverterSpec extends AnyWordSpec, Matchers {
       val dt2 = converter.makeDatatype("http://www.w3.org/2001/XMLSchema#string")
       dt2.dt() should be theSameInstanceAs dt1.dt()
       dt2.coreDatatype().getIri should be theSameInstanceAs dt1.coreDatatype.getIri
+    }
+
+    "construct non-core datatypes" in {
+      val converter = Rdf4jDecoderConverter()
+      val dt1 = converter.makeDatatype("http://example.com/datatype")
+
+      dt1.dt().stringValue() shouldEqual "http://example.com/datatype"
+      dt1.coreDatatype() should be theSameInstanceAs CoreDatatype.NONE
     }
   }
 }


### PR DESCRIPTION
We had an issue where it was possible for RDF4J to throw assertion errors when constructing datatype literals. I don't think this is well-documented, but you are expected to have the core datatype's iri and the datatype iri strictly equal by reference. Oh well.