### PR TITLE
Jena/RDF4J: increase default size of serializer lookups

### DIFF
--- a/docs/docs/user/jena-cli.md
+++ b/docs/docs/user/jena-cli.md
@@ -14,9 +14,9 @@ You can use Jelly as an output format for Jena's CLI utilities by specifying the
     ./riot --stream=jelly data.ttl > data.jelly
     ```
 
-By default Jena will use the "small, all features" Jelly preset (name table: 128 entries, prefix table: 16, datatype table: 16, RDF-star enabled, generalized RDF enabled). There are a few reasons why you might want to change these serialization options:
+By default Jena will use the "big, all features" Jelly preset (name table: 4000 entries, prefix table: 128, datatype table: 32, RDF-star enabled, generalized RDF enabled). There are a few reasons why you might want to change these serialization options:
 
-- **Performance** – for larger files, the small preset does not offer the best performance or compression ratio. It's better to use larger lookup tables.
+- **Performance** – you may want to tweak the settings to better fit your data.
 - **Compatibility** – if your data does not include RDF-star or generalized RDF, you can mark these features as disabled. Later, parsers will know accurately what to expect in your data.
 
 The following presets are available:
@@ -25,12 +25,12 @@ The following presets are available:
     - `SMALL_STRICT` – RDF-star and generalized RDF disabled
     - `SMALL_GENERALIZED` – RDF-star disabled, generalized RDF enabled
     - `SMALL_RDF_STAR` – RDF-star enabled, generalized RDF disabled
-    - `SMALL_ALL_FEATURES` – RDF-star and generalized RDF enabled **(default)**
+    - `SMALL_ALL_FEATURES` – RDF-star and generalized RDF enabled
 - Big: 4000 name table entries, 150 prefix table entries, 32 datatype table entries **(recommended for larger files)**
     - `BIG_STRICT`
     - `BIG_GENERALIZED`
     - `BIG_RDF_STAR`
-    - `BIG_ALL_FEATURES`
+    - `BIG_ALL_FEATURES` **(default)**
 
 To use one of these presets, use the `--set` CLI option with the `https://neverblink.eu/jelly/riot/symbols#preset` symbol:
 

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/IoSerDesSpec.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/IoSerDesSpec.scala
@@ -77,7 +77,7 @@ class IoSerDesSpec extends AnyWordSpec, Matchers, ScalaFutures, JenaTest:
       expectedType: String,
       expectedOpt: Option[RdfStreamOptions],
   ) =
-    val expOpt = expectedOpt.getOrElse(JellyOptions.SMALL_ALL_FEATURES)
+    val expOpt = expectedOpt.getOrElse(JellyOptions.BIG_ALL_FEATURES)
     val frame = RdfStreamFrame.parseDelimitedFrom(new ByteArrayInputStream(bytes))
     frame.getRows.asScala.size should be > 0
     frame.getRows.asScala.head.hasOptions should be(true)

--- a/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
+++ b/integration-tests/src/test/scala/eu/neverblink/jelly/integration_tests/rdf/io/JenaReactiveSerDes.scala
@@ -94,7 +94,7 @@ class JenaReactiveSerDes(implicit mat: Materializer)
       .via(
         EncoderFlow.builder
           .withLimiter(ByteSizeLimiter(32_000))
-          .flatQuads(opt.getOrElse(JellyOptions.SMALL_ALL_FEATURES))
+          .flatQuads(opt.getOrElse(JellyOptions.BIG_ALL_FEATURES))
           .flow,
       )
       .runWith(JellyIo.toIoStream(os))
@@ -110,7 +110,7 @@ class JenaReactiveSerDes(implicit mat: Materializer)
       .via(
         EncoderFlow.builder
           .withLimiter(ByteSizeLimiter(32_000))
-          .flatTriples(opt.getOrElse(JellyOptions.SMALL_ALL_FEATURES))
+          .flatTriples(opt.getOrElse(JellyOptions.BIG_ALL_FEATURES))
           .flow,
       )
       .runWith(JellyIo.toIoStream(os))
@@ -127,7 +127,7 @@ class JenaReactiveSerDes(implicit mat: Materializer)
       .via(
         EncoderFlow.builder
           .withLimiter(ByteSizeLimiter(32_000))
-          .flatTriples(opt.getOrElse(JellyOptions.SMALL_ALL_FEATURES))
+          .flatTriples(opt.getOrElse(JellyOptions.BIG_ALL_FEATURES))
           .flow,
       )
       .runWith(JellyIo.toIoStream(fileOs))
