### PR TITLE
RDF4J: rewrap exceptions in the parser

### DIFF
--- a/examples/src/main/java/eu/neverblink/jelly/examples/Rdf4jRio.java
+++ b/examples/src/main/java/eu/neverblink/jelly/examples/Rdf4jRio.java
@@ -12,10 +12,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
 /**
@@ -76,7 +73,7 @@ public class Rdf4jRio implements Example {
         try {
             // This operation should fail because the Jelly file uses a prefix table larger than 10
             Collection<Statement> customTriples = readRdf4j(jellyFile, JellyFormat.JELLY, Optional.of(customOptions));
-        } catch (RdfProtoDeserializationError e) {
+        } catch (RDFParseException e) {
             // The stream uses a prefix table size of 16, which is larger than the maximum supported size of 10.
             // To read this stream, set maxPrefixTableSize to at least 16 in the supportedOptions for this decoder.
             System.out.printf("Failed to read the Jelly file with custom options: %s%n", e.getMessage());

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
@@ -2,7 +2,7 @@ package eu.neverblink.jelly.integration_tests.rdf.io
 
 import eu.neverblink.jelly.convert.jena.traits.JenaTest
 import eu.neverblink.jelly.core.helpers.RdfAdapter.*
-import eu.neverblink.jelly.core.{JellyOptions, RdfProtoDeserializationError}
+import eu.neverblink.jelly.core.JellyOptions
 import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.integration_tests.util.Measure
 import org.apache.pekko.actor.ActorSystem

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/GeneralizedRdfSpec.scala
@@ -131,7 +131,6 @@ class GeneralizedRdfSpec extends AnyWordSpec, Matchers, JenaTest:
   def parsingFailureTests(impl: NativeSerDes[?, ?], boxed: Boolean = false): Unit =
     def checkException(e: Throwable): Unit =
       val e1 = if boxed then e.getCause else e
-      e1 shouldBe a[RdfProtoDeserializationError]
       e1.getMessage should include("generalized")
       e1.getCause shouldBe a[ClassCastException]
 

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
@@ -178,7 +178,7 @@ public final class JellyParser extends AbstractRDFParser {
                 throw (RDFParseException) e.getCause();
             } else {
                 // Otherwise, move the message and cause into a new RDFParseException
-                throw new RDFParseException(e.getMessage(), e);
+                throw new RDFParseException(e.getMessage(), e.getCause());
             }
         } finally {
             rdfHandler.endRDF();


### PR DESCRIPTION
Another quirk found when implementing https://github.com/eclipse-rdf4j/rdf4j/issues/5449

RDF4J expects parsers to use `RDFParseException` for reporting parsing errors, but we were using Jelly-specific exception classes. RDF4J's tests were not happy about that.

I added a simple exception rewrapping thing to fix this.