### PR TITLE
Update documentation link for Jelly-Neo4J

### DIFF
--- a/neo4j-plugin/README.md
+++ b/neo4j-plugin/README.md
@@ -1,4 +1,4 @@
 # Jelly plugin for Neo4j
 
 See the documentation for installation and usage instructions:
-https://w3id.org/jelly/jelly-jvm/getting-started-neo4j/
+https://w3id.org/jelly/jelly-jvm/dev/getting-started-neo4j/


### PR DESCRIPTION
The previous link was out of date and led to a 404