### PR TITLE
sparql: add basic throughput benchmark, reduce allocations

### DIFF
--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
@@ -111,6 +111,11 @@ public abstract class SparqlEncoder<TNode> extends EncoderBase<TNode> {
      * Finish the current frame and return it. The returned frame is ready for serialization
      * and must be written out (or discarded) before the next row is appended.
      * <p>
+     * The frame points at buffers owned by the encoder, which are refilled for the next frame.
+     * Reading it after the next {@link #appendRow(Object[])} or {@link #endFrame()} call gives
+     * whatever the encoder has put there since, so frames must not be collected and read later.
+     * Serialize the frame, or copy what you need out of it, before continuing.
+     * <p>
      * The first returned frame carries the stream options and the result set header. A later
      * frame restates the header if the column layout had to change (e.g., a previously
      * IRI-only variable encountered a literal).

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -17,10 +17,16 @@ import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 import eu.neverblink.jelly.core.proto.v1.sparql.*;
 import eu.neverblink.jelly.core.sparql.SparqlEncoder;
+import eu.neverblink.protoc.java.runtime.ArrayListMessageCollection;
+import eu.neverblink.protoc.java.runtime.MessageCollection;
 import eu.neverblink.protoc.java.runtime.RepeatedInt;
+import eu.neverblink.protoc.java.runtime.RepeatedString;
+import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import java.util.function.IntFunction;
 
@@ -58,6 +64,70 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     // Not a valid datatype lookup id – marks a literal column that cannot state one datatype
     private static final int MIXED_DATATYPES = -1;
 
+    /**
+     * Reusable store for the SparqlTerm wrappers of a polymorphic column.
+     * <p>
+     * Only {@link #appendMessage()} adds to this - {@code add} is not supported, because a
+     * caller-supplied message would not come from the pool.
+     */
+    private static final class TermBuffer
+        extends AbstractCollection<SparqlTerm>
+        implements MessageCollection<SparqlTerm, SparqlTerm.Mutable>
+    {
+
+        private SparqlTerm.Mutable[] terms = new SparqlTerm.Mutable[0];
+        private int size = 0;
+
+        @Override
+        public SparqlTerm.Mutable appendMessage() {
+            if (size == terms.length) {
+                terms = Arrays.copyOf(terms, Math.max(8, terms.length * 2));
+            }
+            SparqlTerm.Mutable term = terms[size];
+            if (term == null) {
+                term = SparqlTerm.newInstance();
+                terms[size] = term;
+            } else {
+                // The setters leave the cached serialized size alone, so a reused wrapper has to be
+                // cleared - otherwise the frame would be written with the previous value's length.
+                term.clear();
+            }
+            size++;
+            return term;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            // Keeps the wrappers around for the next frame
+            size = 0;
+        }
+
+        @Override
+        public Iterator<SparqlTerm> iterator() {
+            return new Iterator<>() {
+                private int index = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return index < size;
+                }
+
+                @Override
+                public SparqlTerm next() {
+                    if (index >= size) {
+                        throw new NoSuchElementException();
+                    }
+                    return terms[index++];
+                }
+            };
+        }
+    }
+
     private static final class ColumnState {
 
         // Column type. Sticky once set, only ever escalated to TYPE_POLY.
@@ -81,6 +151,17 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // Layout of the current frame
         final RepeatedInt layout = RepeatedInt.newEmptyInstance();
 
+        // Output buffers handed straight to the column messages of the frame being closed, instead
+        // of a fresh one per frame. A column has exactly one type per frame, so only the buffer
+        // matching that type is ever filled. They keep their capacity across frames.
+        final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
+        final RepeatedInt prefixIds = RepeatedInt.newEmptyInstance();
+        final RepeatedString strings = RepeatedString.newEmptyInstance();
+        final MessageCollection<RdfLiteral, RdfLiteral.Mutable> literals = new ArrayListMessageCollection<>(
+            RdfLiteral::newInstance
+        );
+        final TermBuffer terms = new TermBuffer();
+
         void resetFrameState() {
             runNode = null;
             runLength = 0;
@@ -91,6 +172,11 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             lastNameId = 0;
             values.clear();
             layout.clear();
+            nameIds.clear();
+            prefixIds.clear();
+            strings.clear();
+            literals.clear();
+            terms.clear();
         }
     }
 
@@ -178,6 +264,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
     private ColumnState currentColumn = null;
     private final ColumnNodeEncoder columnNodeEncoder = new ColumnNodeEncoder();
+
+    // True while the buffers still hold the contents of the frame endFrame last returned.
+    private boolean framePending = false;
 
     // The lookup ids touched by the current frame – both the ids assigned by its lookup entries
     // and the ids its columns refer to.
@@ -344,6 +433,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 "Expected %d bindings in the row, got %d.".formatted(columns.length, row.length)
             );
         }
