### PR TITLE
Fix several minor RDF4J Rio incompatibilities

### DIFF
--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/Rdf4jSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/Rdf4jSerDes.scala
@@ -96,6 +96,7 @@ object Rdf4jSerDes
           .setFrameSize(frameSize)
           .setJellyOptions(opt.get)
       else JellyWriterSettings.empty.setFrameSize(frameSize)
+    conf.setEnableNamespaceDeclarations(false)
     val writer = Rio.createWriter(JellyFormat.JELLY, os)
     writer.setWriterConfig(conf)
     writer.startRDF()

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParser.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
 
 public final class JellyParser extends AbstractRDFParser {
@@ -123,6 +124,11 @@ public final class JellyParser extends AbstractRDFParser {
         if (in == null) {
             throw new IllegalArgumentException("Input stream must not be null");
         }
+        clear();
+        if (rdfHandler == null) {
+            // No-op handler to avoid null checks later
+            rdfHandler = new AbstractRDFHandler() {};
+        }
 
         final var config = getParserConfig();
         final var options = RdfStreamOptions.newInstance()
@@ -182,6 +188,7 @@ public final class JellyParser extends AbstractRDFParser {
             }
         } finally {
             rdfHandler.endRDF();
+            clear();
         }
     }
 

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriter.java
@@ -16,6 +16,7 @@ import eu.neverblink.protoc.java.runtime.ProtobufUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
+import java.util.HashSet;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -66,7 +67,7 @@ public final class JellyWriter extends AbstractRDFWriter {
 
     @Override
     public Collection<RioSetting<?>> getSupportedSettings() {
-        final var settings = super.getSupportedSettings();
+        final var settings = new HashSet<>(super.getSupportedSettings());
         settings.add(JellyWriterSettings.STREAM_NAME);
         settings.add(JellyWriterSettings.PHYSICAL_TYPE);
         settings.add(JellyWriterSettings.ALLOW_RDF_STAR);

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
@@ -53,10 +53,11 @@ public final class JellyWriterSettings extends WriterConfig {
     public static final BooleanRioSetting ENABLE_NAMESPACE_DECLARATIONS = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.enableNamespaceDeclarations",
         "Enable namespace declarations in the output (equivalent to PREFIX directives in Turtle syntax). " +
-        "This option is disabled by default and is not recommended when your only concern is performance. " +
+        "Enabled by default since Jelly-JVM 3.6.0, to ensure consistent behavior with RDF4J's writers. " +
+        "When your only concern is performance, it's recommended to disable this option. " +
         "It is only useful when you want to preserve the namespace declarations in the output. " +
         "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
-        false
+        true
     );
 
     public static final BooleanRioSetting DELIMITED_OUTPUT = new BooleanRioSetting(

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
@@ -6,7 +6,7 @@ import eu.neverblink.jelly.core.{JellyConstants, JellyOptions}
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.base.{AbstractValueFactory, CoreDatatype}
 import org.eclipse.rdf4j.model.impl.SimpleLiteral
-import org.eclipse.rdf4j.rio.{RDFFormat, RDFParseException}
+import org.eclipse.rdf4j.rio.RDFFormat
 import org.eclipse.rdf4j.rio.helpers.{AbstractRDFParser, BasicParserSettings, StatementCollector}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -192,36 +192,8 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
       keys should contain theSameElementsAs (expectedBase ++ expectedJelly)
     }
 
-    "unwrap RdfProtoDeserializationError containing RDFParseException" in {
+    "work with an unset RDFHandler" in {
       val parser = new JellyParser()
-      parser.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true)
-      val collector = new StatementCollector()
-      parser.setRDFHandler(collector)
-
-      // The inner exception should be unwrapped and rethrown
-      val e = intercept[RDFParseException] {
-        parser.parse(ByteArrayInputStream(invalidLanguage), "")
-      }
-      e.getMessage should include("was not recognised as a language literal")
-    }
-
-    "rewrap generic RdfProtoDeserializationError" in {
-      val parser = new JellyParser()
-      val collector = new StatementCollector()
-      parser.setRDFHandler(collector)
-
-      // Create a frame with an unsupported proto version
-      val frame = RdfStreamFrame.newInstance()
-      frame.addRows(
-        RdfStreamRow.newInstance().setOptions(
-          JellyOptions.SMALL_STRICT.clone().setVersion(999999),
-        ),
-      )
-
-      // The exception should be rethrown as RDFParseException
-      val e = intercept[RDFParseException] {
-        parser.parse(ByteArrayInputStream(frame.toByteArray), "")
-      }
-      e.getMessage should include("Unsupported proto version")
+      parser.parse(ByteArrayInputStream(validData), "")
     }
   }

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
@@ -6,7 +6,7 @@ import eu.neverblink.jelly.core.{JellyConstants, JellyOptions}
 import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.base.{AbstractValueFactory, CoreDatatype}
 import org.eclipse.rdf4j.model.impl.SimpleLiteral
-import org.eclipse.rdf4j.rio.RDFFormat
+import org.eclipse.rdf4j.rio.{RDFFormat, RDFParseException}
 import org.eclipse.rdf4j.rio.helpers.{AbstractRDFParser, BasicParserSettings, StatementCollector}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -190,6 +190,39 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
       )
 
       keys should contain theSameElementsAs (expectedBase ++ expectedJelly)
