### PR TITLE
Add conformance reporting to Jelly-JVM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,23 @@ jobs:
           LATEST_SCALA_VERSION=`ls -1 jena-plugin/target | grep scala- | sort -V | tail -n1`
           echo "LATEST_SCALA_VERSION=$LATEST_SCALA_VERSION" >> $GITHUB_ENV
 
+      - name: 'Build conformance reports'
+        run: |
+          JELLY_DATE=$(date -I)
+          if [ $JELLY_VERSION = "refs/heads/main" ]; then
+            JELLY_VERSION="dev"
+          fi
+          # For Jena 5.5.0
+          sbt "integrationTests/testOnly *ProtocolConformanceSpec -- -z Jena -C eu.neverblink.jelly.integration_tests.util.ConformanceReporter"
+          # Jena 5.3.0 and the rest
+          sed -i "s/lazy val jenaV = .*/lazy val jenaV = \"5.3.0\"/g" build.sbt
+          sbt "integrationTests/testOnly *ProtocolConformanceSpec -- -C eu.neverblink.jelly.integration_tests.util.ConformanceReporter"
+          cd integration-tests/target
+          tar -czf conformance_reports.tar.gz reports/
+          cd ../..
+        env:
+          JELLY_VERSION: ${{ github.ref }}
+
       - name: 'Publish plugins (pre-release)'
         if: github.ref == 'refs/heads/main'
         uses: ncipollo/release-action@v1.18.0
@@ -65,7 +82,8 @@ jobs:
           artifacts: >-
             jena-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
             rdf4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
-            neo4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar
+            neo4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
+            integration-tests/target/conformance_reports.tar.gz
           generateReleaseNotes: true
 
       - name: 'Publish plugins (tagged release)'
@@ -80,7 +98,8 @@ jobs:
           artifacts: >-
             jena-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
             rdf4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
-            neo4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar
+            neo4j-plugin/target/${{ env.LATEST_SCALA_VERSION }}/*-plugin.jar,
+            integration-tests/target/conformance_reports.tar.gz
           generateReleaseNotes: true
 
   publish-docs:

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
@@ -250,10 +250,3 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
     && writingGraphsCompatible
     && testNotRejected
   }
-
-  extension (testEntries: Seq[Resource])
-    private def selectRelevantTestEntriesByFeatures[TN, TT, TQ](
-        serDes: ProtocolSerDes[TN, TT, TQ],
-    ): Seq[Resource] =
-      testEntries
-        .filter(entry => isTestEntryRelevantByFeatures(entry, serDes))

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
@@ -16,6 +16,14 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.io.{File, FileInputStream}
 import java.util.UUID.randomUUID
 
+/** Test the implementation with protocol test cases.
+  *
+  * To generate conformance reports, use the following command, which will limit the test scope to
+  * this file only and use a special reporter:
+  * `sbt "integrationTests/testOnly *ProtocolConformanceSpec -- -C eu.neverblink.jelly.integration_tests.util.ConformanceReporter"`
+  * This will generate reports for every integration in the `integration-tests/target/reports`
+  * directory.
+  */
 class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
   given ActorSystem = ActorSystem("test")
 

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/ProtocolConformanceSpec.scala
@@ -42,10 +42,13 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
         manifestModel.read(manifestFile.toURI.toString)
         val testEntries = manifestModel.extractTestEntries
           .filter(_.isTestRdfToJelly)
-          .selectRelevantTestEntriesByFeatures(ser)
 
         for testEntry <- testEntries do
           s"Protocol test ${testEntry.extractTestUri} – ${testEntry.extractTestName}" in {
+            assume(
+              isTestEntryRelevantByFeatures(testEntry, ser),
+              "Test entry not relevant to implementation",
+            )
             singleRdfToJellyTest(testEntry, ser)
           }
     }
@@ -123,10 +126,13 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
         manifestModel.read(manifestFile.toURI.toString)
         val testEntries = manifestModel.extractTestEntries
           .filter(_.isTestRdfFromJelly)
