### PR TITLE
Speed up dispatch in AnyStatementDecoder

### DIFF
--- a/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
+++ b/rdf4j/src/main/java/eu/neverblink/jelly/convert/rdf4j/Rdf4jEncoderConverter.java
@@ -2,7 +2,6 @@ package eu.neverblink.jelly.convert.rdf4j;
 
 import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
-import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.utils.QuadExtractor;
 import eu.neverblink.jelly.core.utils.TripleExtractor;


### PR DESCRIPTION
We had a wonky `if` there that added a few extra checks for each processed row... which is not great. Instead, we have now a single virtual method call that will be hopefully inlined by the JVM. In my testing on OpenJDK 23, this really does get fully inlined now.