@@ -145,7 +145,7 @@ class JenaReactiveSerDes(implicit mat: Materializer)
       .via(
         EncoderFlow.builder
           .withLimiter(ByteSizeLimiter(32_000))
-          .flatQuads(opt.getOrElse(JellyOptions.SMALL_ALL_FEATURES))
+          .flatQuads(opt.getOrElse(JellyOptions.BIG_ALL_FEATURES))
           .flow,
       )
       .runWith(JellyIo.toIoStream(fileOs))

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyFormatVariant.java
@@ -14,7 +14,7 @@ import org.apache.jena.sparql.util.Context;
  */
 public final class JellyFormatVariant extends RDFFormatVariant {
 
-    public static final RdfStreamOptions DEFAULT_OPTIONS = JellyOptions.SMALL_ALL_FEATURES;
+    public static final RdfStreamOptions DEFAULT_OPTIONS = JellyOptions.BIG_ALL_FEATURES;
     public static final int DEFAULT_FRAME_SIZE = 256;
     public static final boolean DEFAULT_ENABLE_NAMESPACE_DECLARATIONS = false;
     public static final boolean DEFAULT_DELIMITED = true;

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyLanguage.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyLanguage.java
@@ -32,7 +32,7 @@ public final class JellyLanguage {
     /**
      * The Jelly language constant for use in Apache Jena RIOT.
      * <p>
-     * This uses by default JellyFormat.JELLY_SMALL_ALL_FEATURES for serialization, assuming pessimistically
+     * This uses by default JellyFormat.JELLY_BIG_ALL_FEATURES for serialization, assuming pessimistically
      * that the user may want to use all features of the protocol.
      * <p>
      * If you are not intending to use generalized RDF or RDF-star, you may want to use

--- a/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyLanguage.java
+++ b/jena/src/main/java/eu/neverblink/jelly/convert/jena/riot/JellyLanguage.java
@@ -146,10 +146,10 @@ public final class JellyLanguage {
         RDFLanguages.register(JELLY);
 
         // Default serialization format
-        RDFWriterRegistry.register(JELLY, JellyFormat.JELLY_SMALL_ALL_FEATURES);
+        RDFWriterRegistry.register(JELLY, JELLY_BIG_ALL_FEATURES);
 
         // Register also the streaming writer
-        StreamRDFWriter.register(JELLY, JellyFormat.JELLY_SMALL_ALL_FEATURES);
+        StreamRDFWriter.register(JELLY, JELLY_BIG_ALL_FEATURES);
 
         // Register the writers
         final var allFormats = List.of(

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
@@ -1,5 +1,6 @@
 package eu.neverblink.jelly.convert.rdf4j.rio;
 
+import eu.neverblink.jelly.core.internal.BaseJellyOptions;
 import eu.neverblink.jelly.core.proto.v1.LogicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.PhysicalStreamType;
 import eu.neverblink.jelly.core.proto.v1.RdfStreamOptions;
@@ -46,26 +47,26 @@ public final class JellyWriterSettings extends WriterConfig {
     public static final AbstractRioSetting<Integer> FRAME_SIZE = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.frameSize",
         "Target RDF stream frame size. Frame size may be slightly larger than this value, " +
-        "to fit the entire statement and its lookup entries in one frame.",
+            "to fit the entire statement and its lookup entries in one frame.",
         256
     );
 
     public static final BooleanRioSetting ENABLE_NAMESPACE_DECLARATIONS = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.enableNamespaceDeclarations",
         "Enable namespace declarations in the output (equivalent to PREFIX directives in Turtle syntax). " +
-        "Enabled by default since Jelly-JVM 3.6.0, to ensure consistent behavior with RDF4J's writers. " +
-        "When your only concern is performance, it's recommended to disable this option. " +
-        "It is only useful when you want to preserve the namespace declarations in the output. " +
-        "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
+            "Enabled by default since Jelly-JVM 3.6.0, to ensure consistent behavior with RDF4J's writers. " +
+            "When your only concern is performance, it's recommended to disable this option. " +
+            "It is only useful when you want to preserve the namespace declarations in the output. " +
+            "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
         true
     );
 
     public static final BooleanRioSetting DELIMITED_OUTPUT = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.delimitedOutput",
         "Write the output as delimited frames. Note: files saved to disk are recommended to be delimited, " +
-        "for better interoperability with other implementations. In a non-delimited file you can have ONLY ONE FRAME. " +
-        "If the input data is large, this will lead to an out-of-memory error. So, this makes sense only for small data. " +
-        "**Disable this only if you know what you are doing.**",
+            "for better interoperability with other implementations. In a non-delimited file you can have ONLY ONE FRAME. " +
+            "If the input data is large, this will lead to an out-of-memory error. So, this makes sense only for small data. " +
+            "**Disable this only if you know what you are doing.**",
         true
     );
 
@@ -90,25 +91,25 @@ public final class JellyWriterSettings extends WriterConfig {
     public static final BooleanRioSetting ALLOW_RDF_STAR = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.allowRdfStar",
         "Allow RDF-star statements. Enabled by default, because we cannot know this in advance. " +
-        "If your data does not contain RDF-star statements, it is recommended that you set this to false.",
+            "If your data does not contain RDF-star statements, it is recommended that you set this to false.",
         true
     );
 
     public static final AbstractRioSetting<Integer> MAX_NAME_TABLE_SIZE = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.maxNameTableSize",
         "Maximum size of the name table",
-        128
+        BaseJellyOptions.BIG_NAME_TABLE_SIZE
     );
 
     public static final AbstractRioSetting<Integer> MAX_PREFIX_TABLE_SIZE = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.maxPrefixTableSize",
         "Maximum size of the prefix table",
-        16
+        BaseJellyOptions.BIG_PREFIX_TABLE_SIZE
     );
 
     public static final AbstractRioSetting<Integer> MAX_DATATYPE_TABLE_SIZE = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.maxDatatypeTableSize",
         "Maximum size of the datatype table",
-        16
+        BaseJellyOptions.BIG_DT_TABLE_SIZE
     );
 }

--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/rio/JellyWriterSettings.java
@@ -47,26 +47,26 @@ public final class JellyWriterSettings extends WriterConfig {
     public static final AbstractRioSetting<Integer> FRAME_SIZE = new JellyIntegerRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.frameSize",
         "Target RDF stream frame size. Frame size may be slightly larger than this value, " +
-            "to fit the entire statement and its lookup entries in one frame.",
+        "to fit the entire statement and its lookup entries in one frame.",
         256
     );
 
     public static final BooleanRioSetting ENABLE_NAMESPACE_DECLARATIONS = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.enableNamespaceDeclarations",
         "Enable namespace declarations in the output (equivalent to PREFIX directives in Turtle syntax). " +
-            "Enabled by default since Jelly-JVM 3.6.0, to ensure consistent behavior with RDF4J's writers. " +
-            "When your only concern is performance, it's recommended to disable this option. " +
-            "It is only useful when you want to preserve the namespace declarations in the output. " +
-            "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
+        "Enabled by default since Jelly-JVM 3.6.0, to ensure consistent behavior with RDF4J's writers. " +
+        "When your only concern is performance, it's recommended to disable this option. " +
+        "It is only useful when you want to preserve the namespace declarations in the output. " +
+        "Enabling this causes the stream to be written in protocol version 2 (Jelly 1.1.0) instead of 1.",
         true
     );
 
     public static final BooleanRioSetting DELIMITED_OUTPUT = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.delimitedOutput",
         "Write the output as delimited frames. Note: files saved to disk are recommended to be delimited, " +
-            "for better interoperability with other implementations. In a non-delimited file you can have ONLY ONE FRAME. " +
-            "If the input data is large, this will lead to an out-of-memory error. So, this makes sense only for small data. " +
-            "**Disable this only if you know what you are doing.**",
+        "for better interoperability with other implementations. In a non-delimited file you can have ONLY ONE FRAME. " +
+        "If the input data is large, this will lead to an out-of-memory error. So, this makes sense only for small data. " +
+        "**Disable this only if you know what you are doing.**",
         true
     );
 
@@ -91,7 +91,7 @@ public final class JellyWriterSettings extends WriterConfig {
     public static final BooleanRioSetting ALLOW_RDF_STAR = new BooleanRioSetting(
         "eu.neverblink.jelly.convert.rdf4j.rio.allowRdfStar",
         "Allow RDF-star statements. Enabled by default, because we cannot know this in advance. " +
-            "If your data does not contain RDF-star statements, it is recommended that you set this to false.",
+        "If your data does not contain RDF-star statements, it is recommended that you set this to false.",
         true
     );
 

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyEncoder.java
@@ -28,7 +28,7 @@ public interface TitaniumJellyEncoder extends RdfQuadConsumer {
      * @return TitaniumJellyEncoder
      */
     static TitaniumJellyEncoder factory() {
-        return factory(JellyOptions.SMALL_STRICT);
+        return factory(JellyOptions.BIG_STRICT);
     }
 
     /**

--- a/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriter.java
+++ b/titanium-rdf-api/src/main/java/eu/neverblink/jelly/convert/titanium/TitaniumJellyWriter.java
@@ -27,12 +27,12 @@ public interface TitaniumJellyWriter extends RdfQuadConsumer, AutoCloseable {
 
     /**
      * Factory method to create a new TitaniumJellyWriter instance.
-     * This method uses the default options (small preset) and a frame size of 256.
+     * This method uses the default options (big preset) and a frame size of 256.
      * @param outputStream The output stream to write to.
      * @return TitaniumJellyWriter
      */
     static TitaniumJellyWriter factory(OutputStream outputStream) {
-        return factory(outputStream, JellyOptions.SMALL_STRICT, 256);
+        return factory(outputStream, JellyOptions.BIG_STRICT, 256);
     }
 
     /**

--- a/titanium-rdf-api/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyEncoderSpec.scala
+++ b/titanium-rdf-api/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyEncoderSpec.scala
@@ -16,7 +16,7 @@ class TitaniumJellyEncoderSpec extends AnyWordSpec, Matchers:
     "be created with default options" in {
       val encoder = TitaniumJellyEncoder.factory()
       encoder.getOptions should be(
-        JellyOptions.SMALL_STRICT.clone()
+        JellyOptions.BIG_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.QUADS)
           .setLogicalType(LogicalStreamType.FLAT_QUADS)
           .setVersion(JellyConstants.PROTO_VERSION_1_0_X),
@@ -26,12 +26,12 @@ class TitaniumJellyEncoderSpec extends AnyWordSpec, Matchers:
 
     "be created with custom options" in {
       val encoder = TitaniumJellyEncoder.factory(
-        JellyOptions.BIG_STRICT
+        JellyOptions.SMALL_STRICT
           .clone
           .setLogicalType(LogicalStreamType.DATASETS),
       )
       encoder.getOptions should be(
-        JellyOptions.BIG_STRICT.clone()
+        JellyOptions.SMALL_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.QUADS)
           .setLogicalType(LogicalStreamType.DATASETS)
           .setVersion(JellyConstants.PROTO_VERSION_1_0_X),
@@ -42,9 +42,9 @@ class TitaniumJellyEncoderSpec extends AnyWordSpec, Matchers:
     }
 
     "ignore enabling RDF-star and generalized statements" in {
-      val encoder = TitaniumJellyEncoder.factory(JellyOptions.BIG_ALL_FEATURES)
+      val encoder = TitaniumJellyEncoder.factory(JellyOptions.SMALL_ALL_FEATURES)
       encoder.getOptions should be(
-        JellyOptions.BIG_STRICT.clone()
+        JellyOptions.SMALL_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.QUADS)
           .setLogicalType(LogicalStreamType.FLAT_QUADS)
           .setVersion(JellyConstants.PROTO_VERSION_1_0_X),

--- a/titanium-rdf-api/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyWriterSpec.scala
+++ b/titanium-rdf-api/src/test/scala/eu/neveblink/jelly/convert/titanium/TitaniumJellyWriterSpec.scala
@@ -15,7 +15,7 @@ class TitaniumJellyWriterSpec extends AnyWordSpec, Matchers:
       val os = new java.io.ByteArrayOutputStream()
       val writer = TitaniumJellyWriter.factory(os)
       writer.getOptions should be(
-        JellyOptions.SMALL_STRICT.clone()
+        JellyOptions.BIG_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.QUADS)
           .setLogicalType(LogicalStreamType.FLAT_QUADS)
           .setVersion(JellyConstants.PROTO_VERSION_1_0_X),
@@ -29,13 +29,13 @@ class TitaniumJellyWriterSpec extends AnyWordSpec, Matchers:
       val writer = TitaniumJellyWriter.factory(
         os,
         // Incorrect type, should be overridden
-        JellyOptions.BIG_STRICT.clone()
+        JellyOptions.SMALL_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.GRAPHS)
           .setLogicalType(LogicalStreamType.DATASETS),
         123,
       )
       writer.getOptions should be(
-        JellyOptions.BIG_STRICT.clone()
+        JellyOptions.SMALL_STRICT.clone()
           .setPhysicalType(PhysicalStreamType.QUADS)
           .setLogicalType(LogicalStreamType.DATASETS)
           .setVersion(JellyConstants.PROTO_VERSION_1_0_X),


### PR DESCRIPTION
We used to default to the very small name/prefix tables that reduce performance drastically when dealing with larger datasets. Meanwhile, in small datasets these larger lookups perform the same or just slightly worse than the small ones. It makes more sense to use the larger ones as the default.