-          .selectRelevantTestEntriesByFeatures(des)
 
         for testEntry <- testEntries do
           s"Protocol test ${testEntry.extractTestUri} – ${testEntry.extractTestName}" in {
+            assume(
+              isTestEntryRelevantByFeatures(testEntry, des),
+              "Test entry not relevant to implementation",
+            )
             singleRdfFromJellyTest(testEntry, des)
           }
     }
@@ -192,40 +198,62 @@ class ProtocolConformanceSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaT
     frame.getRows.iterator.next.getOptions
   }
 
+  def isTestEntryRelevantByFeatures[TN, TT, TQ](
+      entry: Resource,
+      serDes: ProtocolSerDes[TN, TT, TQ],
+  ): Boolean = {
+    val rdfStarCompatible = !entry.hasRdfStarRequirement
+      || entry.hasRdfStarRequirement && entry.hasPhysicalTypeTriplesRequirement && serDes.supportsRdfStar(
+        PhysicalStreamType.TRIPLES,
+      )
+      || entry.hasRdfStarRequirement && entry.hasPhysicalTypeQuadsRequirement && serDes.supportsRdfStar(
+        PhysicalStreamType.QUADS,
+      )
+      || entry.hasRdfStarRequirement && entry.hasPhysicalTypeGraphsRequirement && serDes.supportsRdfStar(
+        PhysicalStreamType.GRAPHS,
+      )
+
+    val generalizedRdfCompatible =
+      !entry.hasGeneralizedStatementsRequirement
+        || entry.hasGeneralizedStatementsRequirement
+        && serDes.supportsGeneralizedStatements
+
+    val physicalTriplesCompatible =
+      !entry.hasPhysicalTypeTriplesRequirement
+        || entry.hasPhysicalTypeTriplesRequirement
+        && serDes.supportsTriples
+
+    val physicalQuadsCompatible =
+      !entry.hasPhysicalTypeQuadsRequirement
+        || entry.hasPhysicalTypeQuadsRequirement
+        && serDes.supportsQuads
+
+    val readingGraphsCompatible = {
+      val readingGraphsRequirement =
+        entry.hasPhysicalTypeGraphsRequirement && entry.isTestRdfFromJelly
+      !readingGraphsRequirement || readingGraphsRequirement && serDes.supportsReadingGraphs
+    }
+
+    val writingGraphsCompatible = {
+      val writingGraphsRequirement =
+        entry.hasPhysicalTypeGraphsRequirement && entry.isTestRdfToJelly
+      !writingGraphsRequirement || writingGraphsRequirement && serDes.supportsWritingGraphs
+    }
+
+    val testNotRejected = !entry.isTestRejected
+
+    rdfStarCompatible
+    && generalizedRdfCompatible
+    && physicalTriplesCompatible
+    && physicalQuadsCompatible
+    && readingGraphsCompatible
+    && writingGraphsCompatible
+    && testNotRejected
+  }
+
   extension (testEntries: Seq[Resource])
     private def selectRelevantTestEntriesByFeatures[TN, TT, TQ](
         serDes: ProtocolSerDes[TN, TT, TQ],
     ): Seq[Resource] =
       testEntries
-        .filter(entry =>
-          !entry.hasRdfStarRequirement
-            || entry.hasRdfStarRequirement && entry.hasPhysicalTypeTriplesRequirement && serDes.supportsRdfStar(
-              PhysicalStreamType.TRIPLES,
-            )
-            || entry.hasRdfStarRequirement && entry.hasPhysicalTypeQuadsRequirement && serDes.supportsRdfStar(
-              PhysicalStreamType.QUADS,
-            )
-            || entry.hasRdfStarRequirement && entry.hasPhysicalTypeGraphsRequirement && serDes.supportsRdfStar(
-              PhysicalStreamType.GRAPHS,
-            ),
-        )
-        .filter(entry =>
-          !entry.hasGeneralizedStatementsRequirement || entry.hasGeneralizedStatementsRequirement && serDes.supportsGeneralizedStatements,
-        )
-        .filter(entry =>
-          !entry.hasPhysicalTypeTriplesRequirement || entry.hasPhysicalTypeTriplesRequirement && serDes.supportsTriples,
-        )
-        .filter(entry =>
-          !entry.hasPhysicalTypeQuadsRequirement || entry.hasPhysicalTypeQuadsRequirement && serDes.supportsQuads,
-        )
-        .filter(entry => {
-          val readingGraphsRequirement =
-            entry.hasPhysicalTypeGraphsRequirement && entry.isTestRdfFromJelly
-          !readingGraphsRequirement || readingGraphsRequirement && serDes.supportsReadingGraphs
-        })
-        .filter(entry => {
-          val writingGraphsRequirement =
-            entry.hasPhysicalTypeGraphsRequirement && entry.isTestRdfToJelly
-          !writingGraphsRequirement || writingGraphsRequirement && serDes.supportsWritingGraphs
-        })
-        .filterNot(_.isTestRejected)
+        .filter(entry => isTestEntryRelevantByFeatures(entry, serDes))

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/ConformanceReporter.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/ConformanceReporter.scala
@@ -1,38 +1,36 @@
 package eu.neverblink.jelly.integration_tests.util
 
 import eu.neverblink.jelly.integration_tests.rdf.io.*
