### PR TITLE
RDF4J: disable checking by default, allow enabling via factory setting

### DIFF
--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserFactory.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserFactory.java
@@ -9,23 +9,32 @@ import org.eclipse.rdf4j.rio.RDFParserFactory;
 
 public final class JellyParserFactory implements RDFParserFactory {
 
+    private boolean checking = false;
+
     @Override
     public RDFFormat getRDFFormat() {
         return JELLY;
     }
 
     /**
-     * Creates a new JellyParser instance that uses RDF4J's full parsing stack, including literal,
-     * datatype, IRI, and language tag validation.
+     * Creates a new JellyParser instance that will either use RDF4J's full parsing stack or not,
+     * depending on the value of {@link #isChecking()}. The default is false, so the parser will NOT
+     * respect BasicParserSettings, as it does not use RDF4J's parsing stack. It will never validate
+     * IRIs, language tags, or datatypes.
      * <p>
-     * If you want to use a slightly faster non-checking parser, use the {@link #getParser(Rdf4jConverterFactory)}
-     * method and pass in {@link Rdf4jConverterFactory#getInstance()}.
+     * If {@link #isChecking()} is true, the parser does use RDF4J's full parsing stack,
+     * including literal, datatype, IRI, and language tag validation.
+     * <p>
+     * This can be later overridden on the parser instance itself by changing the {@link JellyParserSettings#CHECKING}
+     * setting.
      *
      * @return a new JellyParser instance
      */
     @Override
     public RDFParser getParser() {
-        return new JellyParser();
+        final var parser = new JellyParser();
+        parser.set(JellyParserSettings.CHECKING, checking);
+        return parser;
     }
 
     /**
@@ -40,5 +49,25 @@ public final class JellyParserFactory implements RDFParserFactory {
      */
     public RDFParser getParser(Rdf4jConverterFactory converterFactory) {
         return new JellyParser(converterFactory);
+    }
+
+    /**
+     * Set whether the parser created by {@link #getParser()} will use RDF4J's full parsing stack,
+     * including literal, datatype, IRI, and language tag validation.
+     * @param checking true to use RDF4J's checking stack, false to use a faster non-checking parser.
+     * @return this
+     */
+    public JellyParserFactory setChecking(boolean checking) {
+        this.checking = checking;
+        return this;
+    }
+
+    /**
+     * Whether the parser created by {@link #getParser()} will use RDF4J's full parsing stack,
+     * including literal, datatype, IRI, and language tag validation.
+     * @return true if the parser will use RDF4J's checking stack, false to use a faster non-checking parser.
+     */
+    public boolean isChecking() {
+        return checking;
     }
 }

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSettings.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSettings.java
@@ -24,9 +24,9 @@ public final class JellyParserSettings {
     public static final AbstractRioSetting<Boolean> CHECKING = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.checking",
         "Use RDF4J's checking stack (validating IRIs, language tags, and datatypes). " +
-        "True by default for correctness and consistency with other RDF4J parsers. " +
-        "If you can, set this to false to make the parser much faster.",
-        true
+        "False by default, for maximum performance. Enable this only if you really need to " +
+        "validate the file, as it slows down the parser by ~2–4x.",
+        false
     );
 
     public static final AbstractRioSetting<Integer> PROTO_VERSION = new JellyIntegerRioSetting(

--- a/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
+++ b/rdf4j/src/test/scala/eu/neverblink/jelly/convert/rdf4j/rio/JellyParserSpec.scala
@@ -66,7 +66,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
 
   "JellyParser (non-checking)" should {
     "use SimpleValueFactory by default" in {
-      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      val parser = JellyParserFactory().getParser()
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
       parser.parse(ByteArrayInputStream(validData), "")
@@ -76,7 +76,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "allow overriding the value factory through .setValueFactory" in {
-      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      val parser = JellyParserFactory().getParser()
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
       parser.setValueFactory(customFactory)
@@ -98,7 +98,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "not respect the SKOLEMIZE_ORIGIN setting" in {
-      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      val parser = JellyParserFactory().getParser()
       parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
@@ -110,7 +110,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "switch to checking mode when CHECKING=true" in {
-      val parser = JellyParserFactory().getParser(Rdf4jConverterFactory.getInstance())
+      val parser = JellyParserFactory().getParser()
       parser.set(JellyParserSettings.CHECKING, true)
       parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
       val collector = new StatementCollector()
@@ -128,7 +128,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
   "JellyParser (checking)" should {
     // Check if the AbstractRDFParser machinery is being used
     "respect the SKOLEMIZE_ORIGIN setting" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
@@ -142,7 +142,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "allow overriding the value factory through .setValueFactory" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
       parser.setValueFactory(customFactory)
       val collector = new StatementCollector()
@@ -156,7 +156,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "switch to non-checking mode when CHECKING=false" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       parser.set(JellyParserSettings.CHECKING, false)
       parser.set(BasicParserSettings.SKOLEMIZE_ORIGIN, "https://test.org/")
       val collector = new StatementCollector()
@@ -169,7 +169,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "report supported settings" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       val keys = parser.getSupportedSettings.asScala.toSet
 
       val expectedBase = new AbstractRDFParser() {
@@ -193,7 +193,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "unwrap RdfProtoDeserializationError containing RDFParseException" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       parser.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true)
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
@@ -206,7 +206,7 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "rewrap generic RdfProtoDeserializationError" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       val collector = new StatementCollector()
       parser.setRDFHandler(collector)
 
@@ -226,7 +226,24 @@ class JellyParserSpec extends AnyWordSpec, Matchers:
     }
 
     "work with an unset RDFHandler" in {
-      val parser = new JellyParser()
+      val parser = JellyParserFactory().setChecking(true).getParser()
       parser.parse(ByteArrayInputStream(validData), "")
+    }
+  }
+
+  "JellyParserFactory" should {
+    "update the checking parameter" in {
+      val f = JellyParserFactory()
+      f.isChecking shouldBe false
+      f.setChecking(true) should be theSameInstanceAs f
+      f.isChecking shouldBe true
+      f.setChecking(false) should be theSameInstanceAs f
+      f.isChecking shouldBe false
+      f.setChecking(true) should be theSameInstanceAs f
+      f.isChecking shouldBe true
+    }
+
+    "return the JellyFormat" in {
+      JellyParserFactory().getRDFFormat shouldBe JellyFormat.JELLY
     }
   }


### PR DESCRIPTION
Unfortunately, the term validation stack in RDF4J is very heavy, and with it the Jelly parser become 2–4x slower. I think it makes more sense to disable all the checks by default.

To make it possible to enable these checks in RDF4J parser consistency tests, I also added a setting on the parser factory itself, to control whether parser instances produced by it will be checking or not.