### PR TITLE
Jena protocol conformance fix

### DIFF
--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
@@ -30,7 +30,8 @@ class JenaReactiveSerDes(implicit mat: Materializer)
 
   override def supportsRdfStar: Boolean = !CompatibilityUtils.jenaVersion54OrHigher
 
-  override def supportsRdfStar(physicalStreamType: PhysicalStreamType): Boolean = false
+  override def supportsRdfStar(physicalStreamType: PhysicalStreamType): Boolean =
+    !CompatibilityUtils.jenaVersion54OrHigher
 
   override def readTriplesW3C(is: InputStream): Model = JenaSerDes.readTriplesW3C(is)
 

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaStreamSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaStreamSerDes.scala
@@ -31,7 +31,8 @@ object JenaStreamSerDes
 
   override def supportsRdfStar: Boolean = !CompatibilityUtils.jenaVersion54OrHigher
 
-  override def supportsRdfStar(physicalStreamType: PhysicalStreamType): Boolean = false
+  override def supportsRdfStar(physicalStreamType: PhysicalStreamType): Boolean =
+    !CompatibilityUtils.jenaVersion54OrHigher
 
   override def readTriplesW3C(is: InputStream): Seq[Triple] =
     val sink = SinkSeq[Triple]()


### PR DESCRIPTION
Turns out I changed only one RDF-star compat variable, and protocol conformance tests weren't running with Jena 5.3.0. With another small fix in jelly-protocol, now it should be all good.

I was kind of suspicious that there were roughly the same number of passing tests for Jena 5.3.0 and RDF4J...