### PR TITLE
Disable UTF-8 validity checks in parser for speed

### DIFF
--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/FieldGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/FieldGenerator.scala
@@ -211,7 +211,7 @@ class FieldGenerator(val info: FieldInfo):
       method.addNamedCode("tag = input.readRepeated$capitalizedType:L($field:N, tag);\n", m)
       return false // tag is already read, so don't read again
     } else if (info.isString)
-      method.addStatement(named("$field:N = input.readStringRequireUtf8()"))
+      method.addStatement(named("$field:N = input.readString()"))
     else if (info.isMessageOrGroup)
       method.addStatement(
         "$T.mergeDelimitedFrom($N, input, remainingDepth)",

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
@@ -253,7 +253,7 @@ class OneOfGenerator(val info: OneOfInfo):
           field.info.fieldName,
         )
     else if field.info.isString then
-      method.addStatement("$N(input.readStringRequireUtf8())", info.setterName)
+      method.addStatement("$N(input.readString())", info.setterName)
     else if field.info.isPrimitive then
       method.addStatement(
         "$N(input.read$L())",
@@ -303,7 +303,7 @@ class OneOfGenerator(val info: OneOfInfo):
             field.info.fieldName,
           )
     else if field.info.isString then
-      method.addStatement("$N(input.readStringRequireUtf8())", field.info.setterName)
+      method.addStatement("$N(input.readString())", field.info.setterName)
     else if field.info.isPrimitive then
       method.addStatement(
         "$N(input.read$L())",

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
@@ -252,8 +252,7 @@ class OneOfGenerator(val info: OneOfInfo):
           "ProtoMessage.mergeDelimitedFrom($N, input, remainingDepth)",
           field.info.fieldName,
         )
-    else if field.info.isString then
-      method.addStatement("$N(input.readString())", info.setterName)
+    else if field.info.isString then method.addStatement("$N(input.readString())", info.setterName)
     else if field.info.isPrimitive then
       method.addStatement(
         "$N(input.read$L())",

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/ReadStringBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/ReadStringBench.scala
@@ -1,0 +1,50 @@
+package eu.neverblink.jelly.jmh
+
+import com.google.protobuf.{CodedInputStream, CodedOutputStream}
+import org.openjdk.jmh.annotations.*
+
+object ReadStringBench:
+  @State(Scope.Benchmark)
+  class BenchInput:
+    var toParse: Array[Byte] = _
+
+    val size = 1000
+
+    var inputStream: CodedInputStream = _
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      val os = new java.io.ByteArrayOutputStream()
+      val s1 = "01234567890"
+      val s2 = "ąaaśaadaćżę"
+      var s = ""
+      while s.length < size do
+        s += s1
+        s += s2
+      val cos = CodedOutputStream.newInstance(os)
+      cos.writeStringNoTag(s)
+      cos.flush()
+      toParse = os.toByteArray
+
+    @Setup(Level.Invocation)
+    def setupInvocation(): Unit =
+      val is = new java.io.ByteArrayInputStream(toParse)
+      inputStream = CodedInputStream.newInstance(is)
+      inputStream.pushLimit(toParse.length)
+
+class ReadStringBench:
+  import ReadStringBench.*
+
+  @Benchmark
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def readString(input: BenchInput): Unit =
+    val cis = input.inputStream
+    cis.readString()
+
+  @Benchmark
+  @OutputTimeUnit(java.util.concurrent.TimeUnit.NANOSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def readStringRequireUtf8(input: BenchInput): Unit =
+    val cis = input.inputStream
+    cis.readStringRequireUtf8()


### PR DESCRIPTION
Using readString() any invalid UTF-8 characters are replaced with a UTF replacement char. That's also fine, because we don't actually have a contract saying that we must throw if invalid UTF-8 is encountered. This skips one check, making readString a bit faster:

```
# JMH version: 1.37
# VM version: JDK 25, Java HotSpot(TM) 64-Bit Server VM, 25+37-LTS-jvmci-b01
# VM invoker: /home/piotr/.jdks/graalvm-jdk-25/bin/java
# VM options: -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCIProduct -XX:+EnableJVMCI -XX:-UnlockExperimentalVMOptions -Djacoco.skip=true
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 5 iterations, 10 s each
# Measurement: 10 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: eu.neverblink.jelly.jmh.ReadStringBench.readString

Benchmark                              Mode  Cnt    Score   Error  Units
ReadStringBench.readString             avgt   10  747.251 ± 4.469  ns/op
ReadStringBench.readStringRequireUtf8  avgt   10  793.255 ± 1.196  ns/op
```