### PR TITLE
RDF4J: implement a full checking parser

### DIFF
--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/BaseRdf4jDecoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/BaseRdf4jDecoderConverter.java
@@ -1,0 +1,63 @@
+package eu.neverblink.jelly.convert.rdf4j;
+
+import eu.neverblink.jelly.core.InternalApi;
+import eu.neverblink.jelly.core.ProtoDecoderConverter;
+import eu.neverblink.jelly.core.RdfProtoDeserializationError;
+import eu.neverblink.jelly.core.utils.QuadMaker;
+import eu.neverblink.jelly.core.utils.TripleMaker;
+import org.eclipse.rdf4j.model.*;
+
+/**
+ * Internal base class for RDF4J decoder converters. Do not extend or use directly.
+ */
+@InternalApi
+public abstract class BaseRdf4jDecoderConverter
+    implements ProtoDecoderConverter<Value, Rdf4jDatatype>, TripleMaker<Value, Statement>, QuadMaker<Value, Statement> {
+
+    protected final ValueFactory vf;
+
+    protected BaseRdf4jDecoderConverter(final ValueFactory vf) {
+        this.vf = vf;
+    }
+
+    public ValueFactory getValueFactory() {
+        return vf;
+    }
+
+    @Override
+    public Value makeTripleNode(Value s, Value p, Value o) {
+        try {
+            // RDF4J doesn't accept generalized statements (unlike Jena) which is why we need to do a type cast here.
+            return vf.createTriple((Resource) s, (IRI) p, o);
+        } catch (ClassCastException e) {
+            throw new RdfProtoDeserializationError(
+                "Cannot create generalized triple node with %s, %s, %s".formatted(s, p, o),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Statement makeQuad(Value subject, Value predicate, Value object, Value graph) {
+        try {
+            return vf.createStatement((Resource) subject, (IRI) predicate, object, (Resource) graph);
+        } catch (ClassCastException e) {
+            throw new RdfProtoDeserializationError(
+                "Cannot create generalized quad with %s, %s, %s, %s".formatted(subject, predicate, object, graph),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Statement makeTriple(Value subject, Value predicate, Value object) {
+        try {
+            return vf.createStatement((Resource) subject, (IRI) predicate, object);
+        } catch (ClassCastException e) {
+            throw new RdfProtoDeserializationError(
+                "Cannot create generalized triple with %s, %s, %s".formatted(subject, predicate, object),
+                e
+            );
+        }
+    }
+}

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jDecoderConverter.java
@@ -1,17 +1,10 @@
 package eu.neverblink.jelly.convert.rdf4j;
 
-import eu.neverblink.jelly.core.ProtoDecoderConverter;
-import eu.neverblink.jelly.core.RdfProtoDeserializationError;
-import eu.neverblink.jelly.core.utils.QuadMaker;
-import eu.neverblink.jelly.core.utils.TripleMaker;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
-public final class Rdf4jDecoderConverter
-    implements ProtoDecoderConverter<Value, Rdf4jDatatype>, TripleMaker<Value, Statement>, QuadMaker<Value, Statement> {
-
-    private final ValueFactory vf;
+public final class Rdf4jDecoderConverter extends BaseRdf4jDecoderConverter {
 
     /**
      * Creates a new Rdf4jDecoderConverter.
@@ -20,7 +13,7 @@ public final class Rdf4jDecoderConverter
      * used the one-parameter constructor that takes a {@link ValueFactory} instance.
      */
     public Rdf4jDecoderConverter() {
-        vf = SimpleValueFactory.getInstance();
+        super(SimpleValueFactory.getInstance());
     }
 
     /**
@@ -29,7 +22,7 @@ public final class Rdf4jDecoderConverter
      * @param vf the ValueFactory to use for creating RDF4J values
      */
     public Rdf4jDecoderConverter(ValueFactory vf) {
-        this.vf = vf;
+        super(vf);
     }
 
     @Override
@@ -69,44 +62,7 @@ public final class Rdf4jDecoderConverter
     }
 
     @Override
-    public Value makeTripleNode(Value s, Value p, Value o) {
-        try {
-            // RDF4J doesn't accept generalized statements (unlike Jena) which is why we need to do a type cast here.
-            return vf.createTriple((Resource) s, (IRI) p, o);
-        } catch (ClassCastException e) {
-            throw new RdfProtoDeserializationError(
-                "Cannot create generalized triple node with %s, %s, %s".formatted(s, p, o),
-                e
-            );
-        }
-    }
-
-    @Override
     public Value makeDefaultGraphNode() {
         return null;
-    }
-
-    @Override
-    public Statement makeQuad(Value subject, Value predicate, Value object, Value graph) {
-        try {
-            return vf.createStatement((Resource) subject, (IRI) predicate, object, (Resource) graph);
-        } catch (ClassCastException e) {
-            throw new RdfProtoDeserializationError(
-                "Cannot create generalized quad with %s, %s, %s, %s".formatted(subject, predicate, object, graph),
-                e
-            );
-        }
-    }
-
-    @Override
-    public Statement makeTriple(Value subject, Value predicate, Value object) {
-        try {
-            return vf.createStatement((Resource) subject, (IRI) predicate, object);
-        } catch (ClassCastException e) {
-            throw new RdfProtoDeserializationError(
-                "Cannot create generalized triple with %s, %s, %s".formatted(subject, predicate, object),
-                e
-            );
-        }
     }
 }

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserFactory.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserFactory.java
@@ -14,15 +14,28 @@ public final class JellyParserFactory implements RDFParserFactory {
         return JELLY;
     }
 
+    /**
+     * Creates a new JellyParser instance that uses RDF4J's full parsing stack, including literal,
+     * datatype, IRI, and language tag validation.
+     * <p>
+     * If you want to use a slightly faster non-checking parser, use the {@link #getParser(Rdf4jConverterFactory)}
+     * method and pass in {@link Rdf4jConverterFactory#getInstance()}.
+     *
+     * @return a new JellyParser instance
+     */
     @Override
     public RDFParser getParser() {
-        return getParser(Rdf4jConverterFactory.getInstance());
+        return new JellyParser();
     }
 
     /**
-     * Creates a new JellyParser instance with the specified converter factory.
-     * @param converterFactory
-     * The converter factory to use for creating RDF4J values.
+     * Creates a new JellyParser instance with the specified converter factory. This parser will NOT
+     * respect BasicParserSettings, as it does not use RDF4J's parsing stack. It will never validate
+     * IRIs, language tags, or datatypes.
+     * <p>
+     * If you want to use RDF4J's full parsing stack, use the parameterless {@link #getParser()} method.
+     *
+     * @param converterFactory The converter factory to use for creating RDF4J values.
      * @return a new JellyParser instance
      */
     public RDFParser getParser(Rdf4jConverterFactory converterFactory) {

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSettings.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSettings.java
@@ -21,6 +21,13 @@ public final class JellyParserSettings {
         return config;
     }
 
+    public static final AbstractRioSetting<Boolean> CHECKING = new BooleanRioSetting(
+        "eu.neverblink.jelly.convert.rdf4j.rio.checking",
+        "Use RDF4J's checking stack (validating IRIs, language tags, and datatypes). " +
+        "True by default, setting this to false will make the parser slightly faster.",
+        true
+    );
+
     public static final AbstractRioSetting<Integer> PROTO_VERSION = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.protoVersion",
         "Maximum supported Jelly protocol version",

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
@@ -4,13 +4,14 @@ import eu.neverblink.jelly.convert.rdf4j.Rdf4jConverterFactory
 import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.core.{JellyConstants, JellyOptions}
 import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.base.AbstractValueFactory
+import org.eclipse.rdf4j.model.base.{AbstractValueFactory, CoreDatatype}
 import org.eclipse.rdf4j.model.impl.SimpleLiteral
-import org.eclipse.rdf4j.rio.helpers.StatementCollector
+import org.eclipse.rdf4j.rio.RDFFormat
+import org.eclipse.rdf4j.rio.helpers.{AbstractRDFParser, BasicParserSettings, StatementCollector}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, InputStream, Reader}
 import scala.jdk.CollectionConverters.*
 
 class JellyParserSpec extends AnyWordSpec, Matchers:
@@ -32,7 +33,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     frame.addRows(
       RdfStreamRow.newInstance().setTriple(
         RdfTriple.newInstance()
-          .setSubject(RdfIri.newInstance())
+          .setSubject("b1234")
           .setPredicate(RdfIri.newInstance().setNameId(1))
           .setObject(RdfLiteral.newInstance().setLex("test")),
       ),
@@ -44,11 +45,14 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     override def createLiteral(label: String): Literal = new SimpleLiteral {
       override def getLabel: String = "TEST LITERAL IMPLEMENTATION"
     }
+
+    override def createLiteral(label: String, datatype: CoreDatatype): Literal =
+      createLiteral(label)
   }
 
-  "JellyParser" should {
+  "JellyParser (non-checking)" should {
     "use SimpleValueFactory by default" in {
-      val parser = JellyParserFactory().getParser()
+      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
       parser.parse(ByteArrayInputStream(inputData), "")
@@ -58,7 +62,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "allow overriding the value factory through .setValueFactory" in {
-      val parser = JellyParserFactory().getParser()
+      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
       parser.setValueFactory(customFactory)
@@ -77,5 +81,100 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
       collector.getStatements.size should be(1)
       val st = collector.getStatements.asScala.head
       st.getObject.asInstanceOf[Literal].getLabel shouldEqual "TEST LITERAL IMPLEMENTATION"
+    }
+
+    "not respect the SKOLEMIZE_ORIGIN setting" in {
+      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+      parser.parse(ByteArrayInputStream(inputData), "")
+      collector.getStatements.size should be(1)
+      val st = collector.getStatements.asScala.head
+      st.getSubject.isBNode shouldBe true
+      st.getSubject.stringValue() shouldEqual "b1234"
+    }
+
+    "switch to checking mode when CHECKING=true" in {
+      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      parser.set(JellyParserSettings.CHECKING, true)
+      parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+      parser.parse(ByteArrayInputStream(inputData), "")
+      collector.getStatements.size should be(1)
+      val st = collector.getStatements.asScala.head
+      st.getSubject.isIRI shouldBe true
+      val iri = st.getSubject.stringValue()
+      iri should startWith("https://test.org/.well-known/genid/")
+      iri should endWith("b1234")
+    }
+  }
+
+  "JellyParser (checking)" should {
+    // Check if the AbstractRDFParser machinery is being used
+    "respect the SKOLEMIZE_ORIGIN setting" in {
+      val parser = new JellyParser()
+      parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+      parser.parse(ByteArrayInputStream(inputData), "")
+      collector.getStatements.size should be(1)
+      val st = collector.getStatements.asScala.head
+      st.getSubject.isIRI shouldBe true
+      val iri = st.getSubject.stringValue()
+      iri should startWith("https://test.org/.well-known/genid/")
+      iri should endWith("b1234")
+    }
+
+    "allow overriding the value factory through .setValueFactory" in {
+      val parser = new JellyParser()
+      parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
+      parser.setValueFactory(customFactory)
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+      parser.parse(ByteArrayInputStream(inputData), "")
+      collector.getStatements.size should be(1)
+      val st = collector.getStatements.asScala.head
+      st.getObject.asInstanceOf[Literal].getLabel shouldEqual "TEST LITERAL IMPLEMENTATION"
+      // Skolemization still happens, because we only override the value factory, and not the decoder converter
+      st.getSubject.isBNode shouldBe false
+    }
+
+    "switch to non-checking mode when CHECKING=false" in {
+      val parser = new JellyParser()
+      parser.set(JellyParserSettings.CHECKING, false)
+      parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+      parser.parse(ByteArrayInputStream(inputData), "")
+      collector.getStatements.size should be(1)
+      val st = collector.getStatements.asScala.head
+      st.getSubject.isBNode shouldBe true
+      st.getSubject.stringValue() shouldEqual "b1234"
+    }
+
+    "report supported settings" in {
+      val parser = new JellyParser()
+      val keys = parser.getSupportedSettings.asScala.toSet
+
+      val expectedBase = new AbstractRDFParser() {
+        def getRDFFormat: RDFFormat = ???
+        def parse(in: InputStream, baseURI: String): Unit = ???
+        def parse(reader: Reader, baseURI: String): Unit = ???
+      }.getSupportedSettings.asScala.toSet
+
+      val expectedJelly = Set(
+        JellyParserSettings.CHECKING,
+        JellyParserSettings.PROTO_VERSION,
+        JellyParserSettings.ALLOW_RDF_STAR,
+        JellyParserSettings.MAX_NAME_TABLE_SIZE,
+        JellyParserSettings.MAX_PREFIX_TABLE_SIZE,
+        JellyParserSettings.ALLOW_GENERALIZED_STATEMENTS,
+        JellyParserSettings.MAX_DATATYPE_TABLE_SIZE,
+        JellyParserSettings.PROTO_VERSION,
+      )
+
+      keys should contain theSameElementsAs (expectedBase ++ expectedJelly)
     }
   }


### PR DESCRIPTION
While implementing https://github.com/eclipse-rdf4j/rdf4j/issues/5449 I noticed that the Jelly parser ignores various optional checks that you can add to every RDF4J parser, such as `SKOLEMIZE_ORIGIN` or `VERIFY_DATATYPE_VALUES`. This is because we use decoder converters, which can work outside an RDF4J parser, and therefore use a value factory directly, without any extra checks. To run these checks, you have to use the protected `create*` methods in `AbstractRDFParser` instead.

So, to solve this I wrote a second decoder converter that is internal to the RDF4J parser, where it uses these `create*` methods as RDF4J intended. This can be still turned off by passing a different decoder converter, or by setting the `CHECKING` option to false.

Note that this is a default behavior change, as `JellyParserFactory.getParser()` will now return a checking parser, instead of a non-checking one. But I don't think that violates any specific contract... the extra checks are disabled by default anyway.