### PR TITLE
Upgrade to JDK 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'sbt'
 
       - name: Setup SBT
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'sbt'
 
       - name: Setup SBT

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  java_publish: 17
+  java_publish: 21
   JELLY_TEST_SILENCE_OUTPUT: 'true'
 
 jobs:
@@ -20,21 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Test Jena 5.3, 5.6, and 6.x.
-          # The dependency is set by default to 5.6, to allow the publishing CI to read
-          # Jena's classfiles (6.x requires Java 21).
+          # Tests run on JDK 21 (LTS baseline), 25, and the latest release (26).
+          # Across those we also exercise the oldest and newest supported Jena/RDF4J versions.
+          # The dependency is set by default to Jena 5.6.
           # See: https://github.com/Jelly-RDF/jelly-jvm/issues/622
           - os: ubuntu-latest
-            java: 17
+            java: 21
             # Jena 5.3.0 is the last version supporting RDF-star.
             # 5.4.0 dropped it in favor of RDF1.2.
             jena_version: "5.3.0"
             # Test the last RDF4J 4.x version.
             rdf4j_version: "4.3.16"
-          - os: ubuntu-latest
-            java: 17
-            jena_version: ""
-            rdf4j_version: ""
           # Jena 6 requires Java 21.
           - os: ubuntu-latest
             java: 21
@@ -42,6 +38,10 @@ jobs:
             rdf4j_version: ""
           - os: ubuntu-latest
             java: 25
+            jena_version: ""
+            rdf4j_version: ""
+          - os: ubuntu-latest
+            java: 26
             jena_version: ""
             rdf4j_version: ""
     runs-on: ${{ matrix.os }}

--- a/build.sbt
+++ b/build.sbt
@@ -56,16 +56,16 @@ lazy val commonSettings = Seq(
   ) ++ wErrorIfCI,
   javacOptions ++= Seq(
     "-source",
-    "17",
+    "21",
     "-target",
-    "17",
+    "21",
     // TODO: enable more warnings
   ) ++ wErrorIfCI,
   // Explicitly specify the options for javadoc, otherwise sbt will pass all javacOptions to it
   // which will cause an error.
   // Exclude org.apache to avoid including JenaCompatHelper.
   // See: https://github.com/Jelly-RDF/jelly-jvm/issues/622
