### PR TITLE
Speed up NodeCache

### DIFF
--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -4,7 +4,6 @@ import static eu.neverblink.jelly.core.internal.BaseJellyOptions.MIN_NAME_TABLE_
 
 import eu.neverblink.jelly.core.*;
 import eu.neverblink.jelly.core.proto.v1.*;
-import java.util.LinkedHashMap;
 import java.util.Objects;
 
 /**
@@ -34,22 +33,81 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         public int lookupSerial2;
     }
 
+    /** Rounds up to a power of two, so the caches can mask instead of divide. */
+    private static int tableSizeFor(int minSize) {
+        return Integer.highestOneBit(Math.max(minSize - 1, 1)) << 1;
+    }
+
+    /** Picks the slot for a key, xor-folding so that hashCodes differing only high up still spread. */
+    private static int slotFor(Object key, int mask) {
+        final int h = key.hashCode() * 0x9E3779B1;
+        return (h ^ (h >>> 16)) & mask;
+    }
+
     /**
-     * A simple LRU cache for already encoded nodes.
-     * @param <K> Key type
+     * A direct-mapped cache for already encoded nodes: the hash picks one slot, and a colliding key
+     * takes it over. No eviction bookkeeping and no per-entry object, which makes it ~2x faster than
+     * a LinkedHashMap at a similar hit rate on real data. See NodeCacheBench.
      * @param <V> Value type
      */
