### PR TITLE
Only perform recursion depth checks on recursive messages

### DIFF
--- a/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
+++ b/core/src/main/java/eu/neverblink/protoc/java/runtime/ProtoMessage.java
@@ -279,9 +279,6 @@ public abstract class ProtoMessage<MessageType extends ProtoMessage<?>> {
         CodedInputStream input,
         int remainingDepth
     ) throws IOException {
-        if (remainingDepth < 0) {
-            throw new RuntimeException("Maximum recursion depth exceeded");
-        }
         final int length = input.readRawVarint32();
         final int oldLimit = input.pushLimit(length);
         if (msg.mergeFrom(input, remainingDepth - 1) != 0) {

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/OneOfGenerator.scala
@@ -248,10 +248,7 @@ class OneOfGenerator(val info: OneOfInfo):
         .addStatement("$N = $T.newInstance()", field.info.fieldName, field.info.getTypeName)
         .addStatement("$N($N)", info.setterName, field.info.fieldName)
         .endControlFlow
-        .addStatement(
-          "ProtoMessage.mergeDelimitedFrom($N, input, remainingDepth)",
-          field.info.fieldName,
-        )
+      generateMergeDelimitedFromCall(method, field)
     else if field.info.isString then
       method.addStatement("$N(input.readStringRequireUtf8())", info.setterName)
     else if field.info.isPrimitive then
@@ -283,10 +280,7 @@ class OneOfGenerator(val info: OneOfInfo):
             field.info.getTypeName,
           )
           .addStatement("$N($N)", field.info.setterName, field.info.fieldName)
-          .addStatement(
-            "ProtoMessage.mergeDelimitedFrom($N, input, remainingDepth)",
-            field.info.fieldName,
-          )
+        generateMergeDelimitedFromCall(method, field)
       else
         // If the field is already set to the same kind of message, we merge it.
         // Otherwise, we create a new instance of the message and merge it.
@@ -298,10 +292,7 @@ class OneOfGenerator(val info: OneOfInfo):
           .addStatement("$N = $T.newInstance()", field.info.fieldName, field.info.getTypeName)
           .addStatement("$N($N)", field.info.setterName, field.info.fieldName)
           .endControlFlow
-          .addStatement(
-            "ProtoMessage.mergeDelimitedFrom($N, input, remainingDepth)",
-            field.info.fieldName,
-          )
+        generateMergeDelimitedFromCall(method, field)
     else if field.info.isString then
       method.addStatement("$N(input.readStringRequireUtf8())", field.info.setterName)
     else if field.info.isPrimitive then
@@ -312,6 +303,18 @@ class OneOfGenerator(val info: OneOfInfo):
       )
     else throw new IllegalStateException("Unhandled field type: " + field.info.getTypeName)
     true
+
+  private def generateMergeDelimitedFromCall(method: MethodSpec.Builder, field: FieldGenerator): Unit =
+    val typeName = field.info.getTypeName.asInstanceOf[ClassName].simpleName()
+    if info.parentTypeInfo.request.pluginOptions.isRecursive(typeName) then
+      method
+        .beginControlFlow("if (remainingDepth < 0)")
+        .addStatement("throw new RuntimeException(\"Maximum recursion depth exceeded\")")
+        .endControlFlow
+    method.addStatement(
+      "ProtoMessage.mergeDelimitedFrom($N, input, remainingDepth)",
+      field.info.fieldName,
+    )
 
   def generateConstants(t: TypeSpec.Builder): Unit =
     for field <- fields do

--- a/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/PluginOptions.scala
+++ b/crunchy-protoc-plugin/src/main/scala/eu/neverblink/protoc/java/gen/PluginOptions.scala
@@ -52,6 +52,13 @@ class PluginOptions(request: PluginProtos.CodeGeneratorRequest):
   val implements: Map[String, Seq[String]] = parseImplements(map)
   val fastOneofMerge: Set[String] = map.getOrDefault("fast_oneof_merge", "").split(";").toSet
   val classBasedOneof: Set[String] = map.getOrDefault("class_based_oneof", "").split(";").toSet
+  val recursiveMessages: Set[String] = map.getOrDefault("recursive_messages", "").split(";").toSet
+
+  def isRecursive(messageName: String): Boolean =
+    // If empty (default), all messages are considered recursive for security reasons.
+    // Setting this option to a non-empty value restricts the recursion depth check
+    // to only the listed messages, while all other messages are considered non-recursive.
+    recursiveMessages.isEmpty || recursiveMessages.contains(messageName)
 
   private def parseReplacePackage(replaceOption: String): String => String =
     // leave as is

--- a/rdf-protos/src/main/args.txt
+++ b/rdf-protos/src/main/args.txt
@@ -18,4 +18,5 @@ implements_RdfPatchHeader.Mutable=eu.neverblink.jelly.core.internal.proto.Header
 implements_RdfPatchOptions=eu.neverblink.jelly.core.internal.proto.OptionsBase,
 fast_oneof_merge=RdfStreamRow,
 class_based_oneof=RdfTriple;RdfQuad;RdfGraphStart;RdfPatchNamespace;RdfPatchHeader,
+recursive_messages=RdfTriple,
 replace_package=eu.ostrzyciel=eu.neverblink


### PR DESCRIPTION
A truly micro optimization.

We were checking the recursion depth already quite efficiently, but we can do a little bit better with the observation that most messages are, in fact, not recursive. For them it's enough to just increment the depth.

If we remove the check on everything aside from RdfTriple, our security will not be compromised (as proven by tests). During inlining, the compiler should also get rid of this parameter entirely in some code paths.