-  Compile / doc / javacOptions := Seq("-source", "17", "-exclude", "org.apache"),
+  Compile / doc / javacOptions := Seq("-source", "21", "-exclude", "org.apache"),
   assemblyJarName := s"${name.value}.jar",
   assemblyMergeStrategy := {
     case x if x.endsWith("module-info.class") => MergeStrategy.concat

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -60,14 +60,15 @@ We also publish plugin JARs which allow you to use Jelly-JVM with [Apache Jena](
 
 ## Compatibility
 
-Jelly-JVM is compatible with Java 17 and newer. Java 17, 21, and 25 are tested in CI and are guaranteed to work. The modules integrating with Pekko Streams use Scala and are built with [Scala 3 LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html).
+Jelly-JVM is compatible with Java 21 and newer. Java 21, 25, and 26 are tested in CI and are guaranteed to work. The modules integrating with Pekko Streams use Scala and are built with [Scala 3 LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html).
 
 The following table shows the compatibility of the Jelly-JVM implementation with other libraries:
 {: .jelly-table-tight }
 
 |                                                                    Jelly-JVM                                                                    | Java | <abbr title="Scala is used only in tests and jelly-pekko-* modules. Other modules are 100% in Java">Scala</abbr> | <abbr title="Eclipse RDF4J">RDF4J</abbr> | <abbr title="Apache Jena">Jena</abbr> | <abbr title="Apache Pekko, used in jelly-pekko-* modules.">Pekko</abbr> |                         Neo4j                         |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------:|:----:|:-------------------------:|:-----------:|:-------------------------------------:|:-----------------------------------------------------------------------:|:-----------------------------------------------------:|
-| [3.7.x](https://w3id.org/jelly/jelly-jvm/3.7.x)–[**{{ jvm_package_version() }}**](https://w3id.org/jelly/jelly-jvm/{{ jvm_package_version() }}) | 17+  |      3.3.x (LTS)[^2]      | 4.3.x–5.x.x |              5.x.x–6.x.x              |                               1.1.x–1.2.x                               | {{ neo4j_version('min') }}–{{ neo4j_version('max') }} |
+| [4.0.x](https://w3id.org/jelly/jelly-jvm/4.0.x)–[**{{ jvm_package_version() }}**](https://w3id.org/jelly/jelly-jvm/{{ jvm_package_version() }}) | 21+  |      3.3.x (LTS)[^2]      | 4.3.x–5.x.x |              5.x.x–6.x.x              |                               1.1.x–1.2.x                               | {{ neo4j_version('min') }}–{{ neo4j_version('max') }} |
+|                                                 [3.7.x](https://w3id.org/jelly/jelly-jvm/3.7.x)                                                 | 17+  |      3.3.x (LTS)[^2]      | 4.3.x–5.x.x |              5.x.x–6.x.x              |                               1.1.x–1.2.x                               |                     5.1.0–5.26.0                      |
 |                         [3.5.x](https://w3id.org/jelly/jelly-jvm/3.5.x)–[3.6.x](https://w3id.org/jelly/jelly-jvm/3.6.x)                         | 17+  |      3.3.x (LTS)[^2]      | 4.3.x–5.x.x |                 5.x.x                 |                               1.1.x–1.2.x                               |                     5.1.0–5.26.0                      |
 |                         [3.0.x](https://w3id.org/jelly/jelly-jvm/3.0.x)–[3.4.x](https://w3id.org/jelly/jelly-jvm/3.4.x)                         | 17+  |      3.3.x (LTS)[^2]      |    5.x.x    |                 5.x.x                 |                                  1.1.x                                  |                           –                           |
 |                        [2.0.x](https://w3id.org/jelly/jelly-jvm/2.0.x)–[2.10.x](https://w3id.org/jelly/jelly-jvm/2.10.x)                        | 17+  |        3.3.x (LTS)        |    5.x.x    |                 5.x.x                 |                                  1.1.x                                  |                           –                           |
@@ -111,4 +112,4 @@ The development of the Jelly protocol, its implementations, and supporting tooli
 ![European Funds for Smart Economy, Republic of Poland, Co-funded by the European Union](assets/featured/feng_rp_eu.png)
 
 [^1]: Scala 2.13-compatible builds of Jelly-JVM are available for Jelly-JVM 1.0.x. Scala 2 support was removed in subsequent versions. [See more details](https://w3id.org/jelly/jelly-jvm/1.0.x/user/scala2).
-[^2]: Scala version applies **only** to the `jelly-pekko-*` modules. The other modules **do not depend** on Scala and are compatible with any version of Java 17+.
+[^2]: Scala version applies **only** to the `jelly-pekko-*` modules. The other modules **do not depend** on Scala and are compatible with any version of Java 21+.

--- a/docs/docs/user/compatibility.md
+++ b/docs/docs/user/compatibility.md
@@ -4,9 +4,9 @@ Jelly-JVM follows [Semantic Versioning 2.0.0](https://semver.org/), with MAJOR.M
 
 ## JVM and Scala
 
-The current version of Jelly-JVM is compatible with Java 17 and newer. Java 17, 21, and 24 are tested in CI and are guaranteed to work. We recommend using a recent release of [GraalVM](https://www.graalvm.org/) to get the best performance. If you need Java 11 support, you should use [Jelly-JVM 1.0.x](https://w3id.org/jelly/jelly-jvm/1.0.x).
+The current version of Jelly-JVM is compatible with Java 21 and newer. Java 21, 25, and 26 are tested in CI and are guaranteed to work. We recommend using a recent release of [GraalVM](https://www.graalvm.org/) to get the best performance. For Java 17 support, use [Jelly-JVM 3.7.x](https://w3id.org/jelly/jelly-jvm/3.7.x). For Java 11, use [Jelly-JVM 1.0.x](https://w3id.org/jelly/jelly-jvm/1.0.x).
 
-The current version of Jelly-JVM has some modules (currently `jelly-pekko-stream`) built with [Scala 3 LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html) and support only Scala 3. 
+The current version of Jelly-JVM has some modules (currently `jelly-pekko-stream`) built with [Scala 3 LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html) and support only Scala 3.
 
 Jelly-JVM 2.x.x was written entirely in Scala 3, using [Scala LTS releases](https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html).
 


### PR DESCRIPTION
Jena 6 requires JDK 21, RDF4J 6 requires JDK 25. Newer Neo4j releases also require 21. There is no point in sticking to 17.

This will require a new MAJOR release.