+        beginFrame();
         // A frame that already holds rows is ended rather than overfilled. An empty frame takes
         // the row whatever it costs – ending it again would not make any more room.
         if (rowCount > 0 && !hasRoomForAnotherRow()) {
@@ -367,11 +457,34 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         );
     }
 
+    /**
+     * Discards the previous frame's state, if it is still around. Called before anything is written
+     * into the buffers, so that the frame the caller got from endFrame stays readable for as long
+     * as the contract promises.
+     */
+    private void beginFrame() {
+        if (!framePending) {
+            return;
+        }
+        framePending = false;
+        for (final ColumnState col : columns) {
+            col.resetFrameState();
+        }
+        nameEntries.resetFrameState();
+        prefixEntries.resetFrameState();
+        datatypeEntries.resetFrameState();
+        usedNames.resetFrameState();
+        usedPrefixes.resetFrameState();
+        usedDatatypes.resetFrameState();
+        rowCount = 0;
+    }
+
     @Override
     public SparqlResultsFrame endFrame() {
         if (columns == null) {
             throw new RdfProtoSerializationError("Variables must be set before ending a frame.");
         }
+        beginFrame();
         for (final ColumnState col : columns) {
             if (col.runActive && col.runIsUnbound) {
                 // Trailing unbound run – omitted, the decoder pads with unbound cells.
@@ -425,22 +538,21 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // order in which the column indices were assigned.
         for (int i = 0; i < columns.length; i++) {
             if (types[i] == TYPE_IRI) {
+                final ColumnState col = columns[i];
                 final SparqlIriColumn.Mutable column = SparqlIriColumn.newInstance();
-                final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
+                final RepeatedInt nameIds = col.nameIds;
                 // The prefix ids keep the "same prefix as the previous IRI" inference of RdfIri.
                 // If the whole column resolves to one prefix – the usual case – it is stated once
                 // instead of once per value.
-                final int[] prefixes = new int[columns[i].values.size()];
                 int lastPrefix = 0;
                 int columnPrefix = 0;
                 boolean onePrefix = true;
                 int index = 0;
-                for (final Object value : columns[i].values) {
+                for (final Object value : col.values) {
                     final RdfIri iri = (RdfIri) value;
                     nameIds.add(iri.getNameId());
-                    final int prefix = iri.getPrefixId();
-                    prefixes[index] = prefix;
                     // Resolve the inference to see whether the column really stays on one prefix
+                    final int prefix = iri.getPrefixId();
                     lastPrefix = prefix == 0 ? lastPrefix : prefix;
                     if (index == 0) {
                         columnPrefix = lastPrefix;
@@ -450,10 +562,12 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                     index++;
                 }
                 column.setNameIds(nameIds);
-                final RepeatedInt prefixIds = RepeatedInt.newEmptyInstance();
+                final RepeatedInt prefixIds = col.prefixIds;
                 if (!onePrefix) {
-                    for (int j = 0; j < prefixes.length; j++) {
-                        prefixIds.add(prefixes[j]);
+                    // Rare enough to be worth a second pass over the values rather than a buffer
+                    // to stash the raw prefix ids in
+                    for (final Object value : col.values) {
+                        prefixIds.add(((RdfIri) value).getPrefixId());
                     }
                     column.setPrefixIds(prefixIds);
                 } else if (columnPrefix != 0) {
@@ -461,49 +575,59 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                     column.setPrefixIds(prefixIds);
                 }
                 // Otherwise every value has prefix id 0, which the decoder assumes anyway
-                column.setLayouts(copyLayout(columns[i].layout));
+                column.setLayouts(col.layout);
                 frame.addIriColumns(column);
             }
         }
         for (int i = 0; i < columns.length; i++) {
             if (types[i] == TYPE_BNODE) {
+                final ColumnState col = columns[i];
                 final SparqlBnodeColumn.Mutable column = SparqlBnodeColumn.newInstance();
-                for (final Object value : columns[i].values) {
-                    column.addValues((String) value);
+                final RepeatedString labels = col.strings;
+                for (final Object value : col.values) {
+                    labels.add((String) value);
                 }
-                column.setLayouts(copyLayout(columns[i].layout));
+                column.setValues(labels);
+                column.setLayouts(col.layout);
                 frame.addBnodeColumns(column);
             }
         }
         for (int i = 0; i < columns.length; i++) {
             if (types[i] == TYPE_LITERAL) {
+                final ColumnState col = columns[i];
                 final SparqlLiteralColumn.Mutable column = SparqlLiteralColumn.newInstance();
-                final List<Object> values = columns[i].values;
+                final List<Object> values = col.values;
                 // If every value has the same datatype – the usual case – the column states it
                 // once and carries only the lexical forms.
                 final int datatype = commonDatatype(values);
                 if (datatype == MIXED_DATATYPES) {
+                    final MessageCollection<RdfLiteral, RdfLiteral.Mutable> literals = col.literals;
                     for (final Object value : values) {
-                        column.addValues((RdfLiteral) value);
+                        literals.add((RdfLiteral) value);
                     }
+                    column.setValues(literals);
                 } else {
+                    final RepeatedString lexValues = col.strings;
                     for (final Object value : values) {
-                        column.addLexValues(((RdfLiteral) value).getLex());
+                        lexValues.add(((RdfLiteral) value).getLex());
                     }
+                    column.setLexValues(lexValues);
                     if (datatype != 0) {
                         column.setDatatype(datatype);
                     }
                     // Datatype 0 means simple literals, which the decoder assumes anyway
                 }
-                column.setLayouts(copyLayout(columns[i].layout));
+                column.setLayouts(col.layout);
                 frame.addLiteralColumns(column);
             }
         }
         for (int i = 0; i < columns.length; i++) {
             if (types[i] == TYPE_POLY) {
+                final ColumnState col = columns[i];
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
-                for (final Object value : columns[i].values) {
-                    final SparqlTerm.Mutable term = SparqlTerm.newInstance();
+                final TermBuffer terms = col.terms;
+                for (final Object value : col.values) {
+                    final SparqlTerm.Mutable term = terms.appendMessage();
                     if (value instanceof RdfIri iri) {
                         term.setIri(iri);
                     } else if (value instanceof String bnode) {
@@ -511,25 +635,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                     } else {
                         term.setLiteral((RdfLiteral) value);
                     }
-                    column.addValues(term);
                 }
-                column.setLayouts(copyLayout(columns[i].layout));
+                column.setValues(terms);
+                column.setLayouts(col.layout);
                 frame.addPolyColumns(column);
             }
         }
 
-        // Reset the per-frame state
-        for (final ColumnState col : columns) {
-            col.resetFrameState();
-        }
-        nameEntries.resetFrameState();
-        prefixEntries.resetFrameState();
-        datatypeEntries.resetFrameState();
-        usedNames.resetFrameState();
-        usedPrefixes.resetFrameState();
-        usedDatatypes.resetFrameState();
-        rowCount = 0;
         firstFrame = false;
+        // The frame points at the encoder's buffers, so they stay untouched until the next frame
+        framePending = true;
 
         // Pre-calculate the serialized size, while all objects are likely still in cache.
         frame.getSerializedSize();
@@ -633,12 +748,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             }
         }
         return datatype;
-    }
-
-    private static RepeatedInt copyLayout(RepeatedInt layout) {
-        final RepeatedInt copy = RepeatedInt.newEmptyInstance();
-        copy.addAll(layout);
-        return copy;
     }
 
     @Override

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
@@ -81,6 +81,68 @@ class SparqlEncoderSpec extends AnyWordSpec, Matchers:
     }
   }
 
+  // The encoder hands its own buffers to the frame instead of allocating a fresh set per frame, so
+  // the frame is only valid until the next one starts. These check that the hand-off does not leak
+  // data from one frame into the next.
+  "the reused frame buffers" should {
+    "produce an empty frame when endFrame is called twice in a row" in {
+      val e = encoder()
+      e.setVariables(Seq("x").asJava)
+      e.appendRow(Array[Node](Iri("https://a.org/x1")))
+      val first = e.endFrame()
+      first.getRowCount shouldBe 1
+      first.getIriColumns.asScala.head.getNameIds.size shouldBe 1
+      val second = e.endFrame()
+      second.getRowCount shouldBe 0
+      second.getIriColumns.asScala.head.getNameIds.size shouldBe 0
+      second.getNames.size shouldBe 0
+    }
+
+    "not carry a column's values into the next frame" in {
+      // One case per column type, since each has its own buffer
+      val cases = Seq(
+        "iri" -> Seq[Node](Iri("https://a.org/x1"), Iri("https://a.org/x2")),
+        "bnode" -> Seq[Node](BlankNode("b1"), BlankNode("b2")),
+        "literal" -> Seq[Node](SimpleLiteral("one"), SimpleLiteral("two")),
+        "literal-mixed-dt" -> Seq[Node](
+          DtLiteral("1", Datatype("https://a.org/d1")),
+          LangLiteral("hi", "en"),
+        ),
+        "poly" -> Seq[Node](Iri("https://a.org/x1"), SimpleLiteral("one")),
+      )
+      for (name, rows) <- cases do
+        withClue(s"$name: ") {
+          val e = encoder()
+          e.setVariables(Seq("x").asJava)
+          for row <- rows do e.appendRow(Array(row))
+          e.endFrame().getRowCount shouldBe rows.size
+          // A second frame with a single row must carry exactly that one value
+          e.appendRow(Array(rows.head))
+          val frame = e.endFrame()
+          frame.getRowCount shouldBe 1
+          val valueCount = frame.getIriColumns.asScala.map(_.getNameIds.size).sum +
+            frame.getBnodeColumns.asScala.map(_.getValues.size).sum +
+            frame.getLiteralColumns.asScala
+              .map(c => math.max(c.getValues.size, c.getLexValues.size))
+              .sum +
+            frame.getPolyColumns.asScala.map(_.getValues.size).sum
+          valueCount shouldBe 1
+        }
+    }
+
+    "not carry a column's layout into the next frame" in {
+      val e = encoder()
+      e.setVariables(Seq("x").asJava)
+      // A run of three plus an unbound cell, so the layout is non-empty
+      for _ <- 1 to 3 do e.appendRow(Array[Node](Iri("https://a.org/x1")))
+      e.appendRow(Array[Node](null))
+      e.endFrame().getIriColumns.asScala.head.getLayouts.size should be > 0
+      // A single distinct value emits no layout tokens at all
+      e.appendRow(Array[Node](Iri("https://a.org/x2")))
+      e.endFrame().getIriColumns.asScala.head.getLayouts.size shouldBe 0
+    }
+  }
+
   "the column node encoder" should {
     "compress IRIs against the state of the current column" in {
       // Exercises all four combinations of (same prefix, next name) in one column.

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlRoundTripSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlRoundTripSpec.scala
@@ -266,6 +266,24 @@ class SparqlRoundTripSpec extends AnyWordSpec, Matchers:
       frames.head.getIriColumns.size() shouldBe 0
     }
 
+    "round-trip a polymorphic column across frames whose terms differ in encoded length" in {
+      // The encoder reuses the SparqlTerm wrappers of a poly column between frames. A wrapper
+      // caches its serialized size, so refilling one with a value of a different length has to
+      // invalidate that – otherwise the second frame is written with the first frame's lengths.
+      val batch1 = Seq(
+        Seq[Node | Null](iri(1)),
+        Seq[Node | Null](SimpleLiteral("a lexical form long enough to need a different length")),
+      )
+      val batch2 = Seq(
+        Seq[Node | Null](SimpleLiteral("q")),
+        Seq[Node | Null](iri(2)),
+      )
+      val (collector, frames) = roundTrip(Seq("x"), Seq(batch1, batch2))
+      assertResults(collector, Seq("x"), batch1 ++ batch2)
+      frames.head.getPolyColumns.size() shouldBe 1
+      frames(1).getPolyColumns.size() shouldBe 1
+    }
+
     "round-trip multiple frames" in {
       val batch1 = Seq(Seq[Node | Null](iri(1), SimpleLiteral("a")))
       val batch2 = Seq(Seq[Node | Null](iri(2), SimpleLiteral("b")), Seq[Node | Null](iri(3), null))

--- a/jmh/README.md
+++ b/jmh/README.md
@@ -11,23 +11,23 @@ sbt jmh/Jmh/run
 Or an individual benchmark, in this case with 10 warmup iterations and 10 iterations:
 
 ```bash
-sbt jmh/Jmh/run -wi 10 -i 10 .*RdfIriParseBench.*
+sbt "jmh/Jmh/run -wi 10 -i 10 .*RdfIriParseBench.*"
 ```
 
 To run with the perfasm profiler, use:
 
 ```bash
-sbt jmh/Jmh/run -f1 -prof "perfasm:intelSyntax=true;tooBigThreshold=1500;top=3" .*RdfIriParseBench.*
+sbt "jmh/Jmh/run -f1 -prof "perfasm:intelSyntax=true;tooBigThreshold=1500;top=3" .*RdfIriParseBench.*"
 ```
 
 Run this to get all options for perfasm:
 
 ```bash
-sbt jmh/Jmh/run -f1 -prof "perfasm:help"
+sbt "jmh/Jmh/run -f1 -prof perfasm:help"
 ```
 
 To see allocation rates:
 
 ```bash
-sbt jmh/Jmh/run -f1 -prof gc .*NodeCacheBench.*
+sbt "jmh/Jmh/run -f1 -prof gc .*NodeCacheBench.*"
 ```

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlBenchData.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlBenchData.scala
@@ -1,7 +1,11 @@
 package eu.neverblink.jelly.jmh.sparql
 
+import eu.neverblink.jelly.convert.jena.JenaConverterFactory
 import eu.neverblink.jelly.convert.jena.sparql.gen.JenaTermFactory
 import eu.neverblink.jelly.convert.jena.sparql.{JenaSparqlConverterFactory, RowSetWriterJelly}
+import eu.neverblink.jelly.core.JellyOptions
+import eu.neverblink.jelly.core.RdfHandler.TripleHandler
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlResultsOptions
 import eu.neverblink.jelly.core.sparql.gen.{ResultSetSpec, SparqlDataGen}
 import eu.neverblink.jelly.core.sparql.{JellySparqlOptions, SparqlEncoder}
@@ -12,6 +16,8 @@ import org.apache.jena.sparql.exec.{RowSet, RowSetStream}
 import org.apache.jena.sys.JenaSystem
 
 import java.io.{ByteArrayOutputStream, OutputStream}
+import java.util.zip.GZIPInputStream
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
 /** Shared fixture for the Jelly-SPARQL benchmarks.
@@ -28,20 +34,15 @@ object SparqlBenchData:
     */
   val options: SparqlResultsOptions = JellySparqlOptions.BIG
 
-  /** A generated result set, materialized into Jena nodes and pre-built bindings.
+  /** A result set materialized into Jena nodes and pre-built bindings.
     *
     * Both representations are built once, at trial setup: node construction and binding building
     * are not what these benchmarks are about.
     */
-  final class Data(val spec: ResultSetSpec):
-    JenaSystem.init()
+  final class Data(variableNames: Seq[String], val rows: IndexedSeq[Array[Node]]):
+    val variables: java.util.List[String] = variableNames.asJava
 
-    val rows: IndexedSeq[Array[Node]] =
-      JenaTermFactory.materializeRows(SparqlDataGen.generate(spec))
-
-    val variables: java.util.List[String] = spec.variables.asJava
-
-    private val vars: Seq[Var] = spec.variables.map(Var.alloc)
+    private val vars: Seq[Var] = variableNames.map(Var.alloc)
 
     val jenaVars: java.util.List[Var] = vars.asJava
 
@@ -54,7 +55,35 @@ object SparqlBenchData:
     /** A fresh single-use RowSet over the pre-built bindings. */
     def rowSet(): RowSet = RowSetStream.create(jenaVars, bindings.iterator())
 
-  def load(preset: String): Data = Data(SparqlDataGen.preset(preset))
+  /** Generates the result set described by the spec. */
+  def generate(spec: ResultSetSpec): Data =
+    JenaSystem.init()
+    Data(spec.variables, JenaTermFactory.materializeRows(SparqlDataGen.generate(spec)))
+
+  def load(preset: String): Data = generate(SparqlDataGen.preset(preset))
+
+  private val weatherResource = "/assist-iot-weather_100kt.jelly.gz"
+
+  /** The assist-iot-weather dataset (100k real triples from RiverBench) turned into the result of
+    * `SELECT * WHERE { ?s ?p ?o }` – one row per triple, three columns.
+    */
+  def loadWeather(maxRows: Int): Data =
+    JenaSystem.init()
+    val rows = mutable.ArrayBuffer.empty[Array[Node]]
+    val handler = new TripleHandler[Node]:
+      override def handleTriple(subject: Node, predicate: Node, `object`: Node): Unit =
+        if rows.size < maxRows then rows += Array(subject, predicate, `object`)
+    val decoder = JenaConverterFactory
+      .getInstance()
+      .triplesDecoder(handler, JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+    val in = GZIPInputStream(getClass.getResourceAsStream(weatherResource))
+    try
+      Iterator
+        .continually(RdfStreamFrame.parseDelimitedFrom(in))
+        .takeWhile(_ != null)
+        .foreach(_.getRows.forEach(decoder.ingestRow(_)))
+    finally in.close()
+    Data(Seq("s", "p", "o"), rows.toIndexedSeq)
 
   /** Frames are budgeted in values, so how many rows fit depends on the width of the result set. */
   def rowsPerFrame(data: Data, maxValuesPerFrame: Int): Int =

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlSizeReport.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlSizeReport.scala
@@ -143,11 +143,11 @@ object SparqlSizeReport:
       val jellySize = outputs.head.bytes.fold(0)(_.length)
       val cells = Seq(
         name,
-        format(data.spec.rows),
-        data.spec.columns.size.toString,
+        format(data.rows.size),
+        data.variables.size.toString,
       ) ++ outputs.flatMap { output =>
         output.bytes.fold(Seq("n/a", "n/a"))(b => Seq(format(b.length), format(gzippedSize(b))))
-      } ++ Seq(f"${jellySize.toDouble / math.max(1, data.spec.rows)}%.1f")
+      } ++ Seq(f"${jellySize.toDouble / math.max(1, data.rows.size)}%.1f")
       println(cells.map(c => f"$c%18s").mkString)
 
     if filesWritten > 0 then println(s"\nWrote $filesWritten files.")

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlThroughputBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlThroughputBench.scala
@@ -1,0 +1,114 @@
+package eu.neverblink.jelly.jmh.sparql
+
+import eu.neverblink.jelly.convert.jena.sparql.JellySparqlLanguage
+import eu.neverblink.jelly.core.sparql.gen.SparqlDataGen
+import eu.neverblink.jelly.jmh.CommonParams
+import org.apache.jena.riot.Lang
+import org.apache.jena.riot.resultset.ResultSetLang
+import org.apache.jena.riot.rowset.{RowSetReaderRegistry, RowSetWriterRegistry}
+import org.apache.jena.sparql.exec.RowSet
+import org.apache.jena.sys.JenaSystem
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
+import scala.compiletime.uninitialized
+
+/** Number of rows every dataset is normalized to.
+  *
+  * This has to be an `inline val` – `@OperationsPerInvocation` takes a compile-time constant.
+  */
+inline val throughputRows = 100_000
+
+/** End-to-end throughput of Jelly-SPARQL reading and writing through Jena, in rows per second.
+  *
+  *
+  * By default only Jelly is measured. Pass `format` to compare it against Jena's own result set
+  * formats:
+  * {{{
+  * sbt "jmh/Jmh/run -p format=jelly,srj,tsv -p dataset=weather SparqlThroughputBench"
+  * }}}
+  */
+object SparqlThroughputBench:
+
+  private val formats: Map[String, Lang] = Map(
+    "jelly" -> JellySparqlLanguage.JELLY_SPARQL,
+    "srj" -> ResultSetLang.RS_JSON,
+    "srx" -> ResultSetLang.RS_XML,
+    "tsv" -> ResultSetLang.RS_TSV,
+  )
+
+  @State(Scope.Benchmark)
+  class BenchInput:
+    @Param(
+      Array(
+        // 100k real triples as ?s ?p ?o
+        "weather",
+        // entity / property / label / optional / polymorphic value
+        "realistic-mixed",
+        // five dense IRI columns – a plain wide join result
+        "wide-5",
+        // one IRI column drawing from a pool that fits in the lookup table
+        "iri-small-pool",
+        // language-tagged labels
+        "lit-lang",
+      ),
+    )
+    var dataset: String = uninitialized
+
+    @Param(Array("jelly"))
+    var format: String = uninitialized
+
+    var lang: Lang = uninitialized
+    var data: SparqlBenchData.Data = uninitialized
+    var bytes: Array[Byte] = uninitialized
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      JenaSystem.init()
+      lang = formats.getOrElse(
+        format,
+        throw IllegalArgumentException(
+          s"Unknown format '$format'. Available: ${formats.keys.toSeq.sorted.mkString(", ")}",
+        ),
+      )
+      data = loadDataset(dataset)
+      require(
+        data.rows.size == throughputRows,
+        s"Dataset '$dataset' produced ${data.rows.size} rows, expected $throughputRows. " +
+          "Throughput is reported per row, so a dataset that is short would be misreported.",
+      )
+      val out = ByteArrayOutputStream()
+      write(lang, data, out)
+      bytes = out.toByteArray
+
+  private def loadDataset(name: String): SparqlBenchData.Data =
+    if name == "weather" then SparqlBenchData.loadWeather(throughputRows)
+    else
+      // Presets are defined at their own row counts; stretch them to the common one. Only the row
+      // count changes, so the shape of the data (pools, sparsity, runs) is the preset's.
+      SparqlBenchData.generate(SparqlDataGen.preset(name).copy(rows = throughputRows))
+
+  private def write(lang: Lang, data: SparqlBenchData.Data, out: OutputStream): Unit =
+    RowSetWriterRegistry.getFactory(lang).create(lang).write(out, data.rowSet(), null)
+
+  private def read(lang: Lang, bytes: Array[Byte]): RowSet =
+    RowSetReaderRegistry.getFactory(lang).create(lang).read(ByteArrayInputStream(bytes), null)
+
+class SparqlThroughputBench extends CommonParams:
+  import SparqlThroughputBench.*
+
+  /** Bindings -> bytes. The bindings are pre-built, so this measures the writer and nothing before
+    * it; the bytes go nowhere, so it does not measure the sink either.
+    */
+  @Benchmark
+  @OperationsPerInvocation(throughputRows)
+  def serialize(input: BenchInput): Unit =
+    write(input.lang, input.data, OutputStream.nullOutputStream())
+
+  /** Bytes -> bindings, including building a `Binding` per row. */
+  @Benchmark
+  @OperationsPerInvocation(throughputRows)
+  def deserialize(blackhole: Blackhole, input: BenchInput): Unit =
+    val rowSet = read(input.lang, input.bytes)
+    while rowSet.hasNext do blackhole.consume(rowSet.next())

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlThroughputBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlThroughputBench.scala
@@ -22,7 +22,6 @@ inline val throughputRows = 100_000
 
 /** End-to-end throughput of Jelly-SPARQL reading and writing through Jena, in rows per second.
   *
-  *
   * By default only Jelly is measured. Pass `format` to compare it against Jena's own result set
   * formats:
   * {{{


### PR DESCRIPTION
Parsing is pretty fast, but serialization needs more work... It's currently pretty similar to the TSV format.

```
Benchmark                                (dataset)  (format)   Mode  Cnt         Score         Error  Units
SparqlThroughputBench.deserialize          weather     jelly  thrpt   21  10585927.752 ±   66458.479  ops/s
SparqlThroughputBench.deserialize          weather       srj  thrpt   21   1674796.153 ±   23592.093  ops/s
SparqlThroughputBench.deserialize          weather       srx  thrpt   21    832202.690 ±    7740.505  ops/s
SparqlThroughputBench.deserialize          weather       tsv  thrpt   21    757659.029 ±   37298.300  ops/s
SparqlThroughputBench.deserialize  realistic-mixed     jelly  thrpt   21   3916471.767 ±  101671.108  ops/s
SparqlThroughputBench.deserialize  realistic-mixed       srj  thrpt   21   1095022.825 ±   17904.363  ops/s
SparqlThroughputBench.deserialize  realistic-mixed       srx  thrpt   21    526712.199 ±   18783.826  ops/s
SparqlThroughputBench.deserialize  realistic-mixed       tsv  thrpt   21    772196.885 ±    4192.760  ops/s
SparqlThroughputBench.deserialize           wide-5     jelly  thrpt   21   8442155.825 ±   76246.984  ops/s
SparqlThroughputBench.deserialize           wide-5       srj  thrpt   21   1189328.289 ±    8693.207  ops/s
SparqlThroughputBench.deserialize           wide-5       srx  thrpt   21    575473.574 ±    3976.683  ops/s
SparqlThroughputBench.deserialize           wide-5       tsv  thrpt   21    672388.792 ±   35160.940  ops/s
SparqlThroughputBench.deserialize   iri-small-pool     jelly  thrpt   21  58336327.099 ± 3859447.342  ops/s
SparqlThroughputBench.deserialize   iri-small-pool       srj  thrpt   21   5601878.774 ±   43320.134  ops/s
SparqlThroughputBench.deserialize   iri-small-pool       srx  thrpt   21   2377308.312 ±  106593.085  ops/s
SparqlThroughputBench.deserialize   iri-small-pool       tsv  thrpt   21   3470655.718 ±    7654.845  ops/s
SparqlThroughputBench.deserialize         lit-lang     jelly  thrpt   21   8669961.446 ±   80796.242  ops/s
SparqlThroughputBench.deserialize         lit-lang       srj  thrpt   21   3155050.912 ±   44214.850  ops/s
SparqlThroughputBench.deserialize         lit-lang       srx  thrpt   21   1573564.749 ±    9095.678  ops/s
SparqlThroughputBench.deserialize         lit-lang       tsv  thrpt   21   3538763.220 ±   43299.263  ops/s
SparqlThroughputBench.serialize            weather     jelly  thrpt   21   8631981.004 ±  300638.342  ops/s
SparqlThroughputBench.serialize            weather       srj  thrpt   21    244894.091 ±    6979.635  ops/s
SparqlThroughputBench.serialize            weather       srx  thrpt   21    451678.427 ±    5345.009  ops/s
SparqlThroughputBench.serialize            weather       tsv  thrpt   21   2330753.850 ±  247043.320  ops/s
SparqlThroughputBench.serialize    realistic-mixed     jelly  thrpt   21   2367621.738 ±   51672.437  ops/s
SparqlThroughputBench.serialize    realistic-mixed       srj  thrpt   21    226982.504 ±    4534.536  ops/s
SparqlThroughputBench.serialize    realistic-mixed       srx  thrpt   21    389784.031 ±    6270.653  ops/s
SparqlThroughputBench.serialize    realistic-mixed       tsv  thrpt   21   3017605.478 ±   27994.397  ops/s
SparqlThroughputBench.serialize             wide-5     jelly  thrpt   21   2876984.726 ±  109575.975  ops/s
SparqlThroughputBench.serialize             wide-5       srj  thrpt   21    195941.262 ±    5365.829  ops/s
SparqlThroughputBench.serialize             wide-5       srx  thrpt   21    341413.020 ±    3893.904  ops/s
SparqlThroughputBench.serialize             wide-5       tsv  thrpt   21   1871944.012 ±  207356.055  ops/s
SparqlThroughputBench.serialize     iri-small-pool     jelly  thrpt   21  20784654.311 ±  180045.334  ops/s
SparqlThroughputBench.serialize     iri-small-pool       srj  thrpt   21    958861.054 ±   18815.401  ops/s
SparqlThroughputBench.serialize     iri-small-pool       srx  thrpt   21   1438160.288 ±    6533.433  ops/s
SparqlThroughputBench.serialize     iri-small-pool       tsv  thrpt   21  11442427.832 ±  300080.075  ops/s
SparqlThroughputBench.serialize           lit-lang     jelly  thrpt   21  13656492.772 ±  199939.007  ops/s
SparqlThroughputBench.serialize           lit-lang       srj  thrpt   21   1017633.072 ±   42932.148  ops/s
SparqlThroughputBench.serialize           lit-lang       srx  thrpt   21   1373510.365 ±   39033.630  ops/s
SparqlThroughputBench.serialize           lit-lang       tsv  thrpt   21  16334965.158 ±  478519.040  ops/s
```