+    }
+
+    "unwrap RdfProtoDeserializationError containing RDFParseException" in {
+      val parser = new JellyParser()
+      parser.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true)
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+
+      // The inner exception should be unwrapped and rethrown
+      val e = intercept[RDFParseException] {
+        parser.parse(ByteArrayInputStream(invalidLanguage), "")
+      }
+      e.getMessage should include("was not recognised as a language literal")
+    }
+
+    "rewrap generic RdfProtoDeserializationError" in {
+      val parser = new JellyParser()
+      val collector = new StatementCollector()
+      parser.setRDFHandler(collector)
+
+      // Create a frame with an unsupported proto version
+      val frame = RdfStreamFrame.newInstance()
+      frame.addRows(
+        RdfStreamRow.newInstance().setOptions(
+          JellyOptions.SMALL_STRICT.clone().setVersion(999999),
+        ),
+      )
+
+      // The exception should be rethrown as RDFParseException
+      val e = intercept[RDFParseException] {
+        parser.parse(ByteArrayInputStream(frame.toByteArray), "")
+      }
+      e.getMessage should include("Unsupported proto version")
     }
 
     "work with an unset RDFHandler" in {

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSpec.scala
@@ -1,14 +1,17 @@
 package eu.neverblink.jelly.convert.rdf4j.rio
 
 import eu.neverblink.jelly.core.utils.IoUtils
-import eu.neverblink.jelly.core.proto.v1.{RdfStreamFrame, LogicalStreamType}
+import eu.neverblink.jelly.core.proto.v1.{LogicalStreamType, RdfStreamFrame}
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import scala.annotation.nowarn
+import scala.jdk.CollectionConverters.*
 import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.rio.RDFFormat
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter
 
 @nowarn("msg=deprecated")
 class JellyWriterSpec extends AnyWordSpec, Matchers:
@@ -95,5 +98,30 @@ class JellyWriterSpec extends AnyWordSpec, Matchers:
       val f = RdfStreamFrame.parseDelimitedFrom(response.newInput())
       f should not be null
       f.getRows.iterator.next.getOptions.getLogicalType should be(LogicalStreamType.GRAPHS)
+    }
+
+    "return list of supported settings" in {
+      val writer = JellyWriterFactory().getWriter(new ByteArrayOutputStream())
+      val settings = writer.getSupportedSettings().asScala.toSet
+
+      val expectedBase = new AbstractRDFWriter {
+        def getRDFFormat: RDFFormat = ???
+        def endRDF(): Unit = ???
+        def handleComment(comment: String): Unit = ???
+      }.getSupportedSettings.asScala.toSet
+
+      val expectedJelly = Set(
+        JellyWriterSettings.STREAM_NAME,
+        JellyWriterSettings.PHYSICAL_TYPE,
+        JellyWriterSettings.ALLOW_RDF_STAR,
+        JellyWriterSettings.MAX_NAME_TABLE_SIZE,
+        JellyWriterSettings.MAX_PREFIX_TABLE_SIZE,
+        JellyWriterSettings.MAX_DATATYPE_TABLE_SIZE,
+        JellyWriterSettings.FRAME_SIZE,
+        JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS,
+        JellyWriterSettings.DELIMITED_OUTPUT,
+      )
+
+      settings should contain theSameElementsAs (expectedBase ++ expectedJelly)
     }
   }

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/Rdf4jNamespaceDeclarationSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/Rdf4jNamespaceDeclarationSpec.scala
@@ -50,8 +50,9 @@ class Rdf4jNamespaceDeclarationSpec extends AnyWordSpec, Matchers:
     "preserve namespace declarations (prefixes before triples)" in {
       val out = new ByteArrayOutputStream()
       val writer = JellyWriterFactory().getWriter(out)
-      writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, true)
-//      writer.set(JellyWriterSettings.PHYSICAL_TYPE, PhysicalStreamType.TRIPLES)
+      // Default is true
+      // writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, true)
+      // writer.set(JellyWriterSettings.PHYSICAL_TYPE, PhysicalStreamType.TRIPLES)
 
       writer.startRDF()
       writer.handleNamespace("ex", "http://example.com/")
@@ -65,7 +66,8 @@ class Rdf4jNamespaceDeclarationSpec extends AnyWordSpec, Matchers:
     "preserve namespace declarations (triples before prefixes)" in {
       val out = new ByteArrayOutputStream()
       val writer = JellyWriterFactory().getWriter(out)
-      writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, true)
+      // Default is true
+      // writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, true)
 
       writer.startRDF()
       writer.handleStatement(triple)
@@ -79,8 +81,8 @@ class Rdf4jNamespaceDeclarationSpec extends AnyWordSpec, Matchers:
     "not preserve namespace declarations if disabled" in {
       val out = new ByteArrayOutputStream()
       val writer = JellyWriterFactory().getWriter(out)
-      // Default is false
-      // writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, false)
+      // Default is true
+      writer.set(JellyWriterSettings.ENABLE_NAMESPACE_DECLARATIONS, false)
 
       writer.startRDF()
       writer.handleNamespace("ex", "http://example.com/")


### PR DESCRIPTION
Even more fixes to make https://github.com/eclipse-rdf4j/rdf4j/issues/5449 possible:

- Enable namespace declarations by default, as all RDF4J writers do that.
- In case the RDF handler in the parser is unset, don't crash, just send the data to space.
- Invoke `clear()` after and before parsing to make sure the base machinery can reset e.g., blank node hashes.