-    private static final class NodeCache<K, V> extends LinkedHashMap<K, V> {
+    private static final class NodeCache<V> {
 
-        private final int maxSize;
+        private final Object[] keys;
+        private final Object[] values;
+        private final int mask;
 
-        public NodeCache(int maxSize) {
-            this.maxSize = maxSize;
+        NodeCache(int minSize) {
+            final int size = tableSizeFor(minSize);
+            this.keys = new Object[size];
+            this.values = new Object[size];
+            this.mask = size - 1;
         }
 
-        @Override
-        protected boolean removeEldestEntry(java.util.Map.Entry<K, V> eldest) {
-            return size() > maxSize;
+        @SuppressWarnings("unchecked")
+        V get(Object key) {
+            final int slot = slotFor(key, mask);
+            return key.equals(keys[slot]) ? (V) values[slot] : null;
+        }
+
+        void put(Object key, V value) {
+            final int slot = slotFor(key, mask);
+            keys[slot] = key;
+            values[slot] = value;
+        }
+    }
+
+    /**
+     * The same, for nodes that depend on lookup entries. The DependentNode in a slot is recycled, so
+     * taking a slot over MUST clear `encoded` – otherwise the stale lookupPointer/lookupSerial pair
+     * could still validate and we would emit the previous key's IRI or datatype.
+     * @param <V> Type of the encoded node
+     */
+    private static final class DependentNodeCache<V> {
+
+        private final Object[] keys;
+        private final DependentNode<V>[] nodes;
+        private final int mask;
+
+        @SuppressWarnings("unchecked")
+        DependentNodeCache(int minSize) {
+            final int size = tableSizeFor(minSize);
+            this.keys = new Object[size];
+            this.nodes = new DependentNode[size];
+            this.mask = size - 1;
+        }
+
+        DependentNode<V> get(Object key) {
+            final int slot = slotFor(key, mask);
+            final var node = nodes[slot];
+            if (node == null) {
+                keys[slot] = key;
+                return nodes[slot] = new DependentNode<>();
+            }
+            if (!key.equals(keys[slot])) {
+                keys[slot] = key;
+                node.encoded = null;
+            }
+            return node;
         }
     }
 
@@ -65,9 +123,9 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     // We split the node caches in three – the first two are for nodes that depend on the lookups
     // (IRIs and datatype literals). The third one is for nodes that don't depend on the lookups.
-    private final NodeCache<Object, DependentNode<RdfIri>> iriNodeCache;
-    private final NodeCache<Object, DependentNode<RdfLiteral>> dtLiteralNodeCache;
-    private final NodeCache<Object, RdfLiteral> otherLiteralCache;
+    private final DependentNodeCache<RdfIri> iriNodeCache;
+    private final DependentNodeCache<RdfLiteral> dtLiteralNodeCache;
+    private final NodeCache<RdfLiteral> otherLiteralCache;
 
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     static final RdfIri zeroIri = RdfIri.newInstance();
@@ -97,7 +155,7 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         this.maxPrefixTableSize = prefixTableSize;
         if (maxPrefixTableSize > 0) {
             prefixLookup = new EncoderLookup(maxPrefixTableSize, true);
-            iriNodeCache = new NodeCache<>(iriNodeCacheSize);
+            iriNodeCache = new DependentNodeCache<>(iriNodeCacheSize);
         } else {
             prefixLookup = null;
             iriNodeCache = null;
@@ -114,7 +172,7 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         for (int i = 0; i < nameOnlyIris.length; i++) {
             nameOnlyIris[i] = RdfIri.newInstance().setPrefixId(0).setNameId(i);
         }
-        dtLiteralNodeCache = new NodeCache<>(dtLiteralNodeCacheSize);
+        dtLiteralNodeCache = new DependentNodeCache<>(dtLiteralNodeCacheSize);
         nameLookup = new EncoderLookup(nameTableSize, maxPrefixTableSize > 0);
         otherLiteralCache = new NodeCache<>(nodeCacheSize);
         this.bufferAppender = bufferAppender;
@@ -138,9 +196,9 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             maxPrefixTableSize,
             maxNameTableSize,
             maxDatatypeTableSize,
-            Math.max(Math.min(maxNameTableSize, 1024), 256),
+            Math.clamp(maxNameTableSize, 256, 1024),
             maxNameTableSize,
-            Math.max(Math.min(maxNameTableSize, 1024), 256),
+            Math.clamp(maxNameTableSize, 256, 1024),
             bufferAppender
         );
     }
@@ -168,7 +226,7 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         }
 
         // Slow path, with splitting out the prefix
-        final var cachedNode = Objects.requireNonNull(iriNodeCache).computeIfAbsent(iri, k -> new DependentNode<>());
+        final var cachedNode = Objects.requireNonNull(iriNodeCache).get(iri);
         // Check if the value is still valid
         if (
             cachedNode.encoded != null &&
@@ -224,12 +282,22 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     @Override
     public RdfLiteral makeSimpleLiteral(String lex) {
-        return otherLiteralCache.computeIfAbsent(lex, k -> RdfLiteral.newInstance().setLex(lex));
+        var literal = otherLiteralCache.get(lex);
+        if (literal == null) {
+            literal = RdfLiteral.newInstance().setLex(lex);
+            otherLiteralCache.put(lex, literal);
+        }
+        return literal;
     }
 
     @Override
     public RdfLiteral makeLangLiteral(TNode lit, String lex, String lang) {
-        return otherLiteralCache.computeIfAbsent(lit, k -> RdfLiteral.newInstance().setLex(lex).setLangtag(lang));
+        var literal = otherLiteralCache.get(lit);
+        if (literal == null) {
+            literal = RdfLiteral.newInstance().setLex(lex).setLangtag(lang);
+            otherLiteralCache.put(lit, literal);
+        }
+        return literal;
     }
 
     /**
@@ -247,7 +315,7 @@ final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
                     "to a positive value."
             );
         }
-        final var cachedNode = dtLiteralNodeCache.computeIfAbsent(key, k -> new DependentNode<>());
+        final var cachedNode = dtLiteralNodeCache.get(key);
         // Check if the value is still valid
         if (
             cachedNode.encoded != null &&

--- a/jmh/README.md
+++ b/jmh/README.md
@@ -1,5 +1,7 @@
 See the README here: https://github.com/sbt/sbt-jmh
 
+These benchmarks should be run with the latest JDK (at least 24).
+
 Run all benchmarks with:
 
 ```bash
@@ -22,4 +24,10 @@ Run this to get all options for perfasm:
 
 ```bash
 sbt jmh/Jmh/run -f1 -prof "perfasm:help"
+```
+
+To see allocation rates:
+
+```bash
+sbt jmh/Jmh/run -f1 -prof gc .*NodeCacheBench.*
 ```

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/ArrayNodeCache.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/ArrayNodeCache.java
@@ -1,0 +1,38 @@
+package eu.neverblink.jelly.jmh.caches;
+
+import java.util.function.Function;
+
+/**
+ * Direct-mapped cache: a power-of-two table indexed by the mixed hash, where a colliding key
+ * overwrites the slot.
+ */
+public final class ArrayNodeCache<K, V> {
+
+    private final Object[] keys;
+    private final Object[] values;
+    private final int mask;
+
+    public ArrayNodeCache(int maxSize) {
+        int capacity = Integer.highestOneBit(Math.max(maxSize - 1, 1)) << 1;
+        this.keys = new Object[capacity];
+        this.values = new Object[capacity];
+        this.mask = capacity - 1;
+    }
+
+    private static int mix(int x) {
+        final int h = x * 0x9E3779B1;
+        return h ^ (h >>> 16);
+    }
+
+    @SuppressWarnings("unchecked")
+    public V getOrCompute(K key, Function<K, V> mappingFunction) {
+        final int pos = mix(key.hashCode()) & mask;
+        if (key.equals(keys[pos])) {
+            return (V) values[pos];
+        }
+        final var value = mappingFunction.apply(key);
+        keys[pos] = key;
+        values[pos] = value;
+        return value;
+    }
+}

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/DependentNode.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/DependentNode.java
@@ -1,0 +1,15 @@
+package eu.neverblink.jelly.jmh.caches;
+
+/**
+ * Stand-in for NodeEncoderImpl.DependentNode, which is package-private and therefore not reachable
+ * from here. Only the field layout matters – the caches under test never look inside it, but its
+ * allocation size shows up in the GC profile.
+ */
+public final class DependentNode {
+
+    public Object encoded;
+    public int lookupPointer1;
+    public int lookupSerial1;
+    public int lookupPointer2;
+    public int lookupSerial2;
+}

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/LinkedHashMapLruNodeCache.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/LinkedHashMapLruNodeCache.java
@@ -1,0 +1,26 @@
+package eu.neverblink.jelly.jmh.caches;
+
+import java.util.LinkedHashMap;
+import java.util.function.Function;
+
+/**
+ * LinkedHashMap in accessOrder mode, so eviction is by least recently used.
+ */
+public final class LinkedHashMapLruNodeCache<K, V> extends LinkedHashMap<K, V> {
+
+    private final int maxSize;
+
+    public LinkedHashMapLruNodeCache(int maxSize) {
+        super(16, 0.75f, true);
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(java.util.Map.Entry<K, V> eldest) {
+        return size() > maxSize;
+    }
+
+    public V getOrCompute(K key, Function<K, V> mappingFunction) {
+        return computeIfAbsent(key, mappingFunction);
+    }
+}

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/LinkedHashMapNodeCache.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/LinkedHashMapNodeCache.java
@@ -1,0 +1,29 @@
+package eu.neverblink.jelly.jmh.caches;
+
+import java.util.LinkedHashMap;
+import java.util.function.Function;
+
+/**
+ * Insertion-ordered rather than access-ordered (LinkedHashMap's default), so it evicts FIFO, not LRU.
+ */
+public final class LinkedHashMapNodeCache<K, V> extends LinkedHashMap<K, V> {
+
+    private final int maxSize;
+
+    public LinkedHashMapNodeCache(int maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(java.util.Map.Entry<K, V> eldest) {
+        return size() > maxSize;
+    }
+
+    /**
+     * Named differently from Map.computeIfAbsent so that the benchmark call site cannot accidentally
+     * bind to the interface method and lose the chance to inline.
+     */
+    public V getOrCompute(K key, Function<K, V> mappingFunction) {
+        return computeIfAbsent(key, mappingFunction);
+    }
+}

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/CommonParams.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/CommonParams.scala
@@ -1,0 +1,71 @@
+package eu.neverblink.jelly.jmh
+
+import org.openjdk.jmh.annotations.*
+
+import java.util.concurrent.TimeUnit
+
+/** JVM arguments used by every benchmark in this module.
+  *
+  * The point of these is to pin down as much of the JVM's adaptive behavior as we can, so that two
+  * runs of the same benchmark on the same machine are comparable. Without them, heap resizing, TLAB
+  * resizing, and a varying number of GC/JIT threads add noise that easily exceeds the effect we are
+  * trying to measure.
+  *
+  * Requires JDK 24+ (-XX:+UseCompactObjectHeaders). The benchmarks are never run in CI, so this
+  * only constrains the JDK you run them with locally.
+  *
+  * This has to be a `transparent inline def` – `@Fork`'s `jvmArgs` needs a compile-time constant
+  * array, and a plain `val` does not qualify as one in an annotation argument.
+  */
+transparent inline def jvmArgs: Array[String] = Array(
+  "-server",
+  "-Xnoclassgc",
+  "-Xms4g", // Preallocate all heap regions & make them fixed-size where possible
+  "-Xmx4g",
+  "-Xss2m",
+  "-XX:NewSize=3g",
+  "-XX:MaxNewSize=3g",
+  "-XX:InitialCodeCacheSize=512m", // Preallocate all code regions
+  "-XX:ReservedCodeCacheSize=512m",
+  "-XX:NonNMethodCodeHeapSize=32m",
+  "-XX:NonProfiledCodeHeapSize=240m",
+  "-XX:ProfiledCodeHeapSize=240m",
+  "-XX:TLABSize=4m", // Use large fixed-size TLAB
+  "-XX:-ResizeTLAB",
+  "-XX:+UseParallelGC", // The fastest GC
+  "-XX:+UseCompactObjectHeaders", // Requires JDK 24+
+  "-XX:-UseAdaptiveSizePolicy", // Do not resize heap regions
+  "-XX:MaxInlineLevel=20", // Helps to speed-up Scala code
+  "-XX:InlineSmallCode=2500", // Use defaults from Open JDK 17+
+  "-XX:+AlwaysPreTouch", // Pretouch memory pages
+  // "-XX:+UseTransparentHugePages", Linux only???
+  "-XX:-UseDynamicNumberOfGCThreads", // Stabilize GC & JIT overhead
+  "-XX:-UseDynamicNumberOfCompilerThreads",
+  "-XX:+UseNUMA", // Relevant for multi-socket servers
+  "-XX:-UseAdaptiveNUMAChunkSizing",
+  "-XX:+PerfDisableSharedMem", // See https://github.com/Simonis/mmap-pause#readme
+  "-XX:-UsePerfData",
+  "-XX:+UnlockExperimentalVMOptions",
+  "-XX:+TrustFinalNonStaticFields", // It is safe for almost all Scala code
+)
+
+/** Base class for all benchmarks in this module.
+  *
+  * Benchmarks are free to override `@BenchmarkMode` and `@OutputTimeUnit` on individual methods –
+  * JMH gives method-level annotations precedence over the ones inherited from here. The warmup,
+  * measurement and fork settings are meant to be left alone.
+  */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(
+  iterations = 5,
+  time = 1,
+  timeUnit = TimeUnit.SECONDS,
+) // 5s usually enough for warmup and exiting from "turbo" mode reaching PL2 (Power Limit 2)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(
+  value = 1,
+  jvmArgs = jvmArgs,
+)
+abstract class CommonParams

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/NodeCacheBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/NodeCacheBench.scala
@@ -1,0 +1,201 @@
+package eu.neverblink.jelly.jmh
+
+import eu.neverblink.jelly.convert.jena.JenaConverterFactory
+import eu.neverblink.jelly.core.JellyOptions
+import eu.neverblink.jelly.core.RdfHandler.AnyStatementHandler
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame
+import eu.neverblink.jelly.jmh.caches.{
+  ArrayNodeCache,
+  DependentNode,
+  LinkedHashMapLruNodeCache,
+  LinkedHashMapNodeCache,
+}
+import org.apache.jena.datatypes.xsd.XSDDatatype
+import org.apache.jena.graph.Node
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.compiletime.uninitialized
+
+/** Compares candidate implementations of the node caches in NodeEncoderImpl.
+  *
+  * IRIs are based on the assist-iot-weather dataset.
+  */
+object NodeCacheBench:
+  @State(Scope.Benchmark)
+  class BenchInput:
+    /** Full IRIs, in encoder order. Keys of NodeEncoderImpl.iriNodeCache. */
+    var iriKeys: Array[String] = uninitialized
+
+    /** Datatype literal nodes, in encoder order. Keys of NodeEncoderImpl.dtLiteralNodeCache. */
+    var dtLiteralKeys: Array[AnyRef] = uninitialized
+
+    /** Capacities as computed by NodeEncoderImpl.create for this dataset's stream options. */
+    var iriCacheSize: Int = 0
+    var dtLiteralCacheSize: Int = 0
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      val iris = mutable.ArrayBuilder.make[String]
+      val dtLiterals = mutable.ArrayBuilder.make[AnyRef]
+      val otherLiterals = mutable.ArrayBuilder.make[AnyRef]
+
+      // Mirrors JenaEncoderConverter.nodeToProto – every branch there feeds a different cache.
+      def classify(node: Node): Unit =
+        if node == null then ()
+        else if node.isURI then iris += node.getURI
+        else if node.isLiteral then
+          if node.getLiteralLanguage.isEmpty then
+            // The datatype is a singleton, so reference comparison is what the converter does too.
+            if node.getLiteralDatatype eq XSDDatatype.XSDstring then
+              otherLiterals += node.getLiteralLexicalForm
+            else dtLiterals += node
+          else otherLiterals += node
+
+      val handler = new AnyStatementHandler[Node]:
+        override def handleTriple(subject: Node, predicate: Node, `object`: Node): Unit =
+          classify(subject)
+          classify(predicate)
+          classify(`object`)
+
+        override def handleQuad(
+            subject: Node,
+            predicate: Node,
+            `object`: Node,
+            graph: Node,
+        ): Unit =
+          classify(subject)
+          classify(predicate)
+          classify(`object`)
+          classify(graph)
+
+      val decoder = JenaConverterFactory
+        .getInstance()
+        .anyStatementDecoder(handler, JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+
+      var nameTableSize = 0
+      val is = getClass.getResourceAsStream("/assist-iot-weather_100kt.jelly.gz")
+      val gzis = new java.util.zip.GZIPInputStream(is)
+      Iterator
+        .continually(RdfStreamFrame.parseDelimitedFrom(gzis))
+        .takeWhile(_ != null)
+        .foreach { frame =>
+          frame.getRows.forEach { row =>
+            if row.hasOptions then nameTableSize = row.getOptions.getMaxNameTableSize
+            decoder.ingestRow(row)
+          }
+        }
+
+      iriKeys = iris.result()
+      dtLiteralKeys = dtLiterals.result()
+      iriCacheSize = nameTableSize
+      dtLiteralCacheSize = Math.max(Math.min(nameTableSize, 1024), 256)
+
+      val otherLiteralKeys = otherLiterals.result()
+      System.err.println(
+        f"""
+           |NodeCacheBench input (nameTableSize=$nameTableSize):
+           |  IRI keys:             ${iriKeys.length}%,d (${iriKeys.distinct.length}%,d distinct), cache size $iriCacheSize%,d
+           |  datatype literal keys ${dtLiteralKeys.length}%,d (${dtLiteralKeys.distinct.length}%,d distinct), cache size $dtLiteralCacheSize%,d
+           |  other literal keys:   ${otherLiteralKeys.length}%,d (${otherLiteralKeys.distinct.length}%,d distinct), cache size $dtLiteralCacheSize%,d
+           |  hit rate, IRI cache:              ${report(
+            hitRates(iriKeys.map(k => k: AnyRef), iriCacheSize),
+          )}
+           |  hit rate, datatype literal cache: ${report(
+            hitRates(dtLiteralKeys, dtLiteralCacheSize),
+          )}
+           |""".stripMargin,
+      )
+
+  private def hitRates(keys: Array[AnyRef], cacheSize: Int): Seq[(String, Double)] =
+    val fifo = new LinkedHashMapNodeCache[AnyRef, DependentNode](cacheSize)
+    val lru = new LinkedHashMapLruNodeCache[AnyRef, DependentNode](cacheSize)
+    val array = new ArrayNodeCache[AnyRef, DependentNode](cacheSize)
+    var fifoHits = 0
+    var lruHits = 0
+    var arrayHits = 0
+    for key <- keys do
+      var missed = false
+      fifo.getOrCompute(key, _ => { missed = true; new DependentNode })
+      if !missed then fifoHits += 1
+      missed = false
+      lru.getOrCompute(key, _ => { missed = true; new DependentNode })
+      if !missed then lruHits += 1
+      missed = false
+      array.getOrCompute(key, _ => { missed = true; new DependentNode })
+      if !missed then arrayHits += 1
+    Seq(
+      "FIFO" -> fifoHits.toDouble / keys.length,
+      "LRU" -> lruHits.toDouble / keys.length,
+      "direct-mapped" -> arrayHits.toDouble / keys.length,
+    )
+
+  private def report(rates: Seq[(String, Double)]): String =
+    rates.map((name, rate) => f"$name ${rate * 100}%.2f%%").mkString(", ")
+
+class NodeCacheBench extends CommonParams:
+  import NodeCacheBench.*
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def iriLinkedHashMap(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new LinkedHashMapNodeCache[String, DependentNode](input.iriCacheSize)
+    val make: java.util.function.Function[String, DependentNode] = _ => new DependentNode
+    val keys = input.iriKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def iriArray(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new ArrayNodeCache[String, DependentNode](input.iriCacheSize)
+    val make: java.util.function.Function[String, DependentNode] = _ => new DependentNode
+    val keys = input.iriKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def iriLinkedHashMapLru(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new LinkedHashMapLruNodeCache[String, DependentNode](input.iriCacheSize)
+    val make: java.util.function.Function[String, DependentNode] = _ => new DependentNode
+    val keys = input.iriKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1
+
+  // The datatype literal cache sees ~6% of the lookups the IRI cache sees on this dataset, so these
+  // are mostly a sanity check that the ranking does not invert on a smaller table.
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def dtLiteralLinkedHashMap(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new LinkedHashMapNodeCache[AnyRef, DependentNode](input.dtLiteralCacheSize)
+    val make: java.util.function.Function[AnyRef, DependentNode] = _ => new DependentNode
+    val keys = input.dtLiteralKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1
+
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def dtLiteralArray(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new ArrayNodeCache[AnyRef, DependentNode](input.dtLiteralCacheSize)
+    val make: java.util.function.Function[AnyRef, DependentNode] = _ => new DependentNode
+    val keys = input.dtLiteralKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriDecodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriDecodeBench.scala
@@ -40,7 +40,7 @@ object RdfIriDecodeBench:
         })
         .toArray
 
-class RdfIriDecodeBench:
+class RdfIriDecodeBench extends CommonParams:
   import RdfIriDecodeBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriParseBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfIriParseBench.scala
@@ -44,7 +44,7 @@ object RdfIriParseBench:
         iri.writeDelimitedTo(os)
       toParse = os.toByteArray
 
-class RdfIriParseBench:
+class RdfIriParseBench extends CommonParams:
   import RdfIriParseBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfStreamFrameDecodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfStreamFrameDecodeBench.scala
@@ -22,7 +22,7 @@ object RdfStreamFrameDecodeBench:
         .takeWhile(_ != null)
         .toArray
 
-class RdfStreamFrameDecodeBench:
+class RdfStreamFrameDecodeBench extends CommonParams:
   import RdfStreamFrameDecodeBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfTripleRecursiveBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/RdfTripleRecursiveBench.scala
@@ -37,7 +37,7 @@ object RdfTripleRecursiveBench:
         makeNestedTriple(maxDepth).writeDelimitedTo(os)
       toParse = os.toByteArray
 
-class RdfTripleRecursiveBench:
+class RdfTripleRecursiveBench extends CommonParams:
   import RdfTripleRecursiveBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/ReadStringBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/ReadStringBench.scala
@@ -32,7 +32,7 @@ object ReadStringBench:
       inputStream = CodedInputStream.newInstance(is)
       inputStream.pushLimit(toParse.length)
 
-class ReadStringBench:
+class ReadStringBench extends CommonParams:
   import ReadStringBench.*
 
   @Benchmark


### PR DESCRIPTION
The old implementation was not LRU, it was FIFO. It was also pretty allocation-heavy.

This is a much simpler hashtable which will just naively replace entries on hash collisions. It's way faster, and, at least on assist-iot-weather, it gets us similar cache hit rates.

```
NodeCacheBench input (nameTableSize=4000):
  IRI keys:             281,739 (15,699 distinct), cache size 4,000
  datatype literal keys 16,522 (1,054 distinct), cache size 1,024
  other literal keys:   1,739 (2 distinct), cache size 1,024
  hit rate, IRI cache:              FIFO 94.38%, LRU 94.43%, direct-mapped 94.32%
  hit rate, datatype literal cache: FIFO 93.58%, LRU 93.62%, direct-mapped 92.82%
```

new impls are the ones named `*Array`:

```
Benchmark                                        (idDistribution)  Mode  Cnt      Score       Error  Units
NodeCacheBench.dtLiteralArray                                 N/A  avgt    5    241.444 ±    10.163  us/op
NodeCacheBench.dtLiteralLinkedHashMap                         N/A  avgt    5    314.074 ±   158.762  us/op
NodeCacheBench.iriArray                                       N/A  avgt    5   1109.494 ±    16.146  us/op
NodeCacheBench.iriLinkedHashMap                               N/A  avgt    5   2077.688 ±    69.965  us/op
NodeCacheBench.iriLinkedHashMapLru                            N/A  avgt    5   2750.543 ±   500.802  us/op
```