-import org.apache.jena.datatypes.xsd.XSDDatatype
-import org.apache.jena.rdf.model.{AnonId, Model, ModelFactory, Property}
-import org.apache.pekko.actor.ActorSystem
+import org.apache.jena.Jena
 import org.scalatest.Reporter
-import org.scalatest.events.{Event, SuiteCompleted, TestCanceled, TestFailed, TestSucceeded}
+import org.scalatest.events.*
 
 import java.nio.file.{Files, Paths}
 import java.time.{Instant, ZoneOffset}
-import scala.util.matching.Regex
 import scala.collection.mutable
+import scala.util.matching.Regex
 
 class ConformanceReporter extends Reporter {
-  lazy val jellyV = Option(System.getenv("JELLY_VERSION")).getOrElse("dev")
-  lazy val jellyDate = Option(System.getenv("JELLY_DATE")).getOrElse(
+  lazy val jellyV: String = Option(System.getenv("JELLY_VERSION")).getOrElse("dev")
+  lazy val jellyDate: String = Option(System.getenv("JELLY_DATE")).getOrElse(
     Instant.now().atZone(ZoneOffset.UTC).toLocalDate.toString,
   )
 
   lazy val results: Map[String, mutable.StringBuilder] = Map(
-    JenaSerDes.name -> initStringBuilder(JenaSerDes.name),
+    JenaStreamSerDes.name -> initStringBuilder(JenaStreamSerDes.name),
     Rdf4jSerDes.name -> initStringBuilder(Rdf4jSerDes.name),
     "Reactive (RDF4J)" -> initStringBuilder("Reactive (RDF4J)"),
     "Reactive writes (Apache Jena)" -> initStringBuilder("Reactive writes (Apache Jena)"),
     TitaniumSerDes.name -> initStringBuilder(TitaniumSerDes.name),
   )
 
-  def renameIntegrations(name: String) = name match {
+  def renameIntegrations(name: String): String = name match {
+    case "Jena (StreamRDF)" => s"Jena ${Jena.VERSION}"
     case "Reactive (RDF4J)" => "Pekko Streams (RDF4J)"
-    case "Reactive writes (Apache Jena)" => "Pekko Streams (Jena)"
+    case "Reactive writes (Apache Jena)" => s"Pekko Streams (Jena ${Jena.VERSION})"
     case s => s
   }
 
-  val model: Model = ModelFactory.createDefaultModel()
   val prefixes: String =
     """PREFIX earl: <http://www.w3.org/ns/earl#>
       |PREFIX doap: <http://usefulinc.com/ns/doap#>
@@ -41,14 +39,23 @@ class ConformanceReporter extends Reporter {
       |PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
       |""".stripMargin
 
+  def metadata: String =
+    s"""
+       |<> foaf:primaryTopic <#impl> ;
+       |   dc:issued "${Instant.now().atZone(ZoneOffset.UTC).toLocalDateTime}"^^xsd:dateTime ;
+       |   foaf:maker <#assertor> .
+       |""".stripMargin
+
   val assertor: String =
-    """<#assertor> a earl:Software, earl:Assertor ;
+    """
+      |<#assertor> a earl:Software, earl:Assertor ;
       |  doap:name "Jelly-JVM integration test suite" ;
       |  doap:homepage <https://github.com/Jelly-RDF/jelly-jvm/tree/main/integration-tests> .
       |""".stripMargin
 
   def formatTestSubject(name: String): String =
-    s"""<#impl> a doap:Project, earl:TestSubject, earl:Software ;
+    s"""
+       |<#impl> a doap:Project, earl:TestSubject, earl:Software ;
        |  doap:name "Jelly-JVM ($name)" ;
        |  doap:homepage <https://w3id.org/jelly/jelly-jvm/dev/> ;
        |  doap:description "Jelly-JVM integration with $name"@en ;
@@ -61,9 +68,26 @@ class ConformanceReporter extends Reporter {
        |  ] .
        |""".stripMargin
 
+  def formatResult(testName: String, ts: Long, outcome: String): String = {
+    val date = Instant.ofEpochMilli(ts).atZone(
+      ZoneOffset.UTC,
+    ).toLocalDateTime.toString
+    s"""
+       |<#${testName.replace('/', '_')}> a earl:Assertion ;
+       |  earl:assertedBy <#assertor> ;
+       |  earl:subject    <#impl> ;
+       |  earl:test       <https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/$testName> ;
+       |  earl:mode       earl:automatic ;
+       |  earl:result [
+       |    a earl:TestResult ;
+       |    dc:date "$date"^^xsd:dateTime ;
+       |    earl:outcome earl:$outcome
+       |  ] .
+       |""".stripMargin
+  }
+
   def initStringBuilder(name: String): mutable.StringBuilder = {
     val sb = mutable.StringBuilder()
-    sb.append(prefixes)
     sb.append(assertor)
     sb.append(formatTestSubject(renameIntegrations(name)))
     sb
@@ -73,22 +97,26 @@ class ConformanceReporter extends Reporter {
 
   override def apply(event: Event): Unit = {
     event match {
-      case s: TestSucceeded => {
+      case s: TestSucceeded =>
         val x = testPattern.findFirstMatchIn(s.testName).get
-        results(x.group(1)).append("yay")
-      }
-      case s: TestCanceled => {
+        if x.group(1) == "Jena" then println(x.group(1))
+        results(x.group(1)).append(formatResult(x.group(2), s.timeStamp, "passed"))
+      case s: TestCanceled =>
         val x = testPattern.findFirstMatchIn(s.testName).get
-        results(x.group(1)).append("nay")
-      }
-      case s: TestFailed => {
+        results(x.group(1)).append(formatResult(x.group(2), s.timeStamp, "inapplicable"))
+      case s: TestFailed =>
         val x = testPattern.findFirstMatchIn(s.testName).get
-        results(x.group(1)).append("naaay")
-      }
+        results(x.group(1)).append(formatResult(x.group(2), s.timeStamp, "failed"))
       case _: SuiteCompleted =>
         results.foreach((name, sb) => {
-          println(name)
-          println(sb.toString())
+          println(s"Writing report for $name")
+          Files.createDirectories(Paths.get("integration-tests/target/reports/"))
+          Files.writeString(
+            Paths.get(
+              s"integration-tests/target/reports/Jelly-JVM_${renameIntegrations(name)} conformance report.ttl",
+            ),
+            prefixes + metadata + sb.toString(),
+          )
         })
       case _ =>
     }

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/ConformanceReporter.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/util/ConformanceReporter.scala
@@ -1,0 +1,85 @@
+package eu.neverblink.jelly.integration_tests.util
+
+import org.apache.jena.datatypes.xsd.XSDDatatype
+import org.apache.jena.rdf.model.{AnonId, Model, ModelFactory, Property}
+import org.scalatest.Reporter
+import org.scalatest.events.{Event, SuiteCompleted, TestCanceled, TestFailed, TestSucceeded}
+
+import java.nio.file.{Files, Paths}
+import java.time.{Instant, ZoneOffset}
+import java.time.format.DateTimeFormatter
+import scala.util.matching.Regex
+
+class ConformanceReporter extends Reporter {
+  val model: Model = ModelFactory.createDefaultModel()
+  model.setNsPrefix("earl", "http://www.w3.org/ns/earl#")
+  model.setNsPrefix("doap", "http://usefulinc.com/ns/doap#")
+  model.setNsPrefix("foaf", "http://xmlns.com/foaf/0.1/")
+  model.setNsPrefix("dc", "http://purl.org/dc/terms/")
+  model.setNsPrefix("xsd", "http://www.w3.org/2001/XMLSchema#")
+  model.setNsPrefix("jgh", "https://github.com/Jelly-RDF/jelly-protobuf/tree/main/test/")
+
+  val a: Property = model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+
+  object earl:
+    val assertedBy: Property = model.createProperty(model.expandPrefix("earl:assertedBy"))
+    val subject: Property = model.createProperty(model.expandPrefix("earl:subject"))
+    val test: Property = model.createProperty(model.expandPrefix("earl:test"))
+    val mode: Property = model.createProperty(model.expandPrefix("earl:mode"))
+    val result: Property = model.createProperty(model.expandPrefix("earl:result"))
+    val outcome: Property = model.createProperty(model.expandPrefix("earl:outcome"))
+    val passed: Property = model.createProperty(model.expandPrefix("earl:passed"))
+    val inapplicable: Property = model.createProperty(model.expandPrefix("earl:inapplicable"))
+    val failed: Property = model.createProperty(model.expandPrefix("earl:failed"))
+    val automatic: Property = model.createProperty(model.expandPrefix("earl:automatic"))
+    val TestResult: Property = model.createProperty(model.expandPrefix("earl:TestResult"))
+    val Assertion: Property = model.createProperty(model.expandPrefix("earl:Assertion"))
+
+  val date: Property = model.createProperty(model.expandPrefix("dc:date"))
+
+  val assertor: Property = model.createProperty("#assertor")
+  val impl: Property = model.createProperty("#impl")
+
+  def addAssertion(
+      softNameString: String,
+      testNameString: String,
+      timeStamp: Long,
+      outcome: Property,
+  ): Unit = {
+    val name = model.createProperty(s"${softNameString.replace(' ', '_')}/$testNameString")
+    model.add(name, a, earl.Assertion)
+    model.add(name, earl.assertedBy, assertor)
+    model.add(name, earl.subject, impl)
+    model.add(name, earl.test, model.createProperty(model.expandPrefix(s"jgh:$testNameString")))
+    model.add(name, earl.mode, earl.automatic)
+    val bnode = model.createResource(AnonId())
+    val dt = Instant.ofEpochMilli(timeStamp).atZone(ZoneOffset.UTC).toLocalDateTime.toString
+    model.add(name, earl.result, bnode)
+    model.add(bnode, a, earl.TestResult)
+    model.add(bnode, date, model.createTypedLiteral(dt, XSDDatatype.XSDdateTime))
+    model.add(bnode, earl.outcome, outcome)
+  }
+
+  val buffer: StringBuilder = new StringBuilder()
+
+  val testPattern: Regex = "^.*?erializer (.*?) when Protocol test (.*?) ".r
+
+  override def apply(event: Event): Unit = {
+    event match {
+      case s: TestSucceeded => {
+        val x = testPattern.findFirstMatchIn(s.testName).get
+        addAssertion(x.group(1), x.group(2), s.timeStamp, earl.passed)
+      }
+      case s: TestCanceled => {
+        val x = testPattern.findFirstMatchIn(s.testName).get
+        addAssertion(x.group(1), x.group(2), s.timeStamp, earl.inapplicable)
+      }
+      case s: TestFailed => {
+        val x = testPattern.findFirstMatchIn(s.testName).get
+        addAssertion(x.group(1), x.group(2), s.timeStamp, earl.failed)
+      }
+      case _: SuiteCompleted => model.write(Files.newOutputStream(Paths.get("blep.ttl")), "ttl")
+      case _ =>
+    }
+  }
+}


### PR DESCRIPTION
I had to move a bunch of stuff around in ProtocolConformanceSpec, but other than that, I managed to just write a custom reporter. I'm not sure if the CI was really needed, but I already had most of it done, so hopefully it all just works.

I initially wanted to make the report via Jena, but gave up and just used string templates.