### PR TITLE
Optimize serializer in Jelly-SPARQL and a bit of RDF

### DIFF
--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/JellySparqlOptions.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/JellySparqlOptions.java
@@ -25,18 +25,11 @@ public final class JellySparqlOptions {
     public static final int MIN_NAME_TABLE_SIZE = 128;
 
     public static final int SMALL_NAME_TABLE_SIZE = 256;
-
     /**
-     * The name table of the "big" preset. Deliberately larger than the frame's value budget: a
-     * table sized to exactly one frame's working set evicts almost everything between frames, so
-     * the same names have to be added again and again. With a 4096 table the realistic-mixed
-     * benchmark preset turned 41,785 of its 46,460 name lookups into new entries, because the
-     * preset's ~6,176 distinct names did not fit and so none of them survived a frame boundary.
+     * Double of DEFAULT_MAX_VALUES_PER_FRAME, so that we can avoid churning all entries from frame
+     * to frame in IRI-heavy datasets.
      */
     public static final int BIG_NAME_TABLE_SIZE = 8192;
-
-    // Kept at the same absolute cap as before (16384), so that raising the "big" preset does not
-    // let a peer force a larger table than it already could.
     public static final int MAX_NAME_TABLE_SIZE = BIG_NAME_TABLE_SIZE * 2;
 
     public static final int SMALL_PREFIX_TABLE_SIZE = 64;

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/JellySparqlOptions.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/JellySparqlOptions.java
@@ -25,8 +25,19 @@ public final class JellySparqlOptions {
     public static final int MIN_NAME_TABLE_SIZE = 128;
 
     public static final int SMALL_NAME_TABLE_SIZE = 256;
-    public static final int BIG_NAME_TABLE_SIZE = 4096;
-    public static final int MAX_NAME_TABLE_SIZE = BIG_NAME_TABLE_SIZE * 4;
+
+    /**
+     * The name table of the "big" preset. Deliberately larger than the frame's value budget: a
+     * table sized to exactly one frame's working set evicts almost everything between frames, so
+     * the same names have to be added again and again. With a 4096 table the realistic-mixed
+     * benchmark preset turned 41,785 of its 46,460 name lookups into new entries, because the
+     * preset's ~6,176 distinct names did not fit and so none of them survived a frame boundary.
+     */
+    public static final int BIG_NAME_TABLE_SIZE = 8192;
+
+    // Kept at the same absolute cap as before (16384), so that raising the "big" preset does not
+    // let a peer force a larger table than it already could.
+    public static final int MAX_NAME_TABLE_SIZE = BIG_NAME_TABLE_SIZE * 2;
 
     public static final int SMALL_PREFIX_TABLE_SIZE = 64;
     public static final int BIG_PREFIX_TABLE_SIZE = 1024;

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
@@ -1,7 +1,6 @@
 package eu.neverblink.jelly.core.sparql;
 
 import eu.neverblink.jelly.core.ExperimentalApi;
-import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfBufferAppender;
 import eu.neverblink.jelly.core.internal.NodeEncoderImpl;
@@ -38,7 +37,7 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
 
     protected final ProtoEncoderConverter<TNode> converter;
     protected final SparqlResultsOptions options;
-    private final NodeEncoder<TNode> lookupEncoder;
+    private final NodeEncoderImpl<TNode> lookupEncoder;
 
     /**
      * Creates a new SparqlEncoder instance.
@@ -68,8 +67,11 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
      * The underlying node encoder, which owns the lookup tables and their caches – as opposed
      * to a SparqlEncoder implementation, which may itself act as the NodeEncoder handed to
      * the converter.
+     * <p>
+     * Typed as the implementation rather than the interface, because the SPARQL encoder needs
+     * its ids-only IRI entry point, which is not part of NodeEncoder.
      */
-    protected final NodeEncoder<TNode> getLookupEncoder() {
+    protected final NodeEncoderImpl<TNode> getLookupEncoder() {
         return lookupEncoder;
     }
 

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
@@ -1,10 +1,10 @@
 package eu.neverblink.jelly.core.sparql;
 
 import eu.neverblink.jelly.core.ExperimentalApi;
+import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
-import eu.neverblink.jelly.core.internal.EncoderBase;
-import eu.neverblink.jelly.core.proto.v1.RdfQuad;
-import eu.neverblink.jelly.core.proto.v1.RdfTriple;
+import eu.neverblink.jelly.core.RdfBufferAppender;
+import eu.neverblink.jelly.core.internal.NodeEncoderImpl;
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlAskResult;
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlResultsFrame;
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlResultsOptions;
@@ -20,7 +20,7 @@ import java.util.List;
  * @param <TNode> type of RDF nodes in the library
  */
 @ExperimentalApi
-public abstract class SparqlEncoder<TNode> extends EncoderBase<TNode> {
+public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
 
     /**
      * Parameters passed to the Jelly-SPARQL encoder.
@@ -36,7 +36,9 @@ public abstract class SparqlEncoder<TNode> extends EncoderBase<TNode> {
         }
     }
 
+    protected final ProtoEncoderConverter<TNode> converter;
     protected final SparqlResultsOptions options;
+    private final NodeEncoder<TNode> lookupEncoder;
 
     /**
      * Creates a new SparqlEncoder instance.
@@ -45,38 +47,30 @@ public abstract class SparqlEncoder<TNode> extends EncoderBase<TNode> {
      * @param params parameters for the encoder
      */
     protected SparqlEncoder(ProtoEncoderConverter<TNode> converter, Params params) {
-        super(converter);
+        this.converter = converter;
         this.options =
             params
                 .options()
                 .clone()
                 // Override the user's version setting with what is really supported by the encoder.
                 .setVersion(JellySparqlConstants.PROTO_VERSION);
+        // Safe to pass `this` here: the node encoder only stores it as the receiver of the
+        // lookup entries it emits later, during encoding.
+        this.lookupEncoder = NodeEncoderImpl.create(
+            this,
+            options.getMaxPrefixTableSize(),
+            options.getMaxNameTableSize(),
+            options.getMaxDatatypeTableSize()
+        );
     }
 
-    @Override
-    protected int getNameTableSize() {
-        return options.getMaxNameTableSize();
-    }
-
-    @Override
-    protected int getPrefixTableSize() {
-        return options.getMaxPrefixTableSize();
-    }
-
-    @Override
-    protected int getDatatypeTableSize() {
-        return options.getMaxDatatypeTableSize();
-    }
-
-    @Override
-    protected RdfTriple.Mutable newTriple() {
-        throw new UnsupportedOperationException("Not supported in SparqlEncoder");
-    }
-
-    @Override
-    protected RdfQuad.Mutable newQuad() {
-        throw new UnsupportedOperationException("Not supported in SparqlEncoder");
+    /**
+     * The underlying node encoder, which owns the lookup tables and their caches – as opposed
+     * to a SparqlEncoder implementation, which may itself act as the NodeEncoder handed to
+     * the converter.
+     */
+    protected final NodeEncoder<TNode> getLookupEncoder() {
+        return lookupEncoder;
     }
 
     /**

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
@@ -38,7 +38,7 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
 
     protected final ProtoEncoderConverter<TNode> converter;
     protected final SparqlResultsOptions options;
-    private final NodeEncoder<TNode> lookupEncoder;
+    private final NodeEncoderImpl<TNode> lookupEncoder;
 
     /**
      * Creates a new SparqlEncoder instance.
@@ -71,6 +71,22 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
      */
     protected final NodeEncoder<TNode> getLookupEncoder() {
         return lookupEncoder;
+    }
+
+    /**
+     * Encodes an IRI in the lookup tables and returns only its ids: the name id in the high 32 bits
+     * of the result, the prefix id in the low 32.
+     * <p>
+     * The columnar format stores the two ids and compresses them itself, so unlike Jelly-RDF it
+     * never needs the RdfIri message the node encoder would otherwise build and then be read back
+     * out of. Going straight for the ids saves that allocation on a cache miss, and a dereference
+     * into a second object on every hit.
+     *
+     * @param iri the IRI to encode
+     * @return (nameId &lt;&lt; 32) | prefixId
+     */
+    protected final long lookupIriIds(String iri) {
+        return lookupEncoder.makeIriIds(iri);
     }
 
     /**

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/SparqlEncoder.java
@@ -53,7 +53,7 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
                 .clone()
                 // Override the user's version setting with what is really supported by the encoder.
                 .setVersion(JellySparqlConstants.PROTO_VERSION);
-        // Safe to pass `this` here: the node encoder only stores it as the receiver of the
+        // Safe to pass `this` here: the node encoder only stores `this` as the receiver of the
         // lookup entries it emits later, during encoding.
         this.lookupEncoder = NodeEncoderImpl.create(
             this,
@@ -64,12 +64,10 @@ public abstract class SparqlEncoder<TNode> implements RdfBufferAppender<TNode> {
     }
 
     /**
-     * The underlying node encoder, which owns the lookup tables and their caches – as opposed
-     * to a SparqlEncoder implementation, which may itself act as the NodeEncoder handed to
-     * the converter.
+     * The underlying node encoder, which manages the lookup tables and their caches.
      * <p>
      * Typed as the implementation rather than the interface, because the SPARQL encoder needs
-     * its ids-only IRI entry point, which is not part of NodeEncoder.
+     * the ids-only IRI entry point, which is not part of NodeEncoder.
      */
     protected final NodeEncoderImpl<TNode> getLookupEncoder() {
         return lookupEncoder;

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
@@ -11,9 +11,6 @@ import java.util.NoSuchElementException;
 
 /**
  * Reusable store for the SparqlTerm wrappers of a polymorphic column.
- * <p>
- * Only {@link #appendMessage()} adds to this - {@code add} is not supported, because a
- * caller-supplied message would not come from the pool.
  */
 final class TermBuffer
     extends AbstractCollection<SparqlTerm>
@@ -164,9 +161,8 @@ final class IriBuffer {
 }
 
 /**
- * Buffer for a mixed-datatype or polymorphic column: the SparqlTerm wrappers
- * of a poly column and the pools for the messages materialized at endFrame(). Split out of
- * ColumnState and created lazily, so that never allocate any of this. This also saves bytes in
+ * Buffer for a mixed-datatype or polymorphic column. It is separated from
+ * ColumnState and created lazily, so that monomorphic columns never allocate any of this. This also saves bytes in
  * the SparqlEncoderImpl object, allowing us to fit it into one cache line.
  */
 final class PolyBuffers {

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
@@ -1,0 +1,183 @@
+package eu.neverblink.jelly.core.sparql.internal;
+
+import eu.neverblink.jelly.core.proto.v1.RdfIri;
+import eu.neverblink.jelly.core.proto.v1.RdfLiteral;
+import eu.neverblink.jelly.core.proto.v1.sparql.SparqlTerm;
+import eu.neverblink.protoc.java.runtime.MessageCollection;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Reusable store for the SparqlTerm wrappers of a polymorphic column.
+ * <p>
+ * Only {@link #appendMessage()} adds to this - {@code add} is not supported, because a
+ * caller-supplied message would not come from the pool.
+ */
+final class TermBuffer
+    extends AbstractCollection<SparqlTerm>
+    implements MessageCollection<SparqlTerm, SparqlTerm.Mutable>
+{
+
+    private SparqlTerm.Mutable[] terms = new SparqlTerm.Mutable[0];
+    private int size = 0;
+
+    @Override
+    public SparqlTerm.Mutable appendMessage() {
+        if (size == terms.length) {
+            terms = Arrays.copyOf(terms, Math.max(8, terms.length * 2));
+        }
+        SparqlTerm.Mutable term = terms[size];
+        if (term == null) {
+            term = SparqlTerm.newInstance();
+            terms[size] = term;
+        } else {
+            // The setters leave the cached serialized size alone, so a reused wrapper has to be
+            // cleared - otherwise the frame would be written with the previous value's length.
+            term.clear();
+        }
+        size++;
+        return term;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public void clear() {
+        // Keeps the wrappers around for the next frame
+        size = 0;
+    }
+
+    @Override
+    public Iterator<SparqlTerm> iterator() {
+        return new Iterator<>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < size;
+            }
+
+            @Override
+            public SparqlTerm next() {
+                if (index >= size) {
+                    throw new NoSuchElementException();
+                }
+                return terms[index++];
+            }
+        };
+    }
+}
+
+/**
+ * Reusable store for RdfLiteral messages of a mixed-datatype literal column
+ * or a polymorphic column. Literal values are kept as buffer entries while the frame is
+ * built (see ColumnState), so messages only get materialized here, at endFrame().
+ */
+final class LiteralBuffer
+    extends AbstractCollection<RdfLiteral>
+    implements MessageCollection<RdfLiteral, RdfLiteral.Mutable>
+{
+
+    private RdfLiteral.Mutable[] literals = new RdfLiteral.Mutable[0];
+    private int size = 0;
+
+    @Override
+    public RdfLiteral.Mutable appendMessage() {
+        if (size == literals.length) {
+            literals = Arrays.copyOf(literals, Math.max(8, literals.length * 2));
+        }
+        RdfLiteral.Mutable literal = literals[size];
+        if (literal == null) {
+            literal = RdfLiteral.newInstance();
+            literals[size] = literal;
+        } else {
+            literal.clear();
+        }
+        size++;
+        return literal;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public void clear() {
+        size = 0;
+    }
+
+    @Override
+    public Iterator<RdfLiteral> iterator() {
+        return new Iterator<>() {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < size;
+            }
+
+            @Override
+            public RdfLiteral next() {
+                if (index >= size) {
+                    throw new NoSuchElementException();
+                }
+                return literals[index++];
+            }
+        };
+    }
+}
+
+/**
+ * Reusable store for the RdfIri messages to be used in polymorphic columns.
+ * IRI values are kept as plain ints while the frame is built (see ColumnState), so the
+ * messages only get materialized here, at endFrame(), and only for polymorphic columns.
+ */
+final class IriBuffer {
+
+    private RdfIri.Mutable[] iris = new RdfIri.Mutable[0];
+    private int size = 0;
+
+    RdfIri.Mutable append() {
+        if (size == iris.length) {
+            iris = Arrays.copyOf(iris, Math.max(8, iris.length * 2));
+        }
+        RdfIri.Mutable iri = iris[size];
+        if (iri == null) {
+            iri = RdfIri.newInstance();
+            iris[size] = iri;
+        } else {
+            iri.clear();
+        }
+        size++;
+        return iri;
+    }
+
+    void clear() {
+        size = 0;
+    }
+}
+
+/**
+ * Buffer for a mixed-datatype or polymorphic column: the SparqlTerm wrappers
+ * of a poly column and the pools for the messages materialized at endFrame(). Split out of
+ * ColumnState and created lazily, so that never allocate any of this. This also saves bytes in
+ * the SparqlEncoderImpl object, allowing us to fit it into one cache line.
+ */
+final class PolyBuffers {
+
+    final TermBuffer terms = new TermBuffer();
+    final LiteralBuffer literals = new LiteralBuffer();
+    final IriBuffer iris = new IriBuffer();
+
+    void resetFrameState() {
+        terms.clear();
+        literals.clear();
+        iris.clear();
+    }
+}

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/Buffers.java
@@ -162,8 +162,8 @@ final class IriBuffer {
 
 /**
  * Buffer for a mixed-datatype or polymorphic column. It is separated from
- * ColumnState and created lazily, so that monomorphic columns never allocate any of this. This also saves bytes in
- * the SparqlEncoderImpl object, allowing us to fit it into one cache line.
+ * ColumnState and created lazily, so that monomorphic columns never allocate any of this.
+ * This also saves bytes in the SparqlEncoderImpl object, allowing us to fit it into one cache line.
  */
 final class PolyBuffers {
 

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlDecoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlDecoderImpl.java
@@ -5,10 +5,8 @@ import eu.neverblink.jelly.core.InternalApi;
 import eu.neverblink.jelly.core.ProtoDecoderConverter;
 import eu.neverblink.jelly.core.RdfProtoDeserializationError;
 import eu.neverblink.jelly.core.internal.DecoderBase;
-import eu.neverblink.jelly.core.proto.v1.RdfDatatypeEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfLiteral;
-import eu.neverblink.jelly.core.proto.v1.RdfNameEntryPacked;
-import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntryPacked;
+import eu.neverblink.jelly.core.proto.v1.RdfLookupEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.sparql.*;
 import eu.neverblink.jelly.core.sparql.JellySparqlOptions;
 import eu.neverblink.jelly.core.sparql.SparqlDecoder;
@@ -104,21 +102,21 @@ public final class SparqlDecoderImpl<TNode, TDatatype> extends DecoderBase<TNode
 
         // Apply all lookup entries before decoding any column. In a packed entry only the first
         // value states its id, the rest are sequential.
-        for (final RdfNameEntryPacked entry : frame.getNames()) {
+        for (final RdfLookupEntryPacked entry : frame.getNames()) {
             int id = entry.getId();
             for (final String value : entry.getValues()) {
                 getNameDecoder().updateNames(id, value);
                 id = 0;
             }
         }
-        for (final RdfPrefixEntryPacked entry : frame.getPrefixes()) {
+        for (final RdfLookupEntryPacked entry : frame.getPrefixes()) {
             int id = entry.getId();
             for (final String value : entry.getValues()) {
                 getNameDecoder().updatePrefixes(id, value);
                 id = 0;
             }
         }
-        for (final RdfDatatypeEntryPacked entry : frame.getDatatypes()) {
+        for (final RdfLookupEntryPacked entry : frame.getDatatypes()) {
             int id = entry.getId();
             for (final String value : entry.getValues()) {
                 getDatatypeLookup().update(id, converter.makeDatatype(value));

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -350,9 +350,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
 
         private void appendIriIds(ColumnState col, int storedNameId, int prefixId, int nameId) {
-            usedNames.mark(nameId);
+            markUsed(usedNames, nameId);
             if (prefixId != 0) {
-                usedPrefixes.mark(prefixId);
+                markUsed(usedPrefixes, prefixId);
             }
             col.nameIds.add(storedNameId);
             col.auxIds.add(prefixId);
@@ -395,7 +395,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             // lookup entry emission that comes with it)
             final RdfLiteral literal = getNodeEncoder().makeDtLiteral(lit, lex, dt);
             final int datatype = literal.getDatatype();
-            usedDatatypes.mark(datatype);
+            markUsed(usedDatatypes, datatype);
             final ColumnState col = currentColumn;
             col.strings.add(lex);
             col.auxIds.add(datatype);
@@ -434,69 +434,54 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     // True while the buffers still hold the contents of the frame endFrame last returned.
     private boolean framePending = false;
 
-    // The lookup ids touched by the current frame – both the ids assigned by its lookup entries
-    // and the ids its columns refer to.
-    private final UsedIds usedNames;
-    private final UsedIds usedPrefixes;
-    private final UsedIds usedDatatypes;
+    /**
+     * The lookup ids of one table touched by the current frame – both the ids assigned by
+     * its lookup entries and the ids its columns refer to. One bit per id, starting at
+     * slot 1; slot 0 is the remaining-budget counter: it starts at the table's budget,
+     * every fresh mark decrements it, and a negative value means the frame has no room
+     * for another row.
+     * <p>
+     * A frame's lookup entries are all applied before any of its columns, so an entry that
+     * the frame overwrites while still referring to the old value cannot be represented. The
+     * lookups evict the least recently used entry and everything this frame touched sits at
+     * the recent end, so the frame stays safe exactly as long as it has not touched every id
+     * of the table. The budget is set so that one more row of fresh ids still fits: the
+     * table size minus one potential id per variable.
+     */
+    private final long[] usedNames;
+    private final long[] usedPrefixes;
+    private final long[] usedDatatypes;
 
     // Lookup entries collected for the current frame, packed into runs of consecutive ids
     private final PackedEntries<RdfNameEntryPacked.Mutable> nameEntries;
     private final PackedEntries<RdfPrefixEntryPacked.Mutable> prefixEntries;
     private final PackedEntries<RdfDatatypeEntryPacked.Mutable> datatypeEntries;
 
+    // Bit words for 1-based ids up to tableSize, plus the counter slot in front
+    private static long[] newUsedIds(int tableSize) {
+        return new long[1 + ((tableSize + 64) >> 6)];
+    }
+
     /**
-     * The set of ids of one lookup table touched by the current frame.
-     * <p>
-     * A frame's lookup entries are all applied before any of its columns, so an entry that the
-     * frame overwrites while still referring to the old value cannot be represented. The lookups
-     * evict the least recently used entry and everything this frame touched sits at the recent
-     * end, so the frame stays safe exactly as long as it has not touched every id of the table –
-     * which is what the count is for.
+     * Marks an id as used by this frame. Branchless, and called for every encoded term, so
+     * it folds the "was it already set" answer into the remaining-budget counter at used[0]
+     * instead of branching on it.
      */
-    private static final class UsedIds {
+    private static void markUsed(long[] used, int id) {
+        final int word = 1 + (id >> 6);
+        final int bit = id & 63;
+        final long old = used[word];
+        used[word] = old | (1L << bit);
+        used[0] -= (~old >>> bit) & 1L;
+    }
 
-        private final long[] bits;
-        private final String kind;
-        // Number of set bits
-        private int count = 0;
-        // Highest count that still leaves room for one more row. Set in setVariables.
-        private int budget = 0;
+    private static boolean isUsed(long[] used, int id) {
+        return (used[1 + (id >> 6)] & (1L << (id & 63))) != 0;
+    }
 
-        UsedIds(int tableSize, String kind) {
-            this.bits = new long[(tableSize + 64) >> 6];
-            this.kind = kind;
-        }
-
-        /**
-         * Marks an id as used by this frame. Branchless, and called for every encoded term, so it
-         * folds the "was it already set" answer into the counter instead of branching on it.
-         */
-        void mark(int id) {
-            final int word = id >> 6;
-            final int bit = id & 63;
-            final long old = bits[word];
-            bits[word] = old | (1L << bit);
-            count += (int) ((old >>> bit) & 1) ^ 1;
-        }
-
-        boolean isSet(int id) {
-            return (bits[id >> 6] & (1L << (id & 63))) != 0;
-        }
-
-        boolean isFull() {
-            return count > budget;
-        }
-
-        void setVariableCount(int variables, int tableSize) {
-            // A disabled table can never be referenced, so it must not constrain the frame size
-            budget = tableSize == 0 ? Integer.MAX_VALUE : tableSize - variables;
-        }
-
-        void resetFrameState() {
-            Arrays.fill(bits, 0);
-            count = 0;
-        }
+    // A disabled table can never be referenced, so it must not constrain the frame size
+    private static long usedIdsBudget(int tableSize, int variables) {
+        return tableSize == 0 ? Long.MAX_VALUE : tableSize - variables;
     }
 
     /**
@@ -508,7 +493,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
      */
     private static final class PackedEntries<T> {
 
-        private final UsedIds used;
+        private final long[] used;
+        private final String kind;
         private final IntFunction<T> factory;
         private final BiConsumer<T, String> adder;
 
@@ -517,15 +503,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // State for resolving 0-compressed lookup entry identifiers
         private int lastAssignedId = 0;
 
-        PackedEntries(UsedIds used, IntFunction<T> factory, BiConsumer<T, String> adder) {
+        PackedEntries(long[] used, String kind, IntFunction<T> factory, BiConsumer<T, String> adder) {
             this.used = used;
+            this.kind = kind;
             this.factory = factory;
             this.adder = adder;
         }
 
         void append(int entryId, String value) {
             final int id = entryId == 0 ? lastAssignedId + 1 : entryId;
-            checkAndMarkUsed(used, id);
+            checkAndMarkUsed(used, id, kind);
             if (current != null && id == lastAssignedId + 1) {
                 // Continues the open run – the packed entry numbers it implicitly
                 adder.accept(current, value);
@@ -553,21 +540,24 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
      */
     public SparqlEncoderImpl(ProtoEncoderConverter<TNode> converter, SparqlEncoder.Params params) {
         super(converter, params);
-        usedNames = new UsedIds(options.getMaxNameTableSize(), "name");
-        usedPrefixes = new UsedIds(options.getMaxPrefixTableSize(), "prefix");
-        usedDatatypes = new UsedIds(options.getMaxDatatypeTableSize(), "datatype");
+        usedNames = newUsedIds(options.getMaxNameTableSize());
+        usedPrefixes = newUsedIds(options.getMaxPrefixTableSize());
+        usedDatatypes = newUsedIds(options.getMaxDatatypeTableSize());
         nameEntries = new PackedEntries<>(
             usedNames,
+            "name",
             id -> RdfNameEntryPacked.newInstance().setId(id),
             RdfNameEntryPacked.Mutable::addValues
         );
         prefixEntries = new PackedEntries<>(
             usedPrefixes,
+            "prefix",
             id -> RdfPrefixEntryPacked.newInstance().setId(id),
             RdfPrefixEntryPacked.Mutable::addValues
         );
         datatypeEntries = new PackedEntries<>(
             usedDatatypes,
+            "datatype",
             id -> RdfDatatypeEntryPacked.newInstance().setId(id),
             RdfDatatypeEntryPacked.Mutable::addValues
         );
@@ -583,10 +573,20 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         for (int i = 0; i < columns.length; i++) {
             columns[i] = new ColumnState();
         }
+        resetUsedIds();
+    }
+
+    /** Clears the used-ids bits and puts each remaining-budget counter back at its budget. */
+    private void resetUsedIds() {
         final int n = columns.length;
-        usedNames.setVariableCount(n, options.getMaxNameTableSize());
-        usedPrefixes.setVariableCount(n, options.getMaxPrefixTableSize());
-        usedDatatypes.setVariableCount(n, options.getMaxDatatypeTableSize());
+        resetUsedIds(usedNames, usedIdsBudget(options.getMaxNameTableSize(), n));
+        resetUsedIds(usedPrefixes, usedIdsBudget(options.getMaxPrefixTableSize(), n));
+        resetUsedIds(usedDatatypes, usedIdsBudget(options.getMaxDatatypeTableSize(), n));
+    }
+
+    private static void resetUsedIds(long[] used, long budget) {
+        Arrays.fill(used, 0L);
+        used[0] = budget;
     }
 
     @Override
@@ -618,9 +618,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
      * been mutated, neither is possible any more.
      */
     private boolean hasRoomForAnotherRow() {
-        return (
-            rowCount < MAX_ROWS_PER_FRAME && !usedNames.isFull() && !usedPrefixes.isFull() && !usedDatatypes.isFull()
-        );
+        // A table with its remaining-budget counter below zero has no room left
+        return rowCount < MAX_ROWS_PER_FRAME && usedNames[0] >= 0 && usedPrefixes[0] >= 0 && usedDatatypes[0] >= 0;
     }
 
     /**
@@ -639,9 +638,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         nameEntries.resetFrameState();
         prefixEntries.resetFrameState();
         datatypeEntries.resetFrameState();
-        usedNames.resetFrameState();
-        usedPrefixes.resetFrameState();
-        usedDatatypes.resetFrameState();
+        resetUsedIds();
         rowCount = 0;
     }
 
@@ -944,16 +941,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
      * appendRow ends a frame before it can get that far, so this can only fire for a single row
      * that does not fit in the lookup tables at all – no framing decision can help there.
      */
-    private static void checkAndMarkUsed(UsedIds used, int id) {
-        if (used.isSet(id)) {
+    private static void checkAndMarkUsed(long[] used, int id, String kind) {
+        if (isUsed(used, id)) {
             throw new RdfProtoSerializationError(
                 (
                     "The %s lookup table is too small to encode a single row of these results: " +
                     "entry %d would be overwritten while still referenced in the current frame. " +
                     "Increase the max %s table size."
-                ).formatted(used.kind, id, used.kind)
+                ).formatted(kind, id, kind)
             );
         }
-        used.mark(id);
+        markUsed(used, id);
     }
 }

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -328,20 +328,23 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
 
     @Override
     public RdfIri makeIri(String iri) {
-        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
-        final int nameId = raw.getNameId();
+        // Only the two ids are wanted here – they go straight into the column buffers – so the
+        // underlying encoder is asked for them directly, without an RdfIri being built to carry
+        // them across.
+        final long ids = getLookupEncoder().makeIriIds(iri);
+        final int nameId = (int) (ids >>> 32);
         final ColumnState col = currentColumn;
-        appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, raw.getPrefixId(), nameId);
+        appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, (int) ids, nameId);
         return ZERO_IRI;
     }
 
     @Override
     public RdfIri makeIriRaw(String iri) {
-        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
+        final long ids = getLookupEncoder().makeIriIds(iri);
         // Raw means no next-name inference, so the name id is stored as it is. The decoder
         // still tracks it as the new "previous name", hence the lastNameId update.
-        final int nameId = raw.getNameId();
-        appendIriIds(currentColumn, nameId, raw.getPrefixId(), nameId);
+        final int nameId = (int) (ids >>> 32);
+        appendIriIds(currentColumn, nameId, (int) ids, nameId);
         return ZERO_IRI;
     }
 

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -55,8 +55,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     private static final RdfIri ZERO_IRI = RdfIri.newInstance();
 
-    // Returned by the literal makers as a type marker – the literal's parts go into the
-    // column buffers, not into the returned message
+    // Used as a type marker – the literal's parts go into the column buffers,
+    // not into the returned proto message.
     private static final RdfLiteral LITERAL_MARKER = RdfLiteral.newInstance();
 
     // Not a valid datatype lookup id – marks a literal column that cannot state one datatype
@@ -67,205 +67,35 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     private static final int LANG_LITERAL = -1;
 
     /**
-     * Reusable store for the SparqlTerm wrappers of a polymorphic column.
-     * <p>
-     * Only {@link #appendMessage()} adds to this - {@code add} is not supported, because a
-     * caller-supplied message would not come from the pool.
+     * Temporary column state, filled in from beginFrame() through to endFrame().
      */
-    private static final class TermBuffer
-        extends AbstractCollection<SparqlTerm>
-        implements MessageCollection<SparqlTerm, SparqlTerm.Mutable>
-    {
-
-        private SparqlTerm.Mutable[] terms = new SparqlTerm.Mutable[0];
-        private int size = 0;
-
-        @Override
-        public SparqlTerm.Mutable appendMessage() {
-            if (size == terms.length) {
-                terms = Arrays.copyOf(terms, Math.max(8, terms.length * 2));
-            }
-            SparqlTerm.Mutable term = terms[size];
-            if (term == null) {
-                term = SparqlTerm.newInstance();
-                terms[size] = term;
-            } else {
-                // The setters leave the cached serialized size alone, so a reused wrapper has to be
-                // cleared - otherwise the frame would be written with the previous value's length.
-                term.clear();
-            }
-            size++;
-            return term;
-        }
-
-        @Override
-        public int size() {
-            return size;
-        }
-
-        @Override
-        public void clear() {
-            // Keeps the wrappers around for the next frame
-            size = 0;
-        }
-
-        @Override
-        public Iterator<SparqlTerm> iterator() {
-            return new Iterator<>() {
-                private int index = 0;
-
-                @Override
-                public boolean hasNext() {
-                    return index < size;
-                }
-
-                @Override
-                public SparqlTerm next() {
-                    if (index >= size) {
-                        throw new NoSuchElementException();
-                    }
-                    return terms[index++];
-                }
-            };
-        }
-    }
-
-    /**
-     * The same reusable store, for the RdfLiteral messages of a mixed-datatype literal column
-     * or a polymorphic column. Literal values are kept as buffer entries while the frame is
-     * built (see ColumnState), so messages only get materialized here, at frame end.
-     */
-    private static final class LiteralBuffer
-        extends AbstractCollection<RdfLiteral>
-        implements MessageCollection<RdfLiteral, RdfLiteral.Mutable>
-    {
-
-        private RdfLiteral.Mutable[] literals = new RdfLiteral.Mutable[0];
-        private int size = 0;
-
-        @Override
-        public RdfLiteral.Mutable appendMessage() {
-            if (size == literals.length) {
-                literals = Arrays.copyOf(literals, Math.max(8, literals.length * 2));
-            }
-            RdfLiteral.Mutable literal = literals[size];
-            if (literal == null) {
-                literal = RdfLiteral.newInstance();
-                literals[size] = literal;
-            } else {
-                literal.clear();
-            }
-            size++;
-            return literal;
-        }
-
-        @Override
-        public int size() {
-            return size;
-        }
-
-        @Override
-        public void clear() {
-            size = 0;
-        }
-
-        @Override
-        public Iterator<RdfLiteral> iterator() {
-            return new Iterator<>() {
-                private int index = 0;
-
-                @Override
-                public boolean hasNext() {
-                    return index < size;
-                }
-
-                @Override
-                public RdfLiteral next() {
-                    if (index >= size) {
-                        throw new NoSuchElementException();
-                    }
-                    return literals[index++];
-                }
-            };
-        }
-    }
-
-    /**
-     * Reusable store for the RdfIri messages a polymorphic column wraps in its SparqlTerms.
-     * IRI values are kept as plain ints while the frame is built (see ColumnState), so the
-     * messages only get materialized here, at frame end, and only for polymorphic columns.
-     */
-    private static final class IriBuffer {
-
-        private RdfIri.Mutable[] iris = new RdfIri.Mutable[0];
-        private int size = 0;
-
-        RdfIri.Mutable append() {
-            if (size == iris.length) {
-                iris = Arrays.copyOf(iris, Math.max(8, iris.length * 2));
-            }
-            RdfIri.Mutable iri = iris[size];
-            if (iri == null) {
-                iri = RdfIri.newInstance();
-                iris[size] = iri;
-            } else {
-                iri.clear();
-            }
-            size++;
-            return iri;
-        }
-
-        void clear() {
-            size = 0;
-        }
-    }
-
-    /**
-     * The buffers only a mixed-datatype or polymorphic column needs: the SparqlTerm wrappers
-     * of a poly column and the pools for the messages materialized at frame end. Split out of
-     * ColumnState and created lazily, so that the mono-typed columns – the usual case – stay
-     * within one cache line and never allocate any of this.
-     */
-    private static final class PolyBuffers {
-
-        final TermBuffer terms = new TermBuffer();
-        final LiteralBuffer literals = new LiteralBuffer();
-        final IriBuffer iris = new IriBuffer();
-
-        void resetFrameState() {
-            terms.clear();
-            literals.clear();
-            iris.clear();
-        }
-    }
-
     private static final class ColumnState {
 
         // Column type. Sticky once set, only ever escalated to TYPE_POLY.
         byte type = TYPE_UNSET;
-        // The effective type this column had in the last emitted header, TYPE_UNSET before
-        // the first one. Like type, this survives frame resets.
+        // The effective type this column had in the last emitted header.
+        // This value is kept across frame resets.
         byte lastEmittedType = TYPE_UNSET;
 
-        // Run-length state. A run is active while runLength > 0; runNode == null then means
+        // Run-length state. A run is active while runLength > 0. runNode == null then means
         // a run of unbound cells. Whenever runLength is 0, runNode is null too.
         Object runNode = null;
         int runLength = 0;
         // Number of values emitted exactly once since the last layout exception
         int skip = 0;
 
-        // Per-frame, per-column IRI inference state (the prefix side of the inference is
-        // resolved at frame end, from the aux ids).
+        // Per-frame, per-column IRI inference state. The prefix side of the inference is
+        // resolved at frame end, from the aux ids.
         int lastNameId = 0;
 
-        // Datatype shared by all literals of the column so far: a lookup id, 0 for simple
-        // literals, DATATYPE_NONE before the first literal, or MIXED_DATATYPES.
+        // Datatype shared by all literals of the column so far. One of: a positive lookup id,
+        // 0 for simple literals, DATATYPE_NONE before the first literal, or MIXED_DATATYPES.
         int columnDatatype = DATATYPE_NONE;
 
         // Term type (TYPE_IRI/BNODE/LITERAL) of each encoded value of the frame, in order.
         // Only read back for polymorphic columns – the values themselves sit in the per-type
-        // buffers below, and a mono-typed column reads its buffer directly. So this is only
-        // filled in while the column is polymorphic; a column that becomes one mid-frame
+        // buffers below, and a mono-typed column reads its buffer directly. This is only
+        // filled in while the column is polymorphic. A column that becomes polymorphic mid-frame
         // backfills what it skipped (see backfillTags).
         byte[] tags = new byte[0];
         int valueCount = 0;
@@ -278,13 +108,10 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
         // One auxiliary int per IRI or literal value, in value order: the uncompressed prefix
         // id of an IRI, or the datatype lookup id of a literal (0 for a simple literal,
-        // LANG_LITERAL for a language-tagged one). Bnodes add nothing. A mono-typed column
-        // thus sees only its own kind of entry.
+        // LANG_LITERAL for a language-tagged one). Bnodes add nothing.
         final RepeatedInt auxIds = RepeatedInt.newEmptyInstance();
         // Bnode labels, literal lexical forms and language tags (right after their lexical
-        // form), appended at encode time in value order. A bnode or single-datatype literal
-        // column hands this buffer to its message as-is – safe, because a language tag forces
-        // MIXED_DATATYPES; a mixed-datatype or polymorphic column reads it back with a cursor.
+        // form), appended at encode time in value order.
         final RepeatedString strings = RepeatedString.newEmptyInstance();
 
         // Lazily created – see PolyBuffers
@@ -298,8 +125,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
 
         void addValueTag(byte tag) {
-            // A mono-typed column never reads these back, so recording them would be a bounds
-            // check, a growth check and a store per value for nothing.
+            // This is only needed for polymorphic columns.
             if (type == TYPE_POLY) {
                 if (valueCount == tags.length) {
                     tags = Arrays.copyOf(tags, Math.max(16, tags.length * 2));
@@ -310,8 +136,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
 
         /**
-         * Records the type of the values encoded before this column turned polymorphic. They were
-         * all of the column's previous type, which is what made it mono-typed until now.
+         * Records the type of the values encoded before this column turned polymorphic.
          */
         void backfillTags(byte previousType) {
             if (valueCount > tags.length) {
@@ -337,18 +162,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
     }
 
-    // The encoder is itself the NodeEncoder passed to the converter – a separate object would
-    // only add an indirection to every maker call. Unlike the underlying encoder, the maker
-    // methods below do not build proto messages: every term's parts go straight into the
-    // current column's buffers, and all lookup references are tracked for the frame
-    // working-set check. The return values only carry the term type back to encodeValue –
-    // shared markers for IRIs and literals, the label itself for bnodes.
-
     @Override
     public RdfIri makeIri(String iri) {
-        // Only the two ids are wanted here – they go straight into the column buffers – so the
-        // underlying encoder is asked for them directly, without an RdfIri being built to carry
-        // them across.
+        // Get the ids directly without RdfIri allocation.
         final long ids = getLookupEncoder().makeIriIds(iri);
         final int nameId = (int) (ids >>> 32);
         final ColumnState col = currentColumn;
@@ -379,15 +195,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     @Override
     public String makeBlankNode(String label) {
         final String bnode = getLookupEncoder().makeBlankNode(label);
-        // Straight into the string buffer – a bnode column hands the buffer to its
-        // message as-is, without a copy pass at frame end.
         currentColumn.strings.add(bnode);
         return bnode;
     }
 
     @Override
     public RdfLiteral makeSimpleLiteral(String lex) {
-        // No lookup table involved – the underlying encoder (and its cache) is skipped
+        // No lookup table involved – the underlying encoder (and its cache) is skipped.
+        // The reasoning here is that literals in SPARQL results repeat rarely anyway,
+        // so this saves quite a lot of cache thrashing. Also, the cost of encoding a literal
+        // here is much smaller than in RDF (no allocations).
         final ColumnState col = currentColumn;
         col.strings.add(lex);
         col.auxIds.add(0);
@@ -430,7 +247,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
 
     @Override
     public RdfTriple makeQuotedTriple(TNode s, TNode p, TNode o) {
-        throw new RdfProtoSerializationError("RDF-star quoted triples are not supported in Jelly-SPARQL.");
+        throw new RdfProtoSerializationError("Triple terms are not supported in Jelly-SPARQL.");
     }
 
     @Override
@@ -449,9 +266,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     private boolean framePending = false;
 
     /**
-     * The lookup ids of one table touched by the current frame – both the ids assigned by
+     * The lookup ids used by the current frame – both the ids assigned by
      * its lookup entries and the ids its columns refer to. One bit per id, starting at
-     * slot 1; slot 0 is the remaining-budget counter: it starts at the table's budget,
+     * slot 1. Slot 0 is the remaining-budget counter: it starts at the table's budget,
      * every fresh mark decrements it, and a negative value means the frame has no room
      * for another row.
      * <p>
@@ -460,7 +277,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
      * lookups evict the least recently used entry and everything this frame touched sits at
      * the recent end, so the frame stays safe exactly as long as it has not touched every id
      * of the table. The budget is set so that one more row of fresh ids still fits: the
-     * table size minus one potential id per variable.
+     * table size minus one potential id per variable. Note that this will not work for triple terms,
+     * but that's a future problem...
      */
     private final long[] usedNames;
     private final long[] usedPrefixes;
@@ -471,15 +289,13 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     private final PackedEntries prefixEntries = new PackedEntries();
     private final PackedEntries datatypeEntries = new PackedEntries();
 
-    // Bit words for 1-based ids up to tableSize, plus the counter slot in front
+    // Bit words for 1-based ids up to tableSize, plus the counter slot at index 0
     private static long[] newUsedIds(int tableSize) {
         return new long[1 + ((tableSize + 64) >> 6)];
     }
 
     /**
-     * Marks an id as used by this frame. Branchless, and called for every encoded term, so
-     * it folds the "was it already set" answer into the remaining-budget counter at used[0]
-     * instead of branching on it.
+     * Marks an id as used by this frame. Branchless.
      */
     private static void markUsed(long[] used, int id) {
         final int word = 1 + (id >> 6);
@@ -493,8 +309,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         return (used[1 + (id >> 6)] & (1L << (id & 63))) != 0;
     }
 
-    // A disabled table can never be referenced, so it must not constrain the frame size
     private static long usedIdsBudget(int tableSize, int variables) {
+        // If table size is 0, then it's not used (does not constrain us)
         return tableSize == 0 ? Long.MAX_VALUE : tableSize - variables;
     }
 
@@ -508,11 +324,10 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         implements MessageCollection<RdfLookupEntryPacked, RdfLookupEntryPacked.Mutable>
     {
 
-        // Pooled packed entry messages, reused across frames: the first `size` hold the
-        // current frame's entries, the rest are kept around for the next frames.
+        // Pooled packed entry messages, reused across frames.
         private RdfLookupEntryPacked.Mutable[] entries = new RdfLookupEntryPacked.Mutable[0];
         private int size = 0;
-        // The entry of the currently open run – always entries[size - 1], but kept in a
+        // The entry of the currently open run, kept in a
         // field so that continuing a run does not go through the array
         private RdfLookupEntryPacked.Mutable current = null;
         // State for resolving 0-compressed lookup entry identifiers
@@ -522,11 +337,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             final int id = entryId == 0 ? lastAssignedId + 1 : entryId;
             checkAndMarkUsed(used, id, kind);
             if (current != null && id == lastAssignedId + 1) {
-                // Continues the open run – the packed entry numbers it implicitly
                 current.addValues(value);
             } else {
-                // The id of a fresh entry is passed on as it came, so that a 0 keeps meaning
-                // "continue from the previous frame"
                 current = appendMessage().setId(entryId);
                 current.addValues(value);
             }
@@ -585,8 +397,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
     }
 
     /**
-     * Constructor.
-     *
      * @param converter the converter to use
      * @param params parameters for the encoder
      */
@@ -736,8 +546,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             if (effectiveType(col) == TYPE_IRI) {
                 final SparqlIriColumn.Mutable column = SparqlIriColumn.newInstance();
                 column.setNameIds(col.nameIds);
-                // For an IRI column the aux ids are exactly its uncompressed prefix ids.
-                // If the whole column stays on one prefix – the usual case – it is stated
+                // For an IRI column the aux ids are its uncompressed prefix ids.
+                // If the whole column stays on one prefix, it is stated
                 // once instead of once per value.
                 final RepeatedInt prefixes = col.auxIds;
                 final int valueCount = prefixes.size();
@@ -751,8 +561,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
                 }
                 if (!onePrefix) {
                     // Rewrite the buffer into the "same prefix as the previous IRI" inference
-                    // of RdfIri in place – the raw value only has to survive one step, in prev.
-                    // prev = -1 forces the first IRI of the column to carry its prefix id.
+                    // of RdfIri in place.
                     final int[] raw = prefixes.array();
                     int prev = -1;
                     for (int j = 0; j < valueCount; j++) {
@@ -775,7 +584,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             final ColumnState col = columns[i];
             if (effectiveType(col) == TYPE_BNODE) {
                 final SparqlBnodeColumn.Mutable column = SparqlBnodeColumn.newInstance();
-                // The labels were appended to the buffer as they were encoded
                 column.setValues(col.strings);
                 column.setLayouts(col.layout);
                 frame.addBnodeColumns(column);
@@ -785,9 +593,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             final ColumnState col = columns[i];
             if (effectiveType(col) == TYPE_LITERAL) {
                 final SparqlLiteralColumn.Mutable column = SparqlLiteralColumn.newInstance();
-                // If every value has the same datatype – the usual case – the column states it
-                // once and carries only the lexical forms, already sitting in the buffer.
-                // An empty column counts as simple literals – both forms are empty anyway.
+                // If every value has the same datatype  the column states it
+                // once and contains only the lexical forms, already sitting in the buffer.
+                // An empty column counts as simple literals.
                 final int datatype = col.columnDatatype == DATATYPE_NONE ? 0 : col.columnDatatype;
                 if (datatype == MIXED_DATATYPES) {
                     // For a literal column the aux ids are exactly its datatype ids
@@ -804,7 +612,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
                         } else if (dt != 0) {
                             literal.setDatatype(dt);
                         }
-                        // dt == 0 is a simple literal, which carries only its lexical form
                     }
                     column.setValues(literals);
                 } else {
@@ -820,13 +627,13 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
         for (int i = 0; i < columns.length; i++) {
             final ColumnState col = columns[i];
+            // Slow path: polymorphic column
             if (effectiveType(col) == TYPE_POLY) {
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
                 final PolyBuffers poly = col.poly();
                 final TermBuffer terms = poly.terms;
-                // Cursors into the per-type buffers: the tags say which buffer the next value
-                // sits in. IRIs and literals share the aux buffer; bnode labels and literal
-                // lexical forms (with their language tags) share the string buffer.
+                // Iterates through the per-type buffers: the tags say which buffer the next value
+                // sits in.
                 int iriIndex = 0;
                 int auxIndex = 0;
                 int stringIndex = 0;
@@ -886,7 +693,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             col.runLength = 1;
             return;
         }
-        // runNode != null implies an active bound run
+        // runNode != null means an active bound run
         if (node.equals(col.runNode)) {
             col.runLength++;
             return;
@@ -917,8 +724,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         if (col.type == TYPE_UNSET) {
             col.type = valueType;
         } else if (col.type != TYPE_POLY && col.type != valueType) {
-            // The values already in this frame were all of the old type, and nothing recorded
-            // that while the column still looked mono-typed.
+            // Lazy-switch to a polymorphic column
             col.backfillTags(col.type);
             col.type = TYPE_POLY;
         }

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -264,7 +264,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
 
         // Term type (TYPE_IRI/BNODE/LITERAL) of each encoded value of the frame, in order.
         // Only read back for polymorphic columns – the values themselves sit in the per-type
-        // buffers below, and a mono-typed column reads its buffer directly.
+        // buffers below, and a mono-typed column reads its buffer directly. So this is only
+        // filled in while the column is polymorphic; a column that becomes one mid-frame
+        // backfills what it skipped (see backfillTags).
         byte[] tags = new byte[0];
         int valueCount = 0;
 
@@ -296,10 +298,26 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
 
         void addValueTag(byte tag) {
-            if (valueCount == tags.length) {
-                tags = Arrays.copyOf(tags, Math.max(16, tags.length * 2));
+            // A mono-typed column never reads these back, so recording them would be a bounds
+            // check, a growth check and a store per value for nothing.
+            if (type == TYPE_POLY) {
+                if (valueCount == tags.length) {
+                    tags = Arrays.copyOf(tags, Math.max(16, tags.length * 2));
+                }
+                tags[valueCount] = tag;
             }
-            tags[valueCount++] = tag;
+            valueCount++;
+        }
+
+        /**
+         * Records the type of the values encoded before this column turned polymorphic. They were
+         * all of the column's previous type, which is what made it mono-typed until now.
+         */
+        void backfillTags(byte previousType) {
+            if (valueCount > tags.length) {
+                tags = new byte[Math.max(16, valueCount * 2)];
+            }
+            Arrays.fill(tags, 0, valueCount, previousType);
         }
 
         void resetFrameState() {
@@ -899,6 +917,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         if (col.type == TYPE_UNSET) {
             col.type = valueType;
         } else if (col.type != TYPE_POLY && col.type != valueType) {
+            // The values already in this frame were all of the old type, and nothing recorded
+            // that while the column still looked mono-typed.
+            col.backfillTags(col.type);
             col.type = TYPE_POLY;
         }
         col.addValueTag(valueType);

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -19,7 +19,6 @@ import eu.neverblink.protoc.java.runtime.MessageCollection;
 import eu.neverblink.protoc.java.runtime.RepeatedInt;
 import eu.neverblink.protoc.java.runtime.RepeatedString;
 import java.util.AbstractCollection;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -483,11 +482,17 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
      * packed messages. The identifier numbering runs across frames, but the packing does not:
      * every frame starts a new packed entry.
      */
-    private static final class PackedEntries {
+    private static final class PackedEntries
+        extends AbstractCollection<RdfLookupEntryPacked>
+        implements MessageCollection<RdfLookupEntryPacked, RdfLookupEntryPacked.Mutable>
+    {
 
-        private final ArrayList<RdfLookupEntryPacked.Mutable> entries = new ArrayList<>();
-        // The entry of the currently open run – always the last element of entries, but kept
-        // in a field so that continuing a run does not go through the ArrayList
+        // Pooled packed entry messages, reused across frames: the first `size` hold the
+        // current frame's entries, the rest are kept around for the next frames.
+        private RdfLookupEntryPacked.Mutable[] entries = new RdfLookupEntryPacked.Mutable[0];
+        private int size = 0;
+        // The entry of the currently open run – always entries[size - 1], but kept in a
+        // field so that continuing a run does not go through the array
         private RdfLookupEntryPacked.Mutable current = null;
         // State for resolving 0-compressed lookup entry identifiers
         private int lastAssignedId = 0;
@@ -501,16 +506,60 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             } else {
                 // The id of a fresh entry is passed on as it came, so that a 0 keeps meaning
                 // "continue from the previous frame"
-                current = RdfLookupEntryPacked.newInstance().setId(entryId);
+                current = appendMessage().setId(entryId);
                 current.addValues(value);
-                entries.add(current);
             }
             lastAssignedId = id;
         }
 
-        void resetFrameState() {
-            entries.clear();
+        @Override
+        public RdfLookupEntryPacked.Mutable appendMessage() {
+            if (size == entries.length) {
+                entries = Arrays.copyOf(entries, Math.max(8, entries.length * 2));
+            }
+            RdfLookupEntryPacked.Mutable entry = entries[size];
+            if (entry == null) {
+                entry = RdfLookupEntryPacked.newInstance();
+                entries[size] = entry;
+            } else {
+                // Same reuse rule as the frame buffers: clear resets the previous frame's
+                // values and the cached serialized size
+                entry.clear();
+            }
+            size++;
+            return entry;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            // Keeps the messages around for the next frame
+            size = 0;
             current = null;
+        }
+
+        @Override
+        public Iterator<RdfLookupEntryPacked> iterator() {
+            return new Iterator<>() {
+                private int index = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return index < size;
+                }
+
+                @Override
+                public RdfLookupEntryPacked next() {
+                    if (index >= size) {
+                        throw new NoSuchElementException();
+                    }
+                    return entries[index++];
+                }
+            };
         }
     }
 
@@ -599,9 +648,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         for (final ColumnState col : columns) {
             col.resetFrameState();
         }
-        nameEntries.resetFrameState();
-        prefixEntries.resetFrameState();
-        datatypeEntries.resetFrameState();
+        nameEntries.clear();
+        prefixEntries.clear();
+        datatypeEntries.clear();
         resetUsedIds();
         rowCount = 0;
     }
@@ -655,15 +704,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
         }
 
         frame.setRowCount(rowCount);
-        for (final RdfLookupEntryPacked.Mutable entry : nameEntries.entries) {
-            frame.addNames(entry);
-        }
-        for (final RdfLookupEntryPacked.Mutable entry : prefixEntries.entries) {
-            frame.addPrefixes(entry);
-        }
-        for (final RdfLookupEntryPacked.Mutable entry : datatypeEntries.entries) {
-            frame.addDatatypes(entry);
-        }
+        frame.setNames(nameEntries);
+        frame.setPrefixes(prefixEntries);
+        frame.setDatatypes(datatypeEntries);
 
         // Emit the columns grouped by type, in variable order within each group – the same
         // order in which the column indices were assigned.
@@ -823,7 +866,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
             return;
         }
         // runNode != null implies an active bound run
-        if (col.runNode != null && node.equals(col.runNode)) {
+        if (node.equals(col.runNode)) {
             col.runLength++;
             return;
         }

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -17,7 +17,6 @@ import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 import eu.neverblink.jelly.core.proto.v1.sparql.*;
 import eu.neverblink.jelly.core.sparql.SparqlEncoder;
-import eu.neverblink.protoc.java.runtime.ArrayListMessageCollection;
 import eu.neverblink.protoc.java.runtime.MessageCollection;
 import eu.neverblink.protoc.java.runtime.RepeatedInt;
 import eu.neverblink.protoc.java.runtime.RepeatedString;
@@ -61,8 +60,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     private static final RdfIri ZERO_IRI = RdfIri.newInstance();
 
+    // Returned by the literal makers as a type marker – the literal's parts go into the
+    // column buffers, not into the returned message
+    private static final RdfLiteral LITERAL_MARKER = RdfLiteral.newInstance();
+
     // Not a valid datatype lookup id – marks a literal column that cannot state one datatype
     private static final int MIXED_DATATYPES = -1;
+    // The column datatype of a column that has no literals yet
+    private static final int DATATYPE_NONE = -2;
+    // Per-value marker in litDatatypes for a language-tagged literal
+    private static final int LANG_LITERAL = -1;
 
     /**
      * Reusable store for the SparqlTerm wrappers of a polymorphic column.
@@ -129,6 +136,66 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     }
 
     /**
+     * The same reusable store, for the RdfLiteral messages of a mixed-datatype literal column
+     * or a polymorphic column. Literal values are kept as buffer entries while the frame is
+     * built (see ColumnState), so messages only get materialized here, at frame end.
+     */
+    private static final class LiteralBuffer
+        extends AbstractCollection<RdfLiteral>
+        implements MessageCollection<RdfLiteral, RdfLiteral.Mutable>
+    {
+
+        private RdfLiteral.Mutable[] literals = new RdfLiteral.Mutable[0];
+        private int size = 0;
+
+        @Override
+        public RdfLiteral.Mutable appendMessage() {
+            if (size == literals.length) {
+                literals = Arrays.copyOf(literals, Math.max(8, literals.length * 2));
+            }
+            RdfLiteral.Mutable literal = literals[size];
+            if (literal == null) {
+                literal = RdfLiteral.newInstance();
+                literals[size] = literal;
+            } else {
+                literal.clear();
+            }
+            size++;
+            return literal;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+
+        @Override
+        public void clear() {
+            size = 0;
+        }
+
+        @Override
+        public Iterator<RdfLiteral> iterator() {
+            return new Iterator<>() {
+                private int index = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return index < size;
+                }
+
+                @Override
+                public RdfLiteral next() {
+                    if (index >= size) {
+                        throw new NoSuchElementException();
+                    }
+                    return literals[index++];
+                }
+            };
+        }
+    }
+
+    /**
      * Reusable store for the RdfIri messages a polymorphic column wraps in its SparqlTerms.
      * IRI values are kept as plain ints while the frame is built (see ColumnState), so the
      * messages only get materialized here, at frame end, and only for polymorphic columns.
@@ -175,10 +242,16 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // resolved at frame end, from rawPrefixIds).
         int lastNameId = 0;
 
-        // Encoded run values of the current frame. Strings for bnodes, RdfLiterals for
-        // literals. An IRI is stored as the shared ZERO_IRI marker, with its ids pushed into
-        // nameIds/rawPrefixIds instead.
-        final ArrayList<Object> values = new ArrayList<>();
+        // Datatype shared by all literals of the column so far: a lookup id, 0 for simple
+        // literals, DATATYPE_NONE before the first literal, or MIXED_DATATYPES.
+        int columnDatatype = DATATYPE_NONE;
+
+        // Term type (TYPE_IRI/BNODE/LITERAL) of each encoded value of the frame, in order.
+        // Only read back for polymorphic columns – the values themselves sit in the per-type
+        // buffers below, and a mono-typed column reads its buffer directly.
+        byte[] tags = new byte[0];
+        int valueCount = 0;
+
         // Layout of the current frame
         final RepeatedInt layout = RepeatedInt.newEmptyInstance();
 
@@ -187,17 +260,29 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
         // Uncompressed prefix ids of the frame's IRI values, parallel to nameIds
         final RepeatedInt rawPrefixIds = RepeatedInt.newEmptyInstance();
+        // Datatype lookup id per literal value: 0 for a simple literal, LANG_LITERAL for a
+        // language-tagged one (its tag then sits in litLangtags)
+        final RepeatedInt litDatatypes = RepeatedInt.newEmptyInstance();
+        // Language tags of the frame's language-tagged literals, in order
+        final RepeatedString litLangtags = RepeatedString.newEmptyInstance();
 
-        // Output buffers handed straight to the column messages of the frame being closed, instead
-        // of a fresh one per frame. A column has exactly one type per frame, so only the buffer
-        // matching that type is ever filled. They keep their capacity across frames.
+        // Buffers handed straight to the column messages of the frame being closed, instead
+        // of a fresh one per frame. They keep their capacity across frames.
         final RepeatedInt prefixIds = RepeatedInt.newEmptyInstance();
+        // Bnode labels and literal lexical forms, appended at encode time in value order.
+        // A bnode or single-datatype literal column hands this buffer to its message as-is;
+        // a mixed-datatype or polymorphic column reads it back with a cursor.
         final RepeatedString strings = RepeatedString.newEmptyInstance();
-        final MessageCollection<RdfLiteral, RdfLiteral.Mutable> literals = new ArrayListMessageCollection<>(
-            RdfLiteral::newInstance
-        );
+        final LiteralBuffer literals = new LiteralBuffer();
         final TermBuffer terms = new TermBuffer();
         final IriBuffer polyIris = new IriBuffer();
+
+        void addValueTag(byte tag) {
+            if (valueCount == tags.length) {
+                tags = Arrays.copyOf(tags, Math.max(16, tags.length * 2));
+            }
+            tags[valueCount++] = tag;
+        }
 
         void resetFrameState() {
             runNode = null;
@@ -206,10 +291,13 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             runIsUnbound = false;
             skip = 0;
             lastNameId = 0;
-            values.clear();
+            columnDatatype = DATATYPE_NONE;
+            valueCount = 0;
             layout.clear();
             nameIds.clear();
             rawPrefixIds.clear();
+            litDatatypes.clear();
+            litLangtags.clear();
             prefixIds.clear();
             strings.clear();
             literals.clear();
@@ -219,10 +307,11 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     }
 
     /**
-     * NodeEncoder passed to the converter: same as the underlying encoder, except that IRIs
-     * go straight into the current column's int buffers (with the next-name inference already
-     * applied), and all lookup references are tracked for the frame working-set check.
-     * The RdfIri return value is only the shared ZERO_IRI, serving as a type marker.
+     * NodeEncoder passed to the converter. Unlike the underlying encoder, it does not build
+     * proto messages: every term's parts go straight into the current column's buffers, and
+     * all lookup references are tracked for the frame working-set check. The return values
+     * only carry the term type back to encodeValue – shared markers for IRIs and literals,
+     * the label itself for bnodes.
      */
     private final class ColumnNodeEncoder implements NodeEncoder<TNode> {
 
@@ -257,24 +346,54 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
         @Override
         public String makeBlankNode(String label) {
-            return getNodeEncoder().makeBlankNode(label);
+            final String bnode = getNodeEncoder().makeBlankNode(label);
+            // Straight into the string buffer – a bnode column hands the buffer to its
+            // message as-is, without a copy pass at frame end.
+            currentColumn.strings.add(bnode);
+            return bnode;
         }
 
         @Override
         public RdfLiteral makeSimpleLiteral(String lex) {
-            return getNodeEncoder().makeSimpleLiteral(lex);
+            // No lookup table involved – the underlying encoder (and its cache) is skipped
+            final ColumnState col = currentColumn;
+            col.strings.add(lex);
+            col.litDatatypes.add(0);
+            trackColumnDatatype(col, 0);
+            return LITERAL_MARKER;
         }
 
         @Override
         public RdfLiteral makeLangLiteral(TNode lit, String lex, String lang) {
-            return getNodeEncoder().makeLangLiteral(lit, lex, lang);
+            final ColumnState col = currentColumn;
+            col.strings.add(lex);
+            col.litDatatypes.add(LANG_LITERAL);
+            col.litLangtags.add(lang);
+            // A language-tagged literal always forces the per-value literal representation
+            col.columnDatatype = MIXED_DATATYPES;
+            return LITERAL_MARKER;
         }
 
         @Override
         public RdfLiteral makeDtLiteral(TNode lit, String lex, String dt) {
+            // The underlying encoder is still consulted for the datatype lookup id (and the
+            // lookup entry emission that comes with it)
             final RdfLiteral literal = getNodeEncoder().makeDtLiteral(lit, lex, dt);
-            usedDatatypes.mark(literal.getDatatype());
-            return literal;
+            final int datatype = literal.getDatatype();
+            usedDatatypes.mark(datatype);
+            final ColumnState col = currentColumn;
+            col.strings.add(lex);
+            col.litDatatypes.add(datatype);
+            trackColumnDatatype(col, datatype);
+            return LITERAL_MARKER;
+        }
+
+        private void trackColumnDatatype(ColumnState col, int datatype) {
+            if (col.columnDatatype == DATATYPE_NONE) {
+                col.columnDatatype = datatype;
+            } else if (col.columnDatatype != datatype) {
+                col.columnDatatype = MIXED_DATATYPES;
+            }
         }
 
         @Override
@@ -607,11 +726,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             if (types[i] == TYPE_BNODE) {
                 final ColumnState col = columns[i];
                 final SparqlBnodeColumn.Mutable column = SparqlBnodeColumn.newInstance();
-                final RepeatedString labels = col.strings;
-                for (final Object value : col.values) {
-                    labels.add((String) value);
-                }
-                column.setValues(labels);
+                // The labels were appended to the buffer as they were encoded
+                column.setValues(col.strings);
                 column.setLayouts(col.layout);
                 frame.addBnodeColumns(column);
             }
@@ -620,22 +736,27 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             if (types[i] == TYPE_LITERAL) {
                 final ColumnState col = columns[i];
                 final SparqlLiteralColumn.Mutable column = SparqlLiteralColumn.newInstance();
-                final List<Object> values = col.values;
                 // If every value has the same datatype – the usual case – the column states it
-                // once and carries only the lexical forms.
-                final int datatype = commonDatatype(values);
+                // once and carries only the lexical forms, already sitting in the buffer.
+                // An empty column counts as simple literals – both forms are empty anyway.
+                final int datatype = col.columnDatatype == DATATYPE_NONE ? 0 : col.columnDatatype;
                 if (datatype == MIXED_DATATYPES) {
-                    final MessageCollection<RdfLiteral, RdfLiteral.Mutable> literals = col.literals;
-                    for (final Object value : values) {
-                        literals.add((RdfLiteral) value);
+                    final LiteralBuffer literals = col.literals;
+                    final int litCount = col.litDatatypes.size();
+                    int langIndex = 0;
+                    for (int j = 0; j < litCount; j++) {
+                        final RdfLiteral.Mutable literal = literals.appendMessage().setLex(col.strings.get(j));
+                        final int dt = col.litDatatypes.get(j);
+                        if (dt == LANG_LITERAL) {
+                            literal.setLangtag(col.litLangtags.get(langIndex++));
+                        } else if (dt != 0) {
+                            literal.setDatatype(dt);
+                        }
+                        // dt == 0 is a simple literal, which carries only its lexical form
                     }
                     column.setValues(literals);
                 } else {
-                    final RepeatedString lexValues = col.strings;
-                    for (final Object value : values) {
-                        lexValues.add(((RdfLiteral) value).getLex());
-                    }
-                    column.setLexValues(lexValues);
+                    column.setLexValues(col.strings);
                     if (datatype != 0) {
                         column.setDatatype(datatype);
                     }
@@ -650,28 +771,43 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 final ColumnState col = columns[i];
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
                 final TermBuffer terms = col.terms;
-                // Cursor into the column's IRI ids: the values list holds only markers for
-                // IRIs, the ids themselves sit in nameIds/rawPrefixIds in the same order.
+                // Cursors into the per-type buffers: the tags say which buffer the next value
+                // sits in. Bnode labels and literal lexical forms share the string buffer, in
+                // encoding order.
                 int iriIndex = 0;
+                int stringIndex = 0;
+                int litIndex = 0;
+                int langIndex = 0;
                 // -1 forces the first IRI of the column to carry its prefix id
                 int prevPrefix = -1;
-                for (final Object value : col.values) {
+                for (int v = 0; v < col.valueCount; v++) {
                     final SparqlTerm.Mutable term = terms.appendMessage();
-                    if (value instanceof RdfIri) {
-                        final int nameId = col.nameIds.get(iriIndex);
-                        final int rawPrefix = col.rawPrefixIds.get(iriIndex);
-                        iriIndex++;
-                        final int prefixId = rawPrefix == prevPrefix ? 0 : rawPrefix;
-                        prevPrefix = rawPrefix;
-                        if (prefixId == 0 && nameId == 0) {
-                            term.setIri(ZERO_IRI);
-                        } else {
-                            term.setIri(col.polyIris.append().setPrefixId(prefixId).setNameId(nameId));
+                    switch (col.tags[v]) {
+                        case TYPE_IRI -> {
+                            final int nameId = col.nameIds.get(iriIndex);
+                            final int rawPrefix = col.rawPrefixIds.get(iriIndex);
+                            iriIndex++;
+                            final int prefixId = rawPrefix == prevPrefix ? 0 : rawPrefix;
+                            prevPrefix = rawPrefix;
+                            if (prefixId == 0 && nameId == 0) {
+                                term.setIri(ZERO_IRI);
+                            } else {
+                                term.setIri(col.polyIris.append().setPrefixId(prefixId).setNameId(nameId));
+                            }
                         }
-                    } else if (value instanceof String bnode) {
-                        term.setBnode(bnode);
-                    } else {
-                        term.setLiteral((RdfLiteral) value);
+                        case TYPE_BNODE -> term.setBnode(col.strings.get(stringIndex++));
+                        default -> {
+                            final RdfLiteral.Mutable literal = col.literals
+                                .appendMessage()
+                                .setLex(col.strings.get(stringIndex++));
+                            final int dt = col.litDatatypes.get(litIndex++);
+                            if (dt == LANG_LITERAL) {
+                                literal.setLangtag(col.litLangtags.get(langIndex++));
+                            } else if (dt != 0) {
+                                literal.setDatatype(dt);
+                            }
+                            term.setLiteral(literal);
+                        }
                     }
                 }
                 column.setValues(terms);
@@ -736,7 +872,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         } else if (col.type != TYPE_POLY && col.type != valueType) {
             col.type = TYPE_POLY;
         }
-        col.values.add(encoded);
+        col.addValueTag(valueType);
     }
 
     private void finalizeRun(ColumnState col) {
@@ -760,32 +896,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             col.layout.add(len - MAX_INLINE_LEN);
         }
         col.skip = 0;
-    }
-
-    /**
-     * Returns the datatype id shared by all values of a literal column (0 for simple literals),
-     * or MIXED_DATATYPES if the values have more than one datatype or any of them is
-     * language-tagged. An empty column counts as simple literals – both forms are empty anyway.
-     */
-    private static int commonDatatype(List<Object> values) {
-        int datatype = 0;
-        boolean first = true;
-        for (final Object value : values) {
-            final RdfLiteral literal = (RdfLiteral) value;
-            final int kind = literal.getLiteralKindFieldNumber();
-            if (kind == RdfLiteral.LANGTAG) {
-                return MIXED_DATATYPES;
-            }
-            // A simple literal has no literal kind set at all
-            final int dt = kind == RdfLiteral.DATATYPE ? literal.getDatatype() : 0;
-            if (first) {
-                datatype = dt;
-                first = false;
-            } else if (dt != datatype) {
-                return MIXED_DATATYPES;
-            }
-        }
-        return datatype;
     }
 
     @Override

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -128,6 +128,36 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
     }
 
+    /**
+     * Reusable store for the RdfIri messages a polymorphic column wraps in its SparqlTerms.
+     * IRI values are kept as plain ints while the frame is built (see ColumnState), so the
+     * messages only get materialized here, at frame end, and only for polymorphic columns.
+     */
+    private static final class IriBuffer {
+
+        private RdfIri.Mutable[] iris = new RdfIri.Mutable[0];
+        private int size = 0;
+
+        RdfIri.Mutable append() {
+            if (size == iris.length) {
+                iris = Arrays.copyOf(iris, Math.max(8, iris.length * 2));
+            }
+            RdfIri.Mutable iri = iris[size];
+            if (iri == null) {
+                iri = RdfIri.newInstance();
+                iris[size] = iri;
+            } else {
+                iri.clear();
+            }
+            size++;
+            return iri;
+        }
+
+        void clear() {
+            size = 0;
+        }
+    }
+
     private static final class ColumnState {
 
         // Column type. Sticky once set, only ever escalated to TYPE_POLY.
@@ -141,26 +171,33 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // Number of values emitted exactly once since the last layout exception
         int skip = 0;
 
-        // Per-frame, per-column IRI inference state.
-        // lastPrefixId = -1 forces the first IRI of a column to carry its prefix id.
-        int lastPrefixId = -1;
+        // Per-frame, per-column IRI inference state (the prefix side of the inference is
+        // resolved at frame end, from rawPrefixIds).
         int lastNameId = 0;
 
-        // Encoded run values of the current frame (RdfIri, String or RdfLiteral)
+        // Encoded run values of the current frame. Strings for bnodes, RdfLiterals for
+        // literals. An IRI is stored as the shared ZERO_IRI marker, with its ids pushed into
+        // nameIds/rawPrefixIds instead.
         final ArrayList<Object> values = new ArrayList<>();
         // Layout of the current frame
         final RepeatedInt layout = RepeatedInt.newEmptyInstance();
 
+        // Name ids of the frame's IRI values, with the next-name inference already applied
+        // (0 means "previous + 1").
+        final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
+        // Uncompressed prefix ids of the frame's IRI values, parallel to nameIds
+        final RepeatedInt rawPrefixIds = RepeatedInt.newEmptyInstance();
+
         // Output buffers handed straight to the column messages of the frame being closed, instead
         // of a fresh one per frame. A column has exactly one type per frame, so only the buffer
         // matching that type is ever filled. They keep their capacity across frames.
-        final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
         final RepeatedInt prefixIds = RepeatedInt.newEmptyInstance();
         final RepeatedString strings = RepeatedString.newEmptyInstance();
         final MessageCollection<RdfLiteral, RdfLiteral.Mutable> literals = new ArrayListMessageCollection<>(
             RdfLiteral::newInstance
         );
         final TermBuffer terms = new TermBuffer();
+        final IriBuffer polyIris = new IriBuffer();
 
         void resetFrameState() {
             runNode = null;
@@ -168,59 +205,54 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             runActive = false;
             runIsUnbound = false;
             skip = 0;
-            lastPrefixId = -1;
             lastNameId = 0;
             values.clear();
             layout.clear();
             nameIds.clear();
+            rawPrefixIds.clear();
             prefixIds.clear();
             strings.clear();
             literals.clear();
             terms.clear();
+            polyIris.clear();
         }
     }
 
     /**
      * NodeEncoder passed to the converter: same as the underlying encoder, except that IRIs
-     * are compressed against the current column's inference state, and all lookup references
-     * are tracked for the frame working-set check.
+     * go straight into the current column's int buffers (with the next-name inference already
+     * applied), and all lookup references are tracked for the frame working-set check.
+     * The RdfIri return value is only the shared ZERO_IRI, serving as a type marker.
      */
     private final class ColumnNodeEncoder implements NodeEncoder<TNode> {
 
         @Override
         public RdfIri makeIri(String iri) {
             final RdfIri raw = getNodeEncoder().makeIriRaw(iri);
-            final int prefixId = raw.getPrefixId();
             final int nameId = raw.getNameId();
-            usedNames.mark(nameId);
-            if (prefixId != 0) {
-                usedPrefixes.mark(prefixId);
-            }
             final ColumnState col = currentColumn;
-            final boolean samePrefix = prefixId == col.lastPrefixId;
-            final boolean nextName = nameId == col.lastNameId + 1;
-            col.lastPrefixId = prefixId;
-            col.lastNameId = nameId;
-            if (samePrefix) {
-                if (nextName) {
-                    return ZERO_IRI;
-                }
-                return RdfIri.newInstance().setNameId(nameId);
-            } else if (nextName) {
-                return RdfIri.newInstance().setPrefixId(prefixId);
-            }
-            return raw;
+            appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, raw.getPrefixId(), nameId);
+            return ZERO_IRI;
         }
 
         @Override
         public RdfIri makeIriRaw(String iri) {
             final RdfIri raw = getNodeEncoder().makeIriRaw(iri);
-            usedNames.mark(raw.getNameId());
-            final int prefixId = raw.getPrefixId();
+            // Raw means no next-name inference, so the name id is stored as it is. The decoder
+            // still tracks it as the new "previous name", hence the lastNameId update.
+            final int nameId = raw.getNameId();
+            appendIriIds(currentColumn, nameId, raw.getPrefixId(), nameId);
+            return ZERO_IRI;
+        }
+
+        private void appendIriIds(ColumnState col, int storedNameId, int prefixId, int nameId) {
+            usedNames.mark(nameId);
             if (prefixId != 0) {
                 usedPrefixes.mark(prefixId);
             }
-            return raw;
+            col.nameIds.add(storedNameId);
+            col.rawPrefixIds.add(prefixId);
+            col.lastNameId = nameId;
         }
 
         @Override
@@ -540,34 +572,26 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             if (types[i] == TYPE_IRI) {
                 final ColumnState col = columns[i];
                 final SparqlIriColumn.Mutable column = SparqlIriColumn.newInstance();
-                final RepeatedInt nameIds = col.nameIds;
+                column.setNameIds(col.nameIds);
+                final RepeatedInt rawPrefixIds = col.rawPrefixIds;
+                final int valueCount = rawPrefixIds.size();
                 // The prefix ids keep the "same prefix as the previous IRI" inference of RdfIri.
-                // If the whole column resolves to one prefix – the usual case – it is stated once
-                // instead of once per value.
-                int lastPrefix = 0;
-                int columnPrefix = 0;
+                final int columnPrefix = valueCount == 0 ? 0 : rawPrefixIds.get(0);
                 boolean onePrefix = true;
-                int index = 0;
-                for (final Object value : col.values) {
-                    final RdfIri iri = (RdfIri) value;
-                    nameIds.add(iri.getNameId());
-                    // Resolve the inference to see whether the column really stays on one prefix
-                    final int prefix = iri.getPrefixId();
-                    lastPrefix = prefix == 0 ? lastPrefix : prefix;
-                    if (index == 0) {
-                        columnPrefix = lastPrefix;
-                    } else if (lastPrefix != columnPrefix) {
+                for (int j = 1; j < valueCount; j++) {
+                    if (rawPrefixIds.get(j) != columnPrefix) {
                         onePrefix = false;
+                        break;
                     }
-                    index++;
                 }
-                column.setNameIds(nameIds);
                 final RepeatedInt prefixIds = col.prefixIds;
                 if (!onePrefix) {
-                    // Rare enough to be worth a second pass over the values rather than a buffer
-                    // to stash the raw prefix ids in
-                    for (final Object value : col.values) {
-                        prefixIds.add(((RdfIri) value).getPrefixId());
+                    // prev = -1 forces the first IRI of the column to carry its prefix id
+                    int prev = -1;
+                    for (int j = 0; j < valueCount; j++) {
+                        final int prefix = rawPrefixIds.get(j);
+                        prefixIds.add(prefix == prev ? 0 : prefix);
+                        prev = prefix;
                     }
                     column.setPrefixIds(prefixIds);
                 } else if (columnPrefix != 0) {
@@ -626,10 +650,24 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 final ColumnState col = columns[i];
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
                 final TermBuffer terms = col.terms;
+                // Cursor into the column's IRI ids: the values list holds only markers for
+                // IRIs, the ids themselves sit in nameIds/rawPrefixIds in the same order.
+                int iriIndex = 0;
+                // -1 forces the first IRI of the column to carry its prefix id
+                int prevPrefix = -1;
                 for (final Object value : col.values) {
                     final SparqlTerm.Mutable term = terms.appendMessage();
-                    if (value instanceof RdfIri iri) {
-                        term.setIri(iri);
+                    if (value instanceof RdfIri) {
+                        final int nameId = col.nameIds.get(iriIndex);
+                        final int rawPrefix = col.rawPrefixIds.get(iriIndex);
+                        iriIndex++;
+                        final int prefixId = rawPrefix == prevPrefix ? 0 : rawPrefix;
+                        prevPrefix = rawPrefix;
+                        if (prefixId == 0 && nameId == 0) {
+                            term.setIri(ZERO_IRI);
+                        } else {
+                            term.setIri(col.polyIris.append().setPrefixId(prefixId).setNameId(nameId));
+                        }
                     } else if (value instanceof String bnode) {
                         term.setBnode(bnode);
                     } else {

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -328,20 +328,20 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> impleme
 
     @Override
     public RdfIri makeIri(String iri) {
-        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
-        final int nameId = raw.getNameId();
+        final long ids = lookupIriIds(iri);
+        final int nameId = (int) (ids >>> 32);
         final ColumnState col = currentColumn;
-        appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, raw.getPrefixId(), nameId);
+        appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, (int) ids, nameId);
         return ZERO_IRI;
     }
 
     @Override
     public RdfIri makeIriRaw(String iri) {
-        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
+        final long ids = lookupIriIds(iri);
         // Raw means no next-name inference, so the name id is stored as it is. The decoder
         // still tracks it as the new "previous name", hence the lastNameId update.
-        final int nameId = raw.getNameId();
-        appendIriIds(currentColumn, nameId, raw.getPrefixId(), nameId);
+        final int nameId = (int) (ids >>> 32);
+        appendIriIds(currentColumn, nameId, (int) ids, nameId);
         return ZERO_IRI;
     }
 

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -225,21 +225,39 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
     }
 
+    /**
+     * The buffers only a mixed-datatype or polymorphic column needs: the SparqlTerm wrappers
+     * of a poly column and the pools for the messages materialized at frame end. Split out of
+     * ColumnState and created lazily, so that the mono-typed columns – the usual case – stay
+     * within one cache line and never allocate any of this.
+     */
+    private static final class PolyBuffers {
+
+        final TermBuffer terms = new TermBuffer();
+        final LiteralBuffer literals = new LiteralBuffer();
+        final IriBuffer iris = new IriBuffer();
+
+        void resetFrameState() {
+            terms.clear();
+            literals.clear();
+            iris.clear();
+        }
+    }
+
     private static final class ColumnState {
 
         // Column type. Sticky once set, only ever escalated to TYPE_POLY.
         byte type = TYPE_UNSET;
 
-        // Run-length state
+        // Run-length state. A run is active while runLength > 0; runNode == null then means
+        // a run of unbound cells. Whenever runLength is 0, runNode is null too.
         Object runNode = null;
         int runLength = 0;
-        boolean runIsUnbound = false;
-        boolean runActive = false;
         // Number of values emitted exactly once since the last layout exception
         int skip = 0;
 
         // Per-frame, per-column IRI inference state (the prefix side of the inference is
-        // resolved at frame end, from rawPrefixIds).
+        // resolved at frame end, from the aux ids).
         int lastNameId = 0;
 
         // Datatype shared by all literals of the column so far: a lookup id, 0 for simple
@@ -258,24 +276,26 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // Name ids of the frame's IRI values, with the next-name inference already applied
         // (0 means "previous + 1").
         final RepeatedInt nameIds = RepeatedInt.newEmptyInstance();
-        // Uncompressed prefix ids of the frame's IRI values, parallel to nameIds
-        final RepeatedInt rawPrefixIds = RepeatedInt.newEmptyInstance();
-        // Datatype lookup id per literal value: 0 for a simple literal, LANG_LITERAL for a
-        // language-tagged one (its tag then sits in litLangtags)
-        final RepeatedInt litDatatypes = RepeatedInt.newEmptyInstance();
-        // Language tags of the frame's language-tagged literals, in order
-        final RepeatedString litLangtags = RepeatedString.newEmptyInstance();
-
-        // Buffers handed straight to the column messages of the frame being closed, instead
-        // of a fresh one per frame. They keep their capacity across frames.
-        final RepeatedInt prefixIds = RepeatedInt.newEmptyInstance();
-        // Bnode labels and literal lexical forms, appended at encode time in value order.
-        // A bnode or single-datatype literal column hands this buffer to its message as-is;
-        // a mixed-datatype or polymorphic column reads it back with a cursor.
+        // One auxiliary int per IRI or literal value, in value order: the uncompressed prefix
+        // id of an IRI, or the datatype lookup id of a literal (0 for a simple literal,
+        // LANG_LITERAL for a language-tagged one). Bnodes add nothing. A mono-typed column
+        // thus sees only its own kind of entry.
+        final RepeatedInt auxIds = RepeatedInt.newEmptyInstance();
+        // Bnode labels, literal lexical forms and language tags (right after their lexical
+        // form), appended at encode time in value order. A bnode or single-datatype literal
+        // column hands this buffer to its message as-is – safe, because a language tag forces
+        // MIXED_DATATYPES; a mixed-datatype or polymorphic column reads it back with a cursor.
         final RepeatedString strings = RepeatedString.newEmptyInstance();
-        final LiteralBuffer literals = new LiteralBuffer();
-        final TermBuffer terms = new TermBuffer();
-        final IriBuffer polyIris = new IriBuffer();
+
+        // Lazily created – see PolyBuffers
+        private PolyBuffers poly = null;
+
+        PolyBuffers poly() {
+            if (poly == null) {
+                poly = new PolyBuffers();
+            }
+            return poly;
+        }
 
         void addValueTag(byte tag) {
             if (valueCount == tags.length) {
@@ -287,22 +307,17 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         void resetFrameState() {
             runNode = null;
             runLength = 0;
-            runActive = false;
-            runIsUnbound = false;
             skip = 0;
             lastNameId = 0;
             columnDatatype = DATATYPE_NONE;
             valueCount = 0;
             layout.clear();
             nameIds.clear();
-            rawPrefixIds.clear();
-            litDatatypes.clear();
-            litLangtags.clear();
-            prefixIds.clear();
+            auxIds.clear();
             strings.clear();
-            literals.clear();
-            terms.clear();
-            polyIris.clear();
+            if (poly != null) {
+                poly.resetFrameState();
+            }
         }
     }
 
@@ -340,7 +355,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 usedPrefixes.mark(prefixId);
             }
             col.nameIds.add(storedNameId);
-            col.rawPrefixIds.add(prefixId);
+            col.auxIds.add(prefixId);
             col.lastNameId = nameId;
         }
 
@@ -358,7 +373,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             // No lookup table involved – the underlying encoder (and its cache) is skipped
             final ColumnState col = currentColumn;
             col.strings.add(lex);
-            col.litDatatypes.add(0);
+            col.auxIds.add(0);
             trackColumnDatatype(col, 0);
             return LITERAL_MARKER;
         }
@@ -367,8 +382,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         public RdfLiteral makeLangLiteral(TNode lit, String lex, String lang) {
             final ColumnState col = currentColumn;
             col.strings.add(lex);
-            col.litDatatypes.add(LANG_LITERAL);
-            col.litLangtags.add(lang);
+            col.strings.add(lang);
+            col.auxIds.add(LANG_LITERAL);
             // A language-tagged literal always forces the per-value literal representation
             col.columnDatatype = MIXED_DATATYPES;
             return LITERAL_MARKER;
@@ -383,7 +398,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             usedDatatypes.mark(datatype);
             final ColumnState col = currentColumn;
             col.strings.add(lex);
-            col.litDatatypes.add(datatype);
+            col.auxIds.add(datatype);
             trackColumnDatatype(col, datatype);
             return LITERAL_MARKER;
         }
@@ -637,9 +652,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
         beginFrame();
         for (final ColumnState col : columns) {
-            if (col.runActive && col.runIsUnbound) {
+            if (col.runLength > 0 && col.runNode == null) {
                 // Trailing unbound run – omitted, the decoder pads with unbound cells.
-                col.runActive = false;
+                col.runLength = 0;
             } else {
                 finalizeRun(col);
             }
@@ -692,30 +707,35 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 final ColumnState col = columns[i];
                 final SparqlIriColumn.Mutable column = SparqlIriColumn.newInstance();
                 column.setNameIds(col.nameIds);
-                final RepeatedInt rawPrefixIds = col.rawPrefixIds;
-                final int valueCount = rawPrefixIds.size();
-                // The prefix ids keep the "same prefix as the previous IRI" inference of RdfIri.
-                final int columnPrefix = valueCount == 0 ? 0 : rawPrefixIds.get(0);
+                // For an IRI column the aux ids are exactly its uncompressed prefix ids.
+                // If the whole column stays on one prefix – the usual case – it is stated
+                // once instead of once per value.
+                final RepeatedInt prefixes = col.auxIds;
+                final int valueCount = prefixes.size();
+                final int columnPrefix = valueCount == 0 ? 0 : prefixes.get(0);
                 boolean onePrefix = true;
                 for (int j = 1; j < valueCount; j++) {
-                    if (rawPrefixIds.get(j) != columnPrefix) {
+                    if (prefixes.get(j) != columnPrefix) {
                         onePrefix = false;
                         break;
                     }
                 }
-                final RepeatedInt prefixIds = col.prefixIds;
                 if (!onePrefix) {
-                    // prev = -1 forces the first IRI of the column to carry its prefix id
+                    // Rewrite the buffer into the "same prefix as the previous IRI" inference
+                    // of RdfIri in place – the raw value only has to survive one step, in prev.
+                    // prev = -1 forces the first IRI of the column to carry its prefix id.
+                    final int[] raw = prefixes.array();
                     int prev = -1;
                     for (int j = 0; j < valueCount; j++) {
-                        final int prefix = rawPrefixIds.get(j);
-                        prefixIds.add(prefix == prev ? 0 : prefix);
+                        final int prefix = raw[j];
+                        raw[j] = prefix == prev ? 0 : prefix;
                         prev = prefix;
                     }
-                    column.setPrefixIds(prefixIds);
+                    column.setPrefixIds(prefixes);
                 } else if (columnPrefix != 0) {
-                    prefixIds.add(columnPrefix);
-                    column.setPrefixIds(prefixIds);
+                    prefixes.clear();
+                    prefixes.add(columnPrefix);
+                    column.setPrefixIds(prefixes);
                 }
                 // Otherwise every value has prefix id 0, which the decoder assumes anyway
                 column.setLayouts(col.layout);
@@ -741,14 +761,17 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 // An empty column counts as simple literals – both forms are empty anyway.
                 final int datatype = col.columnDatatype == DATATYPE_NONE ? 0 : col.columnDatatype;
                 if (datatype == MIXED_DATATYPES) {
-                    final LiteralBuffer literals = col.literals;
-                    final int litCount = col.litDatatypes.size();
-                    int langIndex = 0;
+                    // For a literal column the aux ids are exactly its datatype ids
+                    final LiteralBuffer literals = col.poly().literals;
+                    final int litCount = col.auxIds.size();
+                    int stringIndex = 0;
                     for (int j = 0; j < litCount; j++) {
-                        final RdfLiteral.Mutable literal = literals.appendMessage().setLex(col.strings.get(j));
-                        final int dt = col.litDatatypes.get(j);
+                        final RdfLiteral.Mutable literal = literals
+                            .appendMessage()
+                            .setLex(col.strings.get(stringIndex++));
+                        final int dt = col.auxIds.get(j);
                         if (dt == LANG_LITERAL) {
-                            literal.setLangtag(col.litLangtags.get(langIndex++));
+                            literal.setLangtag(col.strings.get(stringIndex++));
                         } else if (dt != 0) {
                             literal.setDatatype(dt);
                         }
@@ -770,39 +793,38 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             if (types[i] == TYPE_POLY) {
                 final ColumnState col = columns[i];
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
-                final TermBuffer terms = col.terms;
+                final PolyBuffers poly = col.poly();
+                final TermBuffer terms = poly.terms;
                 // Cursors into the per-type buffers: the tags say which buffer the next value
-                // sits in. Bnode labels and literal lexical forms share the string buffer, in
-                // encoding order.
+                // sits in. IRIs and literals share the aux buffer; bnode labels and literal
+                // lexical forms (with their language tags) share the string buffer.
                 int iriIndex = 0;
+                int auxIndex = 0;
                 int stringIndex = 0;
-                int litIndex = 0;
-                int langIndex = 0;
                 // -1 forces the first IRI of the column to carry its prefix id
                 int prevPrefix = -1;
                 for (int v = 0; v < col.valueCount; v++) {
                     final SparqlTerm.Mutable term = terms.appendMessage();
                     switch (col.tags[v]) {
                         case TYPE_IRI -> {
-                            final int nameId = col.nameIds.get(iriIndex);
-                            final int rawPrefix = col.rawPrefixIds.get(iriIndex);
-                            iriIndex++;
+                            final int nameId = col.nameIds.get(iriIndex++);
+                            final int rawPrefix = col.auxIds.get(auxIndex++);
                             final int prefixId = rawPrefix == prevPrefix ? 0 : rawPrefix;
                             prevPrefix = rawPrefix;
                             if (prefixId == 0 && nameId == 0) {
                                 term.setIri(ZERO_IRI);
                             } else {
-                                term.setIri(col.polyIris.append().setPrefixId(prefixId).setNameId(nameId));
+                                term.setIri(poly.iris.append().setPrefixId(prefixId).setNameId(nameId));
                             }
                         }
                         case TYPE_BNODE -> term.setBnode(col.strings.get(stringIndex++));
                         default -> {
-                            final RdfLiteral.Mutable literal = col.literals
+                            final RdfLiteral.Mutable literal = poly.literals
                                 .appendMessage()
                                 .setLex(col.strings.get(stringIndex++));
-                            final int dt = col.litDatatypes.get(litIndex++);
+                            final int dt = col.auxIds.get(auxIndex++);
                             if (dt == LANG_LITERAL) {
-                                literal.setLangtag(col.litLangtags.get(langIndex++));
+                                literal.setLangtag(col.strings.get(stringIndex++));
                             } else if (dt != 0) {
                                 literal.setDatatype(dt);
                             }
@@ -827,24 +849,20 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
     private void addCell(ColumnState col, TNode node) {
         if (node == null) {
-            if (col.runActive && col.runIsUnbound) {
+            if (col.runLength > 0 && col.runNode == null) {
                 col.runLength++;
                 return;
             }
             finalizeRun(col);
-            col.runActive = true;
-            col.runIsUnbound = true;
             col.runLength = 1;
-            col.runNode = null;
             return;
         }
-        if (col.runActive && !col.runIsUnbound && node.equals(col.runNode)) {
+        // runNode != null implies an active bound run
+        if (col.runNode != null && node.equals(col.runNode)) {
             col.runLength++;
             return;
         }
         finalizeRun(col);
-        col.runActive = true;
-        col.runIsUnbound = false;
         col.runLength = 1;
         col.runNode = node;
         encodeValue(col, node);
@@ -876,17 +894,18 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     }
 
     private void finalizeRun(ColumnState col) {
-        if (!col.runActive) {
+        if (col.runLength == 0) {
             return;
         }
-        col.runActive = false;
-        if (col.runIsUnbound) {
+        if (col.runNode == null) {
             emitException(col, KIND_UNBOUND, col.runLength - 1);
         } else if (col.runLength >= 2) {
             emitException(col, KIND_REPEAT, col.runLength - 2);
         } else {
             col.skip++;
         }
+        col.runLength = 0;
+        col.runNode = null;
     }
 
     private void emitException(ColumnState col, int kind, int len) {

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -36,7 +36,7 @@ import java.util.NoSuchElementException;
  */
 @ExperimentalApi
 @InternalApi
-public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
+public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> implements NodeEncoder<TNode> {
 
     private static final byte TYPE_UNSET = 0;
     private static final byte TYPE_IRI = 1;
@@ -244,6 +244,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
         // Column type. Sticky once set, only ever escalated to TYPE_POLY.
         byte type = TYPE_UNSET;
+        // The effective type this column had in the last emitted header, TYPE_UNSET before
+        // the first one. Like type, this survives frame resets.
+        byte lastEmittedType = TYPE_UNSET;
 
         // Run-length state. A run is active while runLength > 0; runNode == null then means
         // a run of unbound cells. Whenever runLength is 0, runNode is null too.
@@ -317,115 +320,110 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
     }
 
-    /**
-     * NodeEncoder passed to the converter. Unlike the underlying encoder, it does not build
-     * proto messages: every term's parts go straight into the current column's buffers, and
-     * all lookup references are tracked for the frame working-set check. The return values
-     * only carry the term type back to encodeValue – shared markers for IRIs and literals,
-     * the label itself for bnodes.
-     */
-    private final class ColumnNodeEncoder implements NodeEncoder<TNode> {
+    // The encoder is itself the NodeEncoder passed to the converter – a separate object would
+    // only add an indirection to every maker call. Unlike the underlying encoder, the maker
+    // methods below do not build proto messages: every term's parts go straight into the
+    // current column's buffers, and all lookup references are tracked for the frame
+    // working-set check. The return values only carry the term type back to encodeValue –
+    // shared markers for IRIs and literals, the label itself for bnodes.
 
-        @Override
-        public RdfIri makeIri(String iri) {
-            final RdfIri raw = getNodeEncoder().makeIriRaw(iri);
-            final int nameId = raw.getNameId();
-            final ColumnState col = currentColumn;
-            appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, raw.getPrefixId(), nameId);
-            return ZERO_IRI;
+    @Override
+    public RdfIri makeIri(String iri) {
+        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
+        final int nameId = raw.getNameId();
+        final ColumnState col = currentColumn;
+        appendIriIds(col, nameId == col.lastNameId + 1 ? 0 : nameId, raw.getPrefixId(), nameId);
+        return ZERO_IRI;
+    }
+
+    @Override
+    public RdfIri makeIriRaw(String iri) {
+        final RdfIri raw = getLookupEncoder().makeIriRaw(iri);
+        // Raw means no next-name inference, so the name id is stored as it is. The decoder
+        // still tracks it as the new "previous name", hence the lastNameId update.
+        final int nameId = raw.getNameId();
+        appendIriIds(currentColumn, nameId, raw.getPrefixId(), nameId);
+        return ZERO_IRI;
+    }
+
+    private void appendIriIds(ColumnState col, int storedNameId, int prefixId, int nameId) {
+        markUsed(usedNames, nameId);
+        if (prefixId != 0) {
+            markUsed(usedPrefixes, prefixId);
         }
+        col.nameIds.add(storedNameId);
+        col.auxIds.add(prefixId);
+        col.lastNameId = nameId;
+    }
 
-        @Override
-        public RdfIri makeIriRaw(String iri) {
-            final RdfIri raw = getNodeEncoder().makeIriRaw(iri);
-            // Raw means no next-name inference, so the name id is stored as it is. The decoder
-            // still tracks it as the new "previous name", hence the lastNameId update.
-            final int nameId = raw.getNameId();
-            appendIriIds(currentColumn, nameId, raw.getPrefixId(), nameId);
-            return ZERO_IRI;
-        }
+    @Override
+    public String makeBlankNode(String label) {
+        final String bnode = getLookupEncoder().makeBlankNode(label);
+        // Straight into the string buffer – a bnode column hands the buffer to its
+        // message as-is, without a copy pass at frame end.
+        currentColumn.strings.add(bnode);
+        return bnode;
+    }
 
-        private void appendIriIds(ColumnState col, int storedNameId, int prefixId, int nameId) {
-            markUsed(usedNames, nameId);
-            if (prefixId != 0) {
-                markUsed(usedPrefixes, prefixId);
-            }
-            col.nameIds.add(storedNameId);
-            col.auxIds.add(prefixId);
-            col.lastNameId = nameId;
-        }
+    @Override
+    public RdfLiteral makeSimpleLiteral(String lex) {
+        // No lookup table involved – the underlying encoder (and its cache) is skipped
+        final ColumnState col = currentColumn;
+        col.strings.add(lex);
+        col.auxIds.add(0);
+        trackColumnDatatype(col, 0);
+        return LITERAL_MARKER;
+    }
 
-        @Override
-        public String makeBlankNode(String label) {
-            final String bnode = getNodeEncoder().makeBlankNode(label);
-            // Straight into the string buffer – a bnode column hands the buffer to its
-            // message as-is, without a copy pass at frame end.
-            currentColumn.strings.add(bnode);
-            return bnode;
-        }
+    @Override
+    public RdfLiteral makeLangLiteral(TNode lit, String lex, String lang) {
+        final ColumnState col = currentColumn;
+        col.strings.add(lex);
+        col.strings.add(lang);
+        col.auxIds.add(LANG_LITERAL);
+        // A language-tagged literal always forces the per-value literal representation
+        col.columnDatatype = MIXED_DATATYPES;
+        return LITERAL_MARKER;
+    }
 
-        @Override
-        public RdfLiteral makeSimpleLiteral(String lex) {
-            // No lookup table involved – the underlying encoder (and its cache) is skipped
-            final ColumnState col = currentColumn;
-            col.strings.add(lex);
-            col.auxIds.add(0);
-            trackColumnDatatype(col, 0);
-            return LITERAL_MARKER;
-        }
+    @Override
+    public RdfLiteral makeDtLiteral(TNode lit, String lex, String dt) {
+        // The underlying encoder is still consulted for the datatype lookup id (and the
+        // lookup entry emission that comes with it)
+        final RdfLiteral literal = getLookupEncoder().makeDtLiteral(lit, lex, dt);
+        final int datatype = literal.getDatatype();
+        markUsed(usedDatatypes, datatype);
+        final ColumnState col = currentColumn;
+        col.strings.add(lex);
+        col.auxIds.add(datatype);
+        trackColumnDatatype(col, datatype);
+        return LITERAL_MARKER;
+    }
 
-        @Override
-        public RdfLiteral makeLangLiteral(TNode lit, String lex, String lang) {
-            final ColumnState col = currentColumn;
-            col.strings.add(lex);
-            col.strings.add(lang);
-            col.auxIds.add(LANG_LITERAL);
-            // A language-tagged literal always forces the per-value literal representation
+    private void trackColumnDatatype(ColumnState col, int datatype) {
+        if (col.columnDatatype == DATATYPE_NONE) {
+            col.columnDatatype = datatype;
+        } else if (col.columnDatatype != datatype) {
             col.columnDatatype = MIXED_DATATYPES;
-            return LITERAL_MARKER;
         }
+    }
 
-        @Override
-        public RdfLiteral makeDtLiteral(TNode lit, String lex, String dt) {
-            // The underlying encoder is still consulted for the datatype lookup id (and the
-            // lookup entry emission that comes with it)
-            final RdfLiteral literal = getNodeEncoder().makeDtLiteral(lit, lex, dt);
-            final int datatype = literal.getDatatype();
-            markUsed(usedDatatypes, datatype);
-            final ColumnState col = currentColumn;
-            col.strings.add(lex);
-            col.auxIds.add(datatype);
-            trackColumnDatatype(col, datatype);
-            return LITERAL_MARKER;
-        }
+    @Override
+    public RdfTriple makeQuotedTriple(TNode s, TNode p, TNode o) {
+        throw new RdfProtoSerializationError("RDF-star quoted triples are not supported in Jelly-SPARQL.");
+    }
 
-        private void trackColumnDatatype(ColumnState col, int datatype) {
-            if (col.columnDatatype == DATATYPE_NONE) {
-                col.columnDatatype = datatype;
-            } else if (col.columnDatatype != datatype) {
-                col.columnDatatype = MIXED_DATATYPES;
-            }
-        }
-
-        @Override
-        public RdfTriple makeQuotedTriple(TNode s, TNode p, TNode o) {
-            throw new RdfProtoSerializationError("RDF-star quoted triples are not supported in Jelly-SPARQL.");
-        }
-
-        @Override
-        public RdfDefaultGraph makeDefaultGraph() {
-            throw new RdfProtoSerializationError("The default graph is not a valid SPARQL result binding.");
-        }
+    @Override
+    public RdfDefaultGraph makeDefaultGraph() {
+        throw new RdfProtoSerializationError("The default graph is not a valid SPARQL result binding.");
     }
 
     private String[] variableNames = null;
     private ColumnState[] columns = null;
-    private byte[] lastEmittedTypes = null;
     private int rowCount = 0;
     private boolean firstFrame = true;
 
     private ColumnState currentColumn = null;
-    private final ColumnNodeEncoder columnNodeEncoder = new ColumnNodeEncoder();
 
     // True while the buffers still hold the contents of the frame endFrame last returned.
     private boolean framePending = false;
@@ -628,18 +626,22 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             frame.setOptions(options);
         }
 
-        // Effective column types for this frame: never-bound columns are emitted as IRI columns.
-        final byte[] types = new byte[columns.length];
-        for (int i = 0; i < columns.length; i++) {
-            types[i] = columns[i].type == TYPE_UNSET ? TYPE_IRI : columns[i].type;
+        // Effective column types for this frame vs the last emitted header: any difference
+        // means the header has to be restated.
+        boolean typesChanged = false;
+        for (final ColumnState col : columns) {
+            if (effectiveType(col) != col.lastEmittedType) {
+                typesChanged = true;
+                break;
+            }
         }
-        if (firstFrame || !Arrays.equals(types, lastEmittedTypes)) {
+        if (firstFrame || typesChanged) {
             // Emit (or restate) the header
             final int[] columnIndices = new int[columns.length];
             int nextIndex = 0;
             for (byte type = TYPE_IRI; type <= TYPE_POLY; type++) {
-                for (int i = 0; i < types.length; i++) {
-                    if (types[i] == type) {
+                for (int i = 0; i < columns.length; i++) {
+                    if (effectiveType(columns[i]) == type) {
                         columnIndices[i] = nextIndex++;
                     }
                 }
@@ -648,8 +650,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
                 frame.addVariables(
                     SparqlVariable.newInstance().setName(variableNames[i]).setColumnIndex(columnIndices[i])
                 );
+                columns[i].lastEmittedType = effectiveType(columns[i]);
             }
-            lastEmittedTypes = types;
         }
 
         frame.setRowCount(rowCount);
@@ -666,8 +668,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         // Emit the columns grouped by type, in variable order within each group – the same
         // order in which the column indices were assigned.
         for (int i = 0; i < columns.length; i++) {
-            if (types[i] == TYPE_IRI) {
-                final ColumnState col = columns[i];
+            final ColumnState col = columns[i];
+            if (effectiveType(col) == TYPE_IRI) {
                 final SparqlIriColumn.Mutable column = SparqlIriColumn.newInstance();
                 column.setNameIds(col.nameIds);
                 // For an IRI column the aux ids are exactly its uncompressed prefix ids.
@@ -706,8 +708,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             }
         }
         for (int i = 0; i < columns.length; i++) {
-            if (types[i] == TYPE_BNODE) {
-                final ColumnState col = columns[i];
+            final ColumnState col = columns[i];
+            if (effectiveType(col) == TYPE_BNODE) {
                 final SparqlBnodeColumn.Mutable column = SparqlBnodeColumn.newInstance();
                 // The labels were appended to the buffer as they were encoded
                 column.setValues(col.strings);
@@ -716,8 +718,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             }
         }
         for (int i = 0; i < columns.length; i++) {
-            if (types[i] == TYPE_LITERAL) {
-                final ColumnState col = columns[i];
+            final ColumnState col = columns[i];
+            if (effectiveType(col) == TYPE_LITERAL) {
                 final SparqlLiteralColumn.Mutable column = SparqlLiteralColumn.newInstance();
                 // If every value has the same datatype – the usual case – the column states it
                 // once and carries only the lexical forms, already sitting in the buffer.
@@ -753,8 +755,8 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             }
         }
         for (int i = 0; i < columns.length; i++) {
-            if (types[i] == TYPE_POLY) {
-                final ColumnState col = columns[i];
+            final ColumnState col = columns[i];
+            if (effectiveType(col) == TYPE_POLY) {
                 final SparqlPolyColumn.Mutable column = SparqlPolyColumn.newInstance();
                 final PolyBuffers poly = col.poly();
                 final TermBuffer terms = poly.terms;
@@ -833,7 +835,7 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
     private void encodeValue(ColumnState col, TNode node) {
         currentColumn = col;
-        final Object encoded = converter.nodeToProto(columnNodeEncoder, node);
+        final Object encoded = converter.nodeToProto(this, node);
         final byte valueType;
         if (encoded instanceof RdfIri) {
             valueType = TYPE_IRI;
@@ -854,6 +856,11 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
             col.type = TYPE_POLY;
         }
         col.addValueTag(valueType);
+    }
+
+    // Never-bound columns are emitted as IRI columns
+    private static byte effectiveType(ColumnState col) {
+        return col.type == TYPE_UNSET ? TYPE_IRI : col.type;
     }
 
     private void finalizeRun(ColumnState col) {

--- a/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
+++ b/core-sparql/src/main/java/eu/neverblink/jelly/core/sparql/internal/SparqlEncoderImpl.java
@@ -6,14 +6,12 @@ import eu.neverblink.jelly.core.NodeEncoder;
 import eu.neverblink.jelly.core.ProtoEncoderConverter;
 import eu.neverblink.jelly.core.RdfProtoSerializationError;
 import eu.neverblink.jelly.core.proto.v1.RdfDatatypeEntry;
-import eu.neverblink.jelly.core.proto.v1.RdfDatatypeEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfDefaultGraph;
 import eu.neverblink.jelly.core.proto.v1.RdfIri;
 import eu.neverblink.jelly.core.proto.v1.RdfLiteral;
+import eu.neverblink.jelly.core.proto.v1.RdfLookupEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfNameEntry;
-import eu.neverblink.jelly.core.proto.v1.RdfNameEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntry;
-import eu.neverblink.jelly.core.proto.v1.RdfPrefixEntryPacked;
 import eu.neverblink.jelly.core.proto.v1.RdfTriple;
 import eu.neverblink.jelly.core.proto.v1.sparql.*;
 import eu.neverblink.jelly.core.sparql.SparqlEncoder;
@@ -26,8 +24,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.function.BiConsumer;
-import java.util.function.IntFunction;
 
 /**
  * Implementation of SparqlEncoder.
@@ -453,9 +449,9 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
     private final long[] usedDatatypes;
 
     // Lookup entries collected for the current frame, packed into runs of consecutive ids
-    private final PackedEntries<RdfNameEntryPacked.Mutable> nameEntries;
-    private final PackedEntries<RdfPrefixEntryPacked.Mutable> prefixEntries;
-    private final PackedEntries<RdfDatatypeEntryPacked.Mutable> datatypeEntries;
+    private final PackedEntries nameEntries = new PackedEntries();
+    private final PackedEntries prefixEntries = new PackedEntries();
+    private final PackedEntries datatypeEntries = new PackedEntries();
 
     // Bit words for 1-based ids up to tableSize, plus the counter slot in front
     private static long[] newUsedIds(int tableSize) {
@@ -488,39 +484,27 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
      * Collects the lookup entries of a frame, coalescing consecutively numbered entries into
      * packed messages. The identifier numbering runs across frames, but the packing does not:
      * every frame starts a new packed entry.
-     *
-     * @param <T> the packed entry message type
      */
-    private static final class PackedEntries<T> {
+    private static final class PackedEntries {
 
-        private final long[] used;
-        private final String kind;
-        private final IntFunction<T> factory;
-        private final BiConsumer<T, String> adder;
-
-        private final ArrayList<T> entries = new ArrayList<>();
-        private T current = null;
+        private final ArrayList<RdfLookupEntryPacked.Mutable> entries = new ArrayList<>();
+        // The entry of the currently open run – always the last element of entries, but kept
+        // in a field so that continuing a run does not go through the ArrayList
+        private RdfLookupEntryPacked.Mutable current = null;
         // State for resolving 0-compressed lookup entry identifiers
         private int lastAssignedId = 0;
 
-        PackedEntries(long[] used, String kind, IntFunction<T> factory, BiConsumer<T, String> adder) {
-            this.used = used;
-            this.kind = kind;
-            this.factory = factory;
-            this.adder = adder;
-        }
-
-        void append(int entryId, String value) {
+        void append(long[] used, String kind, int entryId, String value) {
             final int id = entryId == 0 ? lastAssignedId + 1 : entryId;
             checkAndMarkUsed(used, id, kind);
             if (current != null && id == lastAssignedId + 1) {
                 // Continues the open run – the packed entry numbers it implicitly
-                adder.accept(current, value);
+                current.addValues(value);
             } else {
                 // The id of a fresh entry is passed on as it came, so that a 0 keeps meaning
                 // "continue from the previous frame"
-                current = factory.apply(entryId);
-                adder.accept(current, value);
+                current = RdfLookupEntryPacked.newInstance().setId(entryId);
+                current.addValues(value);
                 entries.add(current);
             }
             lastAssignedId = id;
@@ -543,24 +527,6 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         usedNames = newUsedIds(options.getMaxNameTableSize());
         usedPrefixes = newUsedIds(options.getMaxPrefixTableSize());
         usedDatatypes = newUsedIds(options.getMaxDatatypeTableSize());
-        nameEntries = new PackedEntries<>(
-            usedNames,
-            "name",
-            id -> RdfNameEntryPacked.newInstance().setId(id),
-            RdfNameEntryPacked.Mutable::addValues
-        );
-        prefixEntries = new PackedEntries<>(
-            usedPrefixes,
-            "prefix",
-            id -> RdfPrefixEntryPacked.newInstance().setId(id),
-            RdfPrefixEntryPacked.Mutable::addValues
-        );
-        datatypeEntries = new PackedEntries<>(
-            usedDatatypes,
-            "datatype",
-            id -> RdfDatatypeEntryPacked.newInstance().setId(id),
-            RdfDatatypeEntryPacked.Mutable::addValues
-        );
     }
 
     @Override
@@ -687,13 +653,13 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
         }
 
         frame.setRowCount(rowCount);
-        for (final RdfNameEntryPacked.Mutable entry : nameEntries.entries) {
+        for (final RdfLookupEntryPacked.Mutable entry : nameEntries.entries) {
             frame.addNames(entry);
         }
-        for (final RdfPrefixEntryPacked.Mutable entry : prefixEntries.entries) {
+        for (final RdfLookupEntryPacked.Mutable entry : prefixEntries.entries) {
             frame.addPrefixes(entry);
         }
-        for (final RdfDatatypeEntryPacked.Mutable entry : datatypeEntries.entries) {
+        for (final RdfLookupEntryPacked.Mutable entry : datatypeEntries.entries) {
             frame.addDatatypes(entry);
         }
 
@@ -916,17 +882,17 @@ public final class SparqlEncoderImpl<TNode> extends SparqlEncoder<TNode> {
 
     @Override
     public void appendNameEntry(RdfNameEntry nameEntry) {
-        nameEntries.append(nameEntry.getId(), nameEntry.getValue());
+        nameEntries.append(usedNames, "name", nameEntry.getId(), nameEntry.getValue());
     }
 
     @Override
     public void appendPrefixEntry(RdfPrefixEntry prefixEntry) {
-        prefixEntries.append(prefixEntry.getId(), prefixEntry.getValue());
+        prefixEntries.append(usedPrefixes, "prefix", prefixEntry.getId(), prefixEntry.getValue());
     }
 
     @Override
     public void appendDatatypeEntry(RdfDatatypeEntry datatypeEntry) {
-        datatypeEntries.append(datatypeEntry.getId(), datatypeEntry.getValue());
+        datatypeEntries.append(usedDatatypes, "datatype", datatypeEntry.getId(), datatypeEntry.getValue());
     }
 
     @Override

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlDecoderSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlDecoderSpec.scala
@@ -2,12 +2,7 @@ package eu.neverblink.jelly.core.sparql
 
 import eu.neverblink.jelly.core.RdfProtoDeserializationError
 import eu.neverblink.jelly.core.helpers.Mrl.*
-import eu.neverblink.jelly.core.proto.v1.{
-  RdfDatatypeEntryPacked,
-  RdfLiteral,
-  RdfNameEntryPacked,
-  RdfPrefixEntryPacked,
-}
+import eu.neverblink.jelly.core.proto.v1.{RdfLiteral, RdfLookupEntryPacked}
 import eu.neverblink.jelly.core.proto.v1.sparql.*
 import eu.neverblink.jelly.core.sparql.helpers.{MockSparqlConverterFactory, ResultsCollector}
 import org.scalatest.matchers.should.Matchers
@@ -30,7 +25,7 @@ class SparqlDecoderSpec extends AnyWordSpec, Matchers:
       .setOptions(JellySparqlOptions.SMALL)
       .setRowCount(rowCount)
       .addVariables(SparqlVariable.newInstance().setName("x").setColumnIndex(0))
-      .addNames(RdfNameEntryPacked.newInstance().setId(1).addValues("https://test.org/x"))
+      .addNames(RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/x"))
 
   private def iriColumn(valueCount: Int, layout: Seq[Int]) =
     val column = SparqlIriColumn.newInstance()
@@ -227,10 +222,10 @@ class SparqlDecoderSpec extends AnyWordSpec, Matchers:
         .setOptions(JellySparqlOptions.SMALL)
         .setRowCount(4)
         .addVariables(SparqlVariable.newInstance().setName("x").setColumnIndex(0))
-        .addNames(RdfNameEntryPacked.newInstance().addValues("a").addValues("b"))
-        .addNames(RdfNameEntryPacked.newInstance().setId(5).addValues("e").addValues("f"))
+        .addNames(RdfLookupEntryPacked.newInstance().addValues("a").addValues("b"))
+        .addNames(RdfLookupEntryPacked.newInstance().setId(5).addValues("e").addValues("f"))
         .addPrefixes(
-          RdfPrefixEntryPacked.newInstance().addValues("https://one.org/").addValues(
+          RdfLookupEntryPacked.newInstance().addValues("https://one.org/").addValues(
             "https://two.org/",
           ),
         )
@@ -245,7 +240,7 @@ class SparqlDecoderSpec extends AnyWordSpec, Matchers:
       val frame = frameWithOneVariable(1)
         .addVariables(SparqlVariable.newInstance().setName("y").setColumnIndex(1))
         .addDatatypes(
-          RdfDatatypeEntryPacked
+          RdfLookupEntryPacked
             .newInstance()
             .addValues("https://test.org/int")
             .addValues("https://test.org/double"),
@@ -316,10 +311,10 @@ class SparqlDecoderSpec extends AnyWordSpec, Matchers:
       val frame = frameWithOneVariable(3)
         // Overwrites the name entry that frameWithOneVariable sets for id 1
         .addNames(
-          RdfNameEntryPacked.newInstance().setId(1).addValues("a").addValues("b").addValues("c"),
+          RdfLookupEntryPacked.newInstance().setId(1).addValues("a").addValues("b").addValues("c"),
         )
         .addPrefixes(
-          RdfPrefixEntryPacked
+          RdfLookupEntryPacked
             .newInstance()
             .setId(1)
             .addValues("https://one.org/")
@@ -358,7 +353,7 @@ class SparqlDecoderSpec extends AnyWordSpec, Matchers:
       val collector = ResultsCollector()
       val frame = frameWithOneVariable(2)
         .addDatatypes(
-          RdfDatatypeEntryPacked.newInstance().setId(1).addValues("https://test.org/int"),
+          RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/int"),
         )
         .addLiteralColumns(column)
       newDecoder(collector).ingestFrame(frame)

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
@@ -8,7 +8,6 @@ import eu.neverblink.jelly.core.sparql.internal.SparqlEncoderImpl
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import java.lang.reflect.InvocationTargetException
 import scala.annotation.experimental
 import scala.jdk.CollectionConverters.*
 
@@ -69,16 +68,6 @@ class SparqlEncoderSpec extends AnyWordSpec, Matchers:
       error.getMessage should include("quoted triples are not supported")
     }
 
-    "not support building triples or quads" in {
-      val e = encoder()
-      for name <- Seq("newTriple", "newQuad") do
-        val method = classOf[SparqlEncoder[?]].getDeclaredMethod(name)
-        method.setAccessible(true)
-        val error = intercept[InvocationTargetException] {
-          method.invoke(e)
-        }
-        error.getCause shouldBe a[UnsupportedOperationException]
-    }
   }
 
   // The encoder hands its own buffers to the frame instead of allocating a fresh set per frame, so

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlEncoderSpec.scala
@@ -119,6 +119,63 @@ class SparqlEncoderSpec extends AnyWordSpec, Matchers:
         }
     }
 
+    // A polymorphic column reads its literals back out of the shared buffers at frame end, where
+    // language tags and datatypes take their own branches. Every mixed-type preset in
+    // SparqlDataGen pairs its column with plain literals, so nothing else reaches those branches.
+    "encode language-tagged and datatype literals in a polymorphic column" in {
+      val e = encoder()
+      e.setVariables(Seq("x").asJava)
+      val rows = Seq[Node](
+        Iri("https://a.org/x1"),
+        LangLiteral("hello", "en"),
+        DtLiteral("1", Datatype("https://a.org/d1")),
+        SimpleLiteral("plain"),
+        // A second language tag and datatype, so the buffer cursors have to keep advancing
+        LangLiteral("bonjour", "fr"),
+        DtLiteral("2", Datatype("https://a.org/d2")),
+        // A second IRI in the same namespace and with the next name id, so both are inferred away
+        // and the term is written as the shared all-zero IRI
+        Iri("https://a.org/x2"),
+        // Back to the first name: same namespace still, but the name id no longer follows on, so
+        // only the prefix is inferred away
+        Iri("https://a.org/x1"),
+      )
+      for row <- rows do e.appendRow(Array(row))
+      val frame = e.endFrame()
+
+      val terms = frame.getPolyColumns.asScala.head.getValues.asScala.toSeq
+      terms.size shouldBe rows.size
+      terms.head.hasIri shouldBe true
+      // The lexical forms must line up with the values – a language tag takes a second slot in
+      // the shared string buffer, which is what the cursor gets wrong if it is not accounted for
+      terms.map(t => Option.when(t.hasLiteral)(t.getLiteral.getLex)) shouldBe Seq(
+        None,
+        Some("hello"),
+        Some("1"),
+        Some("plain"),
+        Some("bonjour"),
+        Some("2"),
+        None,
+        None,
+      )
+      terms(1).getLiteral.getLangtag shouldBe "en"
+      terms(4).getLiteral.getLangtag shouldBe "fr"
+      // Datatypes are lookup references, and the two distinct ones must not collapse into one
+      val dt1 = terms(2).getLiteral.getDatatype
+      val dt2 = terms(5).getLiteral.getDatatype
+      dt1 should not be 0
+      dt2 should not be 0
+      dt1 should not be dt2
+      // A simple literal is neither, so its literal kind stays unset
+      terms(3).getLiteral.hasLiteralKind shouldBe false
+      // The trailing IRI repeats the first one's prefix and follows its name id, so both
+      // compress to zero
+      terms(6).getIri.getPrefixId shouldBe 0
+      terms(6).getIri.getNameId shouldBe 0
+      terms(7).getIri.getPrefixId shouldBe 0
+      terms(7).getIri.getNameId should not be 0
+    }
+
     "not carry a column's layout into the next frame" in {
       val e = encoder()
       e.setVariables(Seq("x").asJava)

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlProtoSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlProtoSpec.scala
@@ -120,9 +120,9 @@ class SparqlProtoSpec extends AnyWordSpec, Matchers:
     .setAskResult(SparqlAskResult.newInstance().setValue(true))
     .addVariables(SparqlVariable.newInstance().setName("x").setColumnIndex(0))
     .addVariables(SparqlVariable.newInstance().setName("y").setColumnIndex(1))
-    .addNames(RdfNameEntryPacked.newInstance().setId(1).addValues("name").addValues("name2"))
-    .addPrefixes(RdfPrefixEntryPacked.newInstance().setId(1).addValues("https://test.org/"))
-    .addDatatypes(RdfDatatypeEntryPacked.newInstance().setId(1).addValues("https://test.org/dt"))
+    .addNames(RdfLookupEntryPacked.newInstance().setId(1).addValues("name").addValues("name2"))
+    .addPrefixes(RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/"))
+    .addDatatypes(RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/dt"))
     .addIriColumns(iriColumn)
     .addBnodeColumns(bnodeColumn)
     .addLiteralColumns(literalColumn)
@@ -454,19 +454,19 @@ class SparqlProtoSpec extends AnyWordSpec, Matchers:
           SparqlResultsFrame
             .newInstance()
             .addDatatypes(
-              RdfDatatypeEntryPacked.newInstance().setId(1).addValues("https://test.org/dt"),
+              RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/dt"),
             )
             .toByteArray,
           SparqlResultsFrame
             .newInstance()
             .addPrefixes(
-              RdfPrefixEntryPacked.newInstance().setId(1).addValues("https://test.org/"),
+              RdfLookupEntryPacked.newInstance().setId(1).addValues("https://test.org/"),
             )
             .toByteArray,
           SparqlResultsFrame
             .newInstance()
             .addNames(
-              RdfNameEntryPacked.newInstance().setId(1).addValues("name").addValues("name2"),
+              RdfLookupEntryPacked.newInstance().setId(1).addValues("name").addValues("name2"),
             )
             .toByteArray,
           SparqlResultsFrame

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlRoundTripSpec.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/SparqlRoundTripSpec.scala
@@ -366,7 +366,7 @@ class SparqlRoundTripSpec extends AnyWordSpec, Matchers:
       val e = intercept[RdfProtoSerializationError] {
         encoder.appendRow(Array[Node](TripleNode(iri(1), iri(2), iri(3))))
       }
-      e.getMessage should include("quoted triples are not supported")
+      e.getMessage should include("Triple terms are not supported")
     }
 
     "round-trip a result set that outgrows the lookup tables" in {

--- a/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/gen/SparqlDataGen.scala
+++ b/core-sparql/src/test/scala/eu/neverblink/jelly/core/sparql/gen/SparqlDataGen.scala
@@ -224,6 +224,24 @@ object SparqlDataGen:
       Seq(ColumnSpec(distinctValues = 2048, mixFraction = 0.0005, mixStartRow = 5_000)),
       N,
     ),
+    // A mixed column pairs its kind with IRIs (see altKind), so these two are the only way a
+    // preset puts a language-tagged or a datatype literal in a polymorphic column. Those take
+    // their own branches when the column is written out, and the IRI-based poly presets above
+    // never reach them.
+    ResultSetSpec(
+      "poly-lang",
+      Seq(
+        ColumnSpec(ColumnKind.LangLiteral, distinctValues = 2048, namespaces = 4, mixFraction = 0.3),
+      ),
+      N,
+    ),
+    ResultSetSpec(
+      "poly-typed",
+      Seq(
+        ColumnSpec(ColumnKind.DtLiteral, distinctValues = 2048, namespaces = 8, mixFraction = 0.3),
+      ),
+      N,
+    ),
     // --- Result set shape ---
     ResultSetSpec("wide-5", Seq.fill(5)(ColumnSpec(distinctValues = 2048)), N),
     ResultSetSpec("wide-20", Seq.fill(20)(ColumnSpec(distinctValues = 2048)), N / 2),

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -1,7 +1,6 @@
 package eu.neverblink.jelly.core.internal;
 
 import eu.neverblink.jelly.core.InternalApi;
-import java.util.HashMap;
 import java.util.Objects;
 
 /**
@@ -36,8 +35,27 @@ final class EncoderLookup {
         }
     }
 
-    /** The lookup hash map */
-    private final HashMap<String, LookupEntry> map = new HashMap<>();
+    /**
+     * Index from a key's hash to the id of the entry holding it, with linear probing.
+     * <p>
+     * The keys themselves are already stored in {@link #names}, so a slot only has to hold an id.
+     * The bits above the id hold a tag taken from the key's hash, which lets a probe walk past a
+     * colliding slot without dereferencing any string. A slot value of 0 means "empty" – that is
+     * unambiguous because id 0 is never handed out.
+     */
+    private final int[] index;
+
+    /** Slot mask for {@link #index}. There are at least two slots per entry, so it never fills up. */
+    private final int indexMask;
+
+    /** Mask of the low bits of an index slot that hold the entry id; the rest is the hash tag. */
+    private final int idMask;
+
+    /**
+     * For each id, the slot its key hashes to. Only read when an entry is evicted, where the probe
+     * chain around the freed slot has to be repaired.
+     */
+    private final int[] homeSlots;
 
     /**
      * The doubly-linked list of entries, with 1-based indexing.
@@ -69,12 +87,22 @@ final class EncoderLookup {
     // Whether to maintain serial numbers for the entries.
     private final boolean useSerials;
 
+    // The only LookupEntry this class ever hands out. Callers read its fields and are done with it
+    // before they call the lookup again, so there is no reason to allocate one per entry.
     private final LookupEntry entryForReturns = new LookupEntry(0, 0, true);
 
     public EncoderLookup(int size, boolean useSerials) {
         this.size = size;
         table = new int[(size + 1) * 2];
         names = new String[size + 1];
+        homeSlots = new int[size + 1];
+        // Ids run 1..size, so this is how many bits one of them takes in an index slot.
+        final int idBits = 32 - Integer.numberOfLeadingZeros(Math.max(size, 1));
+        idMask = (1 << idBits) - 1;
+        // Two slots per entry: linear probing degrades badly above a half-full table.
+        final int indexSize = Integer.highestOneBit(Math.max(size * 2 - 1, 1)) << 1;
+        index = new int[indexSize];
+        indexMask = indexSize - 1;
         this.useSerials = useSerials;
         if (useSerials) {
             serials = new int[size + 1];
@@ -83,6 +111,110 @@ final class EncoderLookup {
             serials[0] = -1;
         } else {
             serials = null;
+        }
+    }
+
+    /** Mixes a hash so that both the slot bits (low) and the tag bits (high) depend on all of it. */
+    private static int spread(int hash) {
+        final int h = hash * 0x9E3779B1;
+        return h ^ (h >>> 16);
+    }
+
+    /**
+     * The same value as {@code source.substring(from).hashCode()}, without materializing the substring.
+     * It has to agree with String.hashCode, because keys given as whole strings are hashed with that.
+     * @param source The string the key is a suffix of.
+     * @param from Index at which the key starts.
+     */
+    private static int hashSuffix(String source, int from) {
+        final int len = source.length();
+        int h = 0;
+        int i = from;
+        // Four characters at a time, so the multiplications don't form one long dependency chain.
+        // 923521 = 31^4, 29791 = 31^3, 961 = 31^2.
+        for (; i + 3 < len; i += 4) {
+            h =
+                h * 923521 +
+                source.charAt(i) * 29791 +
+                source.charAt(i + 1) * 961 +
+                source.charAt(i + 2) * 31 +
+                source.charAt(i + 3);
+        }
+        for (; i < len; i++) {
+            h = h * 31 + source.charAt(i);
+        }
+        return h;
+    }
+
+    /**
+     * Finds the entry whose name is the suffix of source starting at from.
+     * @param spread The spread hash of the key.
+     * @return The id of the entry, or 0 if there is none.
+     */
+    private int findId(int spread, String source, int from) {
+        final int tag = spread & ~idMask;
+        final int keyLength = source.length() - from;
+        int slot = spread & indexMask;
+        while (true) {
+            final int value = index[slot];
+            if (value == 0) {
+                return 0;
+            }
+            if ((value & ~idMask) == tag) {
+                final int id = value & idMask;
+                final String name = names[id];
+                if (name.length() == keyLength && source.startsWith(name, from)) {
+                    return id;
+                }
+            }
+            slot = (slot + 1) & indexMask;
+        }
+    }
+
+    /**
+     * Puts an id into the index. The key must not already be there.
+     * @param spread The spread hash of the key.
+     */
+    private void insertId(int id, int spread) {
+        final int home = spread & indexMask;
+        int slot = home;
+        while (index[slot] != 0) {
+            slot = (slot + 1) & indexMask;
+        }
+        index[slot] = id | (spread & ~idMask);
+        homeSlots[id] = home;
+    }
+
+    /**
+     * Takes an id out of the index.
+     * <p>
+     * With linear probing, the entries sitting after the freed slot may only be reachable through
+     * it, so the ones that are have to be shifted back – otherwise a later lookup would stop at the
+     * hole and never see them. This is Knuth's backward-shift deletion.
+     */
+    private void removeId(int id) {
+        int hole = homeSlots[id];
+        while ((index[hole] & idMask) != id) {
+            hole = (hole + 1) & indexMask;
+        }
+        index[hole] = 0;
+        int slot = hole;
+        while (true) {
+            slot = (slot + 1) & indexMask;
+            final int value = index[slot];
+            if (value == 0) {
+                return;
+            }
+            final int home = homeSlots[value & idMask];
+            // Leave the entry alone if its home lies in (hole, slot] – then it is still reachable
+            // from its home without passing through the hole. Otherwise move it down into the hole,
+            // which becomes the new hole.
+            final boolean reachable = hole <= slot ? hole < home && home <= slot : hole < home || home <= slot;
+            if (!reachable) {
+                index[hole] = value;
+                index[slot] = 0;
+                hole = slot;
+            }
         }
     }
 
@@ -114,8 +246,9 @@ final class EncoderLookup {
      * One branch of the getOrAddEntry method. Should be inlined by the JIT.
      * @param key The key of the entry.
      * @param id The ID of the entry.
+     * @param spread The spread hash of the key.
      */
-    private void addEntrySequential(String key, int id) {
+    private void addEntrySequential(String key, int id, int spread) {
         int base = id * 2;
         // Set the left to the tail
         table[base] = tail;
@@ -125,20 +258,22 @@ final class EncoderLookup {
         table[tail + 1] = base;
         tail = base;
         names[id] = key;
-        map.put(key, new LookupEntry(id, id));
+        insertId(id, spread);
+        // The ids handed out here run 1, 2, 3, ..., so the decoder can always infer them.
+        entryForReturns.setId = 0;
     }
 
     /**
      * Another branch of the getOrAddEntry method. Should be inlined by the JIT.
      * @param key The key of the entry.
      * @param id The ID of the entry.
+     * @param spread The spread hash of the key.
      */
-    private void addEntryEvicting(String key, int id) {
-        // Remove the entry from the map
-        LookupEntry oldEntry = map.remove(names[id]);
-        // Insert the new entry
+    private void addEntryEvicting(String key, int id, int spread) {
+        // Move the id from the old key to the new one
+        removeId(id);
         names[id] = key;
-        map.put(key, oldEntry);
+        insertId(id, spread);
         // Update the table
         onAccess(id);
         entryForReturns.setId = lastSetId + 1 == id ? 0 : id;
@@ -152,21 +287,44 @@ final class EncoderLookup {
      * @return The entry.
      */
     public LookupEntry getOrAddEntry(String key) {
-        final var value = map.get(key);
-        if (value != null) {
+        return getOrAddEntry(key, 0, key.hashCode());
+    }
+
+    /**
+     * Adds a new entry to the lookup table or retrieves it if it already exists, with the key given
+     * as the suffix of an existing string. This way an already-known key costs no allocation at all:
+     * the substring is only cut out when the entry actually turns out to be new.
+     * @param source The string the key is a suffix of.
+     * @param from Index at which the key starts.
+     * @return The entry.
+     */
+    public LookupEntry getOrAddEntry(String source, int from) {
+        return getOrAddEntry(source, from, hashSuffix(source, from));
+    }
+
+    private LookupEntry getOrAddEntry(String source, int from, int hash) {
+        final int spread = spread(hash);
+        final var entry = entryForReturns;
+        final int existing = findId(spread, source, from);
+        if (existing != 0) {
             // The entry is already in the table, just update the access order
-            onAccess(value.getId);
-            return value;
+            onAccess(existing);
+            entry.getId = existing;
+            entry.setId = existing;
+            entry.newEntry = false;
+            return entry;
         }
+        // substring(0) returns the string itself, so a whole-string key costs nothing here
+        final String key = source.substring(from);
         int id;
         if (used < size) {
             // We still have space in the table, add a new entry to the end of the table.
             id = ++used;
-            addEntrySequential(key, id);
+            addEntrySequential(key, id, spread);
         } else {
             // The table is full, evict the least recently used entry.
             id = table[1] / 2;
-            addEntryEvicting(key, id);
+            addEntryEvicting(key, id, spread);
         }
         if (this.useSerials) {
             // Increment the serial number
@@ -174,8 +332,9 @@ final class EncoderLookup {
             // The if should be very predictable and have no negative performance impact.
             ++Objects.requireNonNull(serials)[id];
         }
-        entryForReturns.getId = id;
-        return entryForReturns;
+        entry.getId = id;
+        entry.newEntry = true;
+        return entry;
     }
 
     /**
@@ -186,15 +345,20 @@ final class EncoderLookup {
      * @return The entry.
      */
     public LookupEntry getOrAddEntryTranscoder(String key, int evictHint) {
-        final var value = map.get(key);
-        if (value != null) {
-            onAccess(value.getId);
-            return value;
+        final int spread = spread(key.hashCode());
+        final var entry = entryForReturns;
+        final int existing = findId(spread, key, 0);
+        if (existing != 0) {
+            onAccess(existing);
+            entry.getId = existing;
+            entry.setId = existing;
+            entry.newEntry = false;
+            return entry;
         }
         int id;
         if (used < size) {
             id = ++used;
-            addEntrySequential(key, id);
+            addEntrySequential(key, id, spread);
         } else {
             // The table is full
             if (evictHint != 0) {
@@ -204,10 +368,11 @@ final class EncoderLookup {
                 // Evict the least recently used entry.
                 id = table[1] / 2;
             }
-            addEntryEvicting(key, id);
+            addEntryEvicting(key, id, spread);
         }
         // Serials are not used for transcoders
-        entryForReturns.getId = id;
-        return entryForReturns;
+        entry.getId = id;
+        entry.newEntry = true;
+        return entry;
     }
 }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -65,7 +65,7 @@ final class EncoderLookup {
     // The last id that was set in the table.
     private int lastSetId = -1000;
     // Names of the entries. Entry 0 is always null.
-    private final String[] names;
+    final String[] names;
     // Whether to maintain serial numbers for the entries.
     private final boolean useSerials;
 

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -55,11 +55,19 @@ final class EncoderLookup {
      */
     private final int[] index;
 
-    /** Slot mask for {@link #index}. */
+    /** Slot mask for {@link #index}, which is always a power of two long. */
     private final int indexMask;
 
+    /**
+     * How many low bits of an index slot hold the entry id. The rest are the hash tag.
+     */
+    private static final int ID_BITS = 18;
+
     /** Mask of the low bits of an index slot that hold the entry id. */
-    private final int idMask;
+    private static final int ID_MASK = (1 << ID_BITS) - 1;
+
+    /** The largest lookup table that fits in {@link #ID_BITS}. */
+    static final int MAX_TABLE_SIZE = ID_MASK;
 
     /**
      * For each id, the slot its key hashes to. Only read when an entry is evicted.
@@ -104,17 +112,19 @@ final class EncoderLookup {
     private final LookupEntry entryForReturns = new LookupEntry(0, 0, true);
 
     public EncoderLookup(int size, boolean useSerials) {
+        if (size > MAX_TABLE_SIZE) {
+            throw new IllegalArgumentException(
+                "Lookup table size %d is above the maximum of %d.".formatted(size, MAX_TABLE_SIZE)
+            );
+        }
         this.size = size;
         capacity = Math.min(size, INITIAL_CAPACITY);
         table = new int[(capacity + 1) * 2];
         names = new String[capacity + 1];
         homeSlots = new int[capacity + 1];
-        final int idBits = 32 - Integer.numberOfLeadingZeros(Math.max(size, 1));
-        idMask = (1 << idBits) - 1;
         // Two slots per entry: linear probing degrades badly above a half-full table.
-        final int indexSize = Integer.highestOneBit(Math.max(size * 2 - 1, 1)) << 1;
-        index = new int[indexSize];
-        indexMask = indexSize - 1;
+        index = new int[Integer.highestOneBit(Math.max(size * 2 - 1, 1)) << 1];
+        indexMask = index.length - 1;
         this.useSerials = useSerials;
         if (useSerials) {
             serials = new int[capacity + 1];
@@ -183,40 +193,13 @@ final class EncoderLookup {
         return result;
     }
 
-    // TODO: remove?
-    /**
-     * The same value as {@code source.substring(from).hashCode()}, without materializing the substring.
-     * It has to agree with String.hashCode, because keys given as whole strings are hashed with that.
-     * @param source The string the key is a suffix of.
-     * @param from Index at which the key starts.
-     */
-    static int hashSuffix(String source, int from) {
-        final int len = source.length();
-        int h = 0;
-        int i = from;
-        // Four characters at a time, so the multiplications don't form one long dependency chain.
-        // 923521 = 31^4, 29791 = 31^3, 961 = 31^2.
-        for (; i + 3 < len; i += 4) {
-            h =
-                h * 923521 +
-                source.charAt(i) * 29791 +
-                source.charAt(i + 1) * 961 +
-                source.charAt(i + 2) * 31 +
-                source.charAt(i + 3);
-        }
-        for (; i < len; i++) {
-            h = h * 31 + source.charAt(i);
-        }
-        return h;
-    }
-
     /**
      * Finds the entry whose name is the suffix of source starting at from.
      * @param spread The spread hash of the key.
      * @return The id of the entry, or 0 if there is none.
      */
     private int findId(int spread, String source, int from) {
-        final int tag = spread & ~idMask;
+        final int tag = spread & ~ID_MASK;
         final int keyLength = source.length() - from;
         int slot = spread & indexMask;
         while (true) {
@@ -224,8 +207,8 @@ final class EncoderLookup {
             if (value == 0) {
                 return 0;
             }
-            if ((value & ~idMask) == tag) {
-                final int id = value & idMask;
+            if ((value & ~ID_MASK) == tag) {
+                final int id = value & ID_MASK;
                 final String name = names[id];
                 if (name.length() == keyLength && source.startsWith(name, from)) {
                     return id;
@@ -245,7 +228,7 @@ final class EncoderLookup {
         while (index[slot] != 0) {
             slot = (slot + 1) & indexMask;
         }
-        index[slot] = id | (spread & ~idMask);
+        index[slot] = id | (spread & ~ID_MASK);
         homeSlots[id] = home;
     }
 
@@ -258,7 +241,7 @@ final class EncoderLookup {
      */
     private void removeId(int id) {
         int hole = homeSlots[id];
-        while ((index[hole] & idMask) != id) {
+        while ((index[hole] & ID_MASK) != id) {
             hole = (hole + 1) & indexMask;
         }
         index[hole] = 0;
@@ -269,10 +252,9 @@ final class EncoderLookup {
             if (value == 0) {
                 return;
             }
-            final int home = homeSlots[value & idMask];
+            final int home = homeSlots[value & ID_MASK];
             // Leave the entry alone if its home lies in (hole, slot] – then it is still reachable
-            // from its home without passing through the hole. Otherwise move it down into the hole,
-            // which becomes the new hole.
+            // from its home without passing through the hole.
             final boolean reachable = hole <= slot ? hole < home && home <= slot : hole < home || home <= slot;
             if (!reachable) {
                 index[hole] = value;
@@ -323,7 +305,6 @@ final class EncoderLookup {
         tail = base;
         names[id] = key;
         insertId(id, spread);
-        // The ids handed out here run 1, 2, 3, ..., so the decoder can always infer them.
         entryForReturns.setId = 0;
     }
 
@@ -355,23 +336,12 @@ final class EncoderLookup {
     }
 
     /**
-     * // TODO: remove?
      * Adds a new entry to the lookup table or retrieves it if it already exists, with the key given
      * as the suffix of an existing string. This way an already-known key costs no allocation at all:
      * the substring is only cut out when the entry actually turns out to be new.
-     * @param source The string the key is a suffix of.
-     * @param from Index at which the key starts.
-     * @return The entry.
-     */
-    public LookupEntry getOrAddEntry(String source, int from) {
-        return getOrAddEntry(source, from, hashSuffix(source, from));
-    }
-
-    /**
-     * The same, for a caller that already knows the key's hash. It must be exactly what
-     * {@code source.substring(from).hashCode()} would return – a wrong one either fails to find an
-     * entry that is there, or files the key under a slot no later lookup will probe.
-     * See {@link #hashOfSuffix} for how to get one without scanning the key.
+     * <p>
+     * The hash must be exactly what {@code source.substring(from).hashCode()} would return.
+     * {@link #hashOfSuffix} produces it without scanning the key.
      * @param source The string the key is a suffix of.
      * @param from Index at which the key starts.
      * @param hash Hash of the key.
@@ -389,7 +359,6 @@ final class EncoderLookup {
             entry.newEntry = false;
             return entry;
         }
-        // substring(0) returns the string itself, so a whole-string key costs nothing here
         final String key = source.substring(from);
         int id;
         if (used < size) {

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -24,11 +24,6 @@ final class EncoderLookup {
         /** Whether this entry is a new entry. */
         public boolean newEntry;
 
-        public LookupEntry(int getId, int setId) {
-            this.getId = getId;
-            this.setId = setId;
-        }
-
         public LookupEntry(int getId, int setId, boolean newEntry) {
             this.getId = getId;
             this.setId = setId;
@@ -67,8 +62,7 @@ final class EncoderLookup {
     private final int idMask;
 
     /**
-     * For each id, the slot its key hashes to. Only read when an entry is evicted, where the probe
-     * chain around the freed slot has to be repaired.
+     * For each id, the slot its key hashes to. Only read when an entry is evicted.
      */
     private int[] homeSlots;
 
@@ -98,7 +92,7 @@ final class EncoderLookup {
     // Current size of the lookup (how many entries are used).
     // This will monotonically increase until it reaches the maximum size.
     private int used;
-    // How many ids the entry arrays currently hold. Grows towards `size` as ids are handed out.
+    // How many ids the entry arrays can currently hold.
     private int capacity;
     // The last id that was set in the table.
     private int lastSetId = -1000;
@@ -107,8 +101,6 @@ final class EncoderLookup {
     // Whether to maintain serial numbers for the entries.
     private final boolean useSerials;
 
-    // The only LookupEntry this class ever hands out. Callers read its fields and are done with it
-    // before they call the lookup again, so there is no reason to allocate one per entry.
     private final LookupEntry entryForReturns = new LookupEntry(0, 0, true);
 
     public EncoderLookup(int size, boolean useSerials) {
@@ -117,7 +109,6 @@ final class EncoderLookup {
         table = new int[(capacity + 1) * 2];
         names = new String[capacity + 1];
         homeSlots = new int[capacity + 1];
-        // Ids run 1..size, so this is how many bits one of them takes in an index slot.
         final int idBits = 32 - Integer.numberOfLeadingZeros(Math.max(size, 1));
         idMask = (1 << idBits) - 1;
         // Two slots per entry: linear probing degrades badly above a half-full table.
@@ -135,11 +126,6 @@ final class EncoderLookup {
         }
     }
 
-    /**
-     * Makes room for more ids, up to the table's configured size. Only the arrays indexed by id
-     * have to grow – the values in them are keyed by id, so copying them over is enough and
-     * nothing has to be rehashed.
-     */
     private void grow() {
         capacity = Math.min(size, capacity * GROWTH_FACTOR);
         table = Arrays.copyOf(table, (capacity + 1) * 2);
@@ -156,7 +142,7 @@ final class EncoderLookup {
         return h ^ (h >>> 16);
     }
 
-    /** Powers of 31, for {@link #hashOfSuffix}. Long enough to cover any sane IRI local name. */
+    /** Powers of 31, for {@link #hashOfSuffix}. Long enough to cover any sane IRI prefix. */
     private static final int[] POW31 = new int[256];
 
     static {
@@ -169,16 +155,7 @@ final class EncoderLookup {
 
     /**
      * The hash of a suffix, worked out from the hash of the whole string and the hash of the prefix
-     * that was cut off it, without looking at a single character.
-     * <p>
-     * String.hashCode is {@code h = 31 * h + c} per character, so for {@code s = prefix + suffix}
-     * it satisfies {@code hash(s) = hash(prefix) * 31^len(suffix) + hash(suffix)}, and the suffix
-     * hash falls out. The int arithmetic wraps the same way on both sides, so this is exact, not an
-     * approximation.
-     * <p>
-     * Both inputs are hashes of Strings that are kept alive – the IRI by the caller's node cache and
-     * the prefix by the lookup's names array – so String has them cached and this costs no scanning
-     * at all, where hashing the suffix directly costs one pass over it.
+     * that was cut off it, without looking at the actual string. Yes, it does work.
      *
      * @param wholeHash {@code source.hashCode()}
      * @param prefixHash hash of the first {@code source.length() - suffixLength} characters
@@ -189,7 +166,7 @@ final class EncoderLookup {
         return wholeHash - prefixHash * pow31(suffixLength);
     }
 
-    /** 31 to the n. Tabulated for the lengths that occur in practice, computed for the rest. */
+    /** 31 to the n. Tabulated for the lengths that occur in practice. */
     private static int pow31(int n) {
         if (n < POW31.length) {
             return POW31[n];
@@ -206,6 +183,7 @@ final class EncoderLookup {
         return result;
     }
 
+    // TODO: remove?
     /**
      * The same value as {@code source.substring(from).hashCode()}, without materializing the substring.
      * It has to agree with String.hashCode, because keys given as whole strings are hashed with that.
@@ -377,6 +355,7 @@ final class EncoderLookup {
     }
 
     /**
+     * // TODO: remove?
      * Adds a new entry to the lookup table or retrieves it if it already exists, with the key given
      * as the suffix of an existing string. This way an already-known key costs no allocation at all:
      * the substring is only cut out when the entry actually turns out to be new.

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -37,10 +37,8 @@ final class EncoderLookup {
     }
 
     /**
-     * How many ids the entry arrays start out holding. The declared table size is an upper bound,
-     * and most streams never come near it – a one-row result set uses a handful of names – so the
-     * arrays start small and are grown as ids are handed out. Building the arrays at full size
-     * used to be most of the cost of creating an encoder.
+     * How many ids the entry arrays start with. Small to avoid large up-front allocations for
+     * small datasets.
      */
     private static final int INITIAL_CAPACITY = 64;
 
@@ -55,18 +53,17 @@ final class EncoderLookup {
      * <p>
      * The keys themselves are already stored in {@link #names}, so a slot only has to hold an id.
      * The bits above the id hold a tag taken from the key's hash, which lets a probe walk past a
-     * colliding slot without dereferencing any string. A slot value of 0 means "empty" – that is
-     * unambiguous because id 0 is never handed out.
+     * colliding slot without dereferencing any string. A slot value of 0 means "empty".
      * <p>
      * Unlike the entry arrays, this one is built at full size right away: growing it would mean
-     * rehashing every key in it, which costs more than the allocation it saves.
+     * rehashing every key in it.
      */
     private final int[] index;
 
-    /** Slot mask for {@link #index}. There are at least two slots per entry, so it never fills up. */
+    /** Slot mask for {@link #index}. */
     private final int indexMask;
 
-    /** Mask of the low bits of an index slot that hold the entry id; the rest is the hash tag. */
+    /** Mask of the low bits of an index slot that hold the entry id. */
     private final int idMask;
 
     /**

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -159,13 +159,63 @@ final class EncoderLookup {
         return h ^ (h >>> 16);
     }
 
+    /** Powers of 31, for {@link #hashOfSuffix}. Long enough to cover any sane IRI local name. */
+    private static final int[] POW31 = new int[256];
+
+    static {
+        int p = 1;
+        for (int i = 0; i < POW31.length; i++) {
+            POW31[i] = p;
+            p *= 31;
+        }
+    }
+
+    /**
+     * The hash of a suffix, worked out from the hash of the whole string and the hash of the prefix
+     * that was cut off it, without looking at a single character.
+     * <p>
+     * String.hashCode is {@code h = 31 * h + c} per character, so for {@code s = prefix + suffix}
+     * it satisfies {@code hash(s) = hash(prefix) * 31^len(suffix) + hash(suffix)}, and the suffix
+     * hash falls out. The int arithmetic wraps the same way on both sides, so this is exact, not an
+     * approximation.
+     * <p>
+     * Both inputs are hashes of Strings that are kept alive – the IRI by the caller's node cache and
+     * the prefix by the lookup's names array – so String has them cached and this costs no scanning
+     * at all, where hashing the suffix directly costs one pass over it.
+     *
+     * @param wholeHash {@code source.hashCode()}
+     * @param prefixHash hash of the first {@code source.length() - suffixLength} characters
+     * @param suffixLength length of the suffix
+     * @return the hash the suffix would have
+     */
+    static int hashOfSuffix(int wholeHash, int prefixHash, int suffixLength) {
+        return wholeHash - prefixHash * pow31(suffixLength);
+    }
+
+    /** 31 to the n. Tabulated for the lengths that occur in practice, computed for the rest. */
+    private static int pow31(int n) {
+        if (n < POW31.length) {
+            return POW31[n];
+        }
+        int result = 1;
+        int base = 31;
+        while (n > 0) {
+            if ((n & 1) != 0) {
+                result *= base;
+            }
+            base *= base;
+            n >>>= 1;
+        }
+        return result;
+    }
+
     /**
      * The same value as {@code source.substring(from).hashCode()}, without materializing the substring.
      * It has to agree with String.hashCode, because keys given as whole strings are hashed with that.
      * @param source The string the key is a suffix of.
      * @param from Index at which the key starts.
      */
-    private static int hashSuffix(String source, int from) {
+    static int hashSuffix(String source, int from) {
         final int len = source.length();
         int h = 0;
         int i = from;
@@ -341,7 +391,17 @@ final class EncoderLookup {
         return getOrAddEntry(source, from, hashSuffix(source, from));
     }
 
-    private LookupEntry getOrAddEntry(String source, int from, int hash) {
+    /**
+     * The same, for a caller that already knows the key's hash. It must be exactly what
+     * {@code source.substring(from).hashCode()} would return – a wrong one either fails to find an
+     * entry that is there, or files the key under a slot no later lookup will probe.
+     * See {@link #hashOfSuffix} for how to get one without scanning the key.
+     * @param source The string the key is a suffix of.
+     * @param from Index at which the key starts.
+     * @param hash Hash of the key.
+     * @return The entry.
+     */
+    public LookupEntry getOrAddEntry(String source, int from, int hash) {
         final int spread = spread(hash);
         final var entry = entryForReturns;
         final int existing = findId(spread, source, from);

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -235,9 +235,9 @@ final class EncoderLookup {
     /**
      * Takes an id out of the index.
      * <p>
-     * With linear probing, the entries sitting after the freed slot may only be reachable through
-     * it, so the ones that are have to be shifted back – otherwise a later lookup would stop at the
-     * hole and never see them. This is Knuth's backward-shift deletion.
+     * We use linear probing. So, entries that are in the array after a freed slot would become
+     * invisible (the linear probe would stop at the hole). To prevent this, we shift them back.
+     * This is Knuth's backward-shift deletion.
      */
     private void removeId(int id) {
         int hole = homeSlots[id];

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/EncoderLookup.java
@@ -1,6 +1,7 @@
 package eu.neverblink.jelly.core.internal;
 
 import eu.neverblink.jelly.core.InternalApi;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -36,12 +37,29 @@ final class EncoderLookup {
     }
 
     /**
+     * How many ids the entry arrays start out holding. The declared table size is an upper bound,
+     * and most streams never come near it – a one-row result set uses a handful of names – so the
+     * arrays start small and are grown as ids are handed out. Building the arrays at full size
+     * used to be most of the cost of creating an encoder.
+     */
+    private static final int INITIAL_CAPACITY = 64;
+
+    /**
+     * By how much the entry arrays grow at a time. Big, so that a table which does fill up gets
+     * there in a couple of copies.
+     */
+    private static final int GROWTH_FACTOR = 4;
+
+    /**
      * Index from a key's hash to the id of the entry holding it, with linear probing.
      * <p>
      * The keys themselves are already stored in {@link #names}, so a slot only has to hold an id.
      * The bits above the id hold a tag taken from the key's hash, which lets a probe walk past a
      * colliding slot without dereferencing any string. A slot value of 0 means "empty" – that is
      * unambiguous because id 0 is never handed out.
+     * <p>
+     * Unlike the entry arrays, this one is built at full size right away: growing it would mean
+     * rehashing every key in it, which costs more than the allocation it saves.
      */
     private final int[] index;
 
@@ -55,7 +73,7 @@ final class EncoderLookup {
      * For each id, the slot its key hashes to. Only read when an entry is evicted, where the probe
      * chain around the freed slot has to be repaired.
      */
-    private final int[] homeSlots;
+    private int[] homeSlots;
 
     /**
      * The doubly-linked list of entries, with 1-based indexing.
@@ -63,15 +81,18 @@ final class EncoderLookup {
      * The head pointer is in table[1].
      * The first valid entry is in table[2] – table[3].
      */
-    private final int[] table;
+    private int[] table;
 
     /**
      * The serial numbers of the entries, incremented each time the entry is replaced in the table.
      * This could theoretically overflow and cause bogus cache hits, but it's enormously
      * unlikely to happen in practice. I can buy a beer for anyone who can construct an RDF dataset that
      * causes this to happen.
+     * <p>
+     * Replaced by a longer array when the lookup grows, so a caller must not hold on to it across
+     * a call that can add an entry.
      */
-    final int[] serials;
+    int[] serials;
 
     // Tail pointer for the table.
     private int tail;
@@ -80,10 +101,12 @@ final class EncoderLookup {
     // Current size of the lookup (how many entries are used).
     // This will monotonically increase until it reaches the maximum size.
     private int used;
+    // How many ids the entry arrays currently hold. Grows towards `size` as ids are handed out.
+    private int capacity;
     // The last id that was set in the table.
     private int lastSetId = -1000;
     // Names of the entries. Entry 0 is always null.
-    final String[] names;
+    String[] names;
     // Whether to maintain serial numbers for the entries.
     private final boolean useSerials;
 
@@ -93,9 +116,10 @@ final class EncoderLookup {
 
     public EncoderLookup(int size, boolean useSerials) {
         this.size = size;
-        table = new int[(size + 1) * 2];
-        names = new String[size + 1];
-        homeSlots = new int[size + 1];
+        capacity = Math.min(size, INITIAL_CAPACITY);
+        table = new int[(capacity + 1) * 2];
+        names = new String[capacity + 1];
+        homeSlots = new int[capacity + 1];
         // Ids run 1..size, so this is how many bits one of them takes in an index slot.
         final int idBits = 32 - Integer.numberOfLeadingZeros(Math.max(size, 1));
         idMask = (1 << idBits) - 1;
@@ -105,12 +129,27 @@ final class EncoderLookup {
         indexMask = indexSize - 1;
         this.useSerials = useSerials;
         if (useSerials) {
-            serials = new int[size + 1];
+            serials = new int[capacity + 1];
             // Set the head's serial to non-zero value, so that default-initialized DependentNodes are not
             // accidentally considered as valid entries.
             serials[0] = -1;
         } else {
             serials = null;
+        }
+    }
+
+    /**
+     * Makes room for more ids, up to the table's configured size. Only the arrays indexed by id
+     * have to grow – the values in them are keyed by id, so copying them over is enough and
+     * nothing has to be rehashed.
+     */
+    private void grow() {
+        capacity = Math.min(size, capacity * GROWTH_FACTOR);
+        table = Arrays.copyOf(table, (capacity + 1) * 2);
+        names = Arrays.copyOf(names, capacity + 1);
+        homeSlots = Arrays.copyOf(homeSlots, capacity + 1);
+        if (useSerials) {
+            serials = Arrays.copyOf(Objects.requireNonNull(serials), capacity + 1);
         }
     }
 
@@ -320,6 +359,9 @@ final class EncoderLookup {
         if (used < size) {
             // We still have space in the table, add a new entry to the end of the table.
             id = ++used;
+            if (id > capacity) {
+                grow();
+            }
             addEntrySequential(key, id, spread);
         } else {
             // The table is full, evict the least recently used entry.
@@ -358,6 +400,9 @@ final class EncoderLookup {
         int id;
         if (used < size) {
             id = ++used;
+            if (id > capacity) {
+                grow();
+            }
             addEntrySequential(key, id, spread);
         } else {
             // The table is full

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -159,7 +159,12 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     static final RdfIri zeroIri = RdfIri.newInstance();
-    // Pre-allocated IRIs that have prefixId=0
+    // One IRI with prefixId=0 per name lookup id, created the first time that id is emitted.
+    // Filling this eagerly used to dominate the cost of building an encoder – a name table entry
+    // is 8 bytes of array, but an RdfIri per entry is a separate object each. Most streams touch
+    // only a fraction of the table, and a stream that uses the prefix table (which is what
+    // Jelly-SPARQL always does) never reads this array at all, because it goes through
+    // makeIriRaw. Slot 0 is never used: lookup ids start at 1.
     private final RdfIri[] nameOnlyIris;
 
     /**
@@ -199,9 +204,6 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             );
         }
         nameOnlyIris = new RdfIri[nameTableSize + 1];
-        for (int i = 0; i < nameOnlyIris.length; i++) {
-            nameOnlyIris[i] = RdfIri.newInstance().setPrefixId(0).setNameId(i);
-        }
         dtLiteralNodeCache = new DependentNodeCache<>(dtLiteralNodeCacheSize);
         nameLookup = new EncoderLookup(nameTableSize, maxPrefixTableSize > 0);
         otherLiteralCache = new NodeCache<>(nodeCacheSize);
@@ -230,12 +232,26 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             // Two IRI cache slots per name table entry. Distinct IRIs outnumber distinct names – one
             // name can be the tail of several IRIs – so one slot per name entry leaves the cache
             // short: on the SPARQL benchmark presets it missed 20-28% of the time at that size and
-            // 4-13% at twice that. The extra cost is one more slot pair per name entry, which is on
-            // the order of the RdfIri per name entry that the encoder already keeps in nameOnlyIris.
+            // 4-13% at twice that. The extra cost is one more slot pair per name entry.
             maxNameTableSize * 2,
             Math.clamp(maxNameTableSize, 256, 1024),
             bufferAppender
         );
+    }
+
+    /**
+     * The prefix-0 IRI for a name id, created on first use. The returned object is handed on to the
+     * frame buffer and must therefore stay valid until the frame is serialized, which is why one is
+     * kept per id instead of a single mutable one. An id that gets evicted and reassigned keeps its
+     * IRI: only the id is encoded, not the name behind it.
+     * @param nameId The id of the entry in the name lookup
+     */
+    private RdfIri nameOnlyIri(int nameId) {
+        final var iri = nameOnlyIris[nameId];
+        if (iri != null) {
+            return iri;
+        }
+        return (nameOnlyIris[nameId] = RdfIri.newInstance().setPrefixId(0).setNameId(nameId));
     }
 
     /**
@@ -252,7 +268,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
                 return zeroIri;
             } else {
                 lastIriNameId = nameId;
-                return nameOnlyIris[nameId];
+                return nameOnlyIri(nameId);
             }
         }
         return outputIri(encodeIriWithPrefix(iri));
@@ -262,7 +278,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     public RdfIri makeIriRaw(String iri) {
         if (maxPrefixTableSize == 0) {
             // Fast path for no prefixes
-            return nameOnlyIris[encodeIriNameOnly(iri)];
+            return nameOnlyIri(encodeIriNameOnly(iri));
         }
         return encodeIriWithPrefix(iri).encoded;
     }
@@ -435,7 +451,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
                 return zeroIri;
             } else {
                 lastIriNameId = nameId;
-                return nameOnlyIris[nameId];
+                return nameOnlyIri(nameId);
             }
         } else {
             lastIriPrefixId = prefixId;

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -144,6 +144,9 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             } else {
                 node = other == null ? new DependentNode<>() : other;
                 node.encoded = null;
+                // The pointers are what says "this entry has been encoded" for IRIs, so a recycled
+                // slot has to lose them as well as its message.
+                node.lookupPointer1 = 0;
                 node.key = key;
                 node.keyHash = hash;
             }
@@ -238,7 +241,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * @param maxDatatypeTableSize The maximum size of the datatype table
      * @return A new NodeEncoder
      */
-    public static <TNode> NodeEncoder<TNode> create(
+    public static <TNode> NodeEncoderImpl<TNode> create(
         RdfBufferAppender<TNode> bufferAppender,
         int maxPrefixTableSize,
         int maxNameTableSize,
@@ -300,7 +303,38 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             // Fast path for no prefixes
             return nameOnlyIri(encodeIriNameOnly(iri));
         }
-        return encodeIriWithPrefix(iri).encoded;
+        return encodedIriOf(encodeIriWithPrefix(iri));
+    }
+
+    /**
+     * The RdfIri message for a cached node, built the first time it is asked for. Jelly-SPARQL only
+     * ever wants the two ids, so for it this is never called and the message never exists.
+     */
+    private static RdfIri encodedIriOf(DependentNode<RdfIri> node) {
+        final var encoded = node.encoded;
+        if (encoded != null) {
+            return encoded;
+        }
+        return (node.encoded = RdfIri.newInstance().setPrefixId(node.lookupPointer2).setNameId(node.lookupPointer1));
+    }
+
+    /**
+     * Encodes an IRI and returns only its lookup ids: the name id in the high 32 bits, the prefix id
+     * in the low 32. No RdfIri message is built and none is read back, which saves an allocation on
+     * a cache miss and a dereference on a hit - the ids are in the cache entry the probe just read.
+     * <p>
+     * The name-id and prefix-id inference of {@link #makeIri} is NOT applied: the ids come out as
+     * they are, and the caller decides how to compress them.
+     * @param iri The IRI to encode
+     * @return (nameId &lt;&lt; 32) | prefixId
+     */
+    public long makeIriIds(String iri) {
+        if (maxPrefixTableSize == 0) {
+            // Fast path for no prefixes
+            return (long) encodeIriNameOnly(iri) << 32;
+        }
+        final var node = encodeIriWithPrefix(iri);
+        return ((long) node.lookupPointer1 << 32) | Integer.toUnsignedLong(node.lookupPointer2);
     }
 
     /**
@@ -329,8 +363,11 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         // Slow path, with splitting out the prefix
         final var cachedNode = Objects.requireNonNull(iriNodeCache).get(iri);
         // Check if the value is still valid
+        // Lookup ids start at 1, so a zero name pointer means the slot has never been filled.
+        // The message itself is not the flag any more: a caller that only wants the ids never
+        // builds one.
         if (
-            cachedNode.encoded != null &&
+            cachedNode.lookupPointer1 != 0 &&
             cachedNode.lookupSerial1 == nameSerials[cachedNode.lookupPointer1] &&
             cachedNode.lookupSerial2 == prefixSerials[cachedNode.lookupPointer2]
         ) {
@@ -391,7 +428,9 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         cachedNode.lookupSerial1 = Objects.requireNonNull(nameLookup.serials)[nameId];
         cachedNode.lookupPointer2 = prefixId;
         cachedNode.lookupSerial2 = Objects.requireNonNull(prefixLookup.serials)[prefixId];
-        cachedNode.encoded = RdfIri.newInstance().setPrefixId(prefixId).setNameId(nameId);
+        // Whatever message was here is stale now that the ids have moved. Only Jelly-RDF ever
+        // builds one, and it does so on demand.
+        cachedNode.encoded = null;
         return cachedNode;
     }
 
@@ -492,7 +531,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
                 return RdfIri.newInstance().setPrefixId(prefixId);
             } else {
                 lastIriNameId = nameId;
-                return cachedNode.encoded;
+                return encodedIriOf(cachedNode);
             }
         }
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -136,6 +136,15 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     private int lastIriNameId;
     private int lastIriPrefixId = -1000;
 
+    // Lookup id of the prefix we split off the previous IRI. Consecutive IRIs almost always come
+    // from the same namespace, so checking whether this IRI starts with that prefix lets us skip
+    // allocating the prefix substring, hashing it, and probing the prefix map. The prefix string
+    // itself is read back from the lookup's names array, which by definition holds whatever the id
+    // means right now – so an entry that has been evicted and reassigned in the meantime cannot
+    // give a stale answer. Id 0 is never assigned and its name is always null, which is what makes
+    // the initial value safe.
+    private int lastPrefixId;
+
     private final EncoderLookup datatypeLookup;
     private final EncoderLookup prefixLookup;
     private final EncoderLookup nameLookup;
@@ -278,14 +287,16 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * @return the cached dependent node
      */
     private DependentNode<RdfIri> encodeIriWithPrefix(String iri) {
+        final var prefixLookup = Objects.requireNonNull(this.prefixLookup);
+        final var prefixSerials = Objects.requireNonNull(prefixLookup.serials);
+        final var nameSerials = Objects.requireNonNull(nameLookup.serials);
         // Slow path, with splitting out the prefix
         final var cachedNode = Objects.requireNonNull(iriNodeCache).get(iri);
         // Check if the value is still valid
         if (
             cachedNode.encoded != null &&
-            cachedNode.lookupSerial1 == Objects.requireNonNull(nameLookup.serials)[cachedNode.lookupPointer1] &&
-            cachedNode.lookupSerial2 ==
-                Objects.requireNonNull(Objects.requireNonNull(prefixLookup).serials)[cachedNode.lookupPointer2]
+            cachedNode.lookupSerial1 == nameSerials[cachedNode.lookupPointer1] &&
+            cachedNode.lookupSerial2 == prefixSerials[cachedNode.lookupPointer2]
         ) {
             nameLookup.onAccess(cachedNode.lookupPointer1);
             prefixLookup.onAccess(cachedNode.lookupPointer2);
@@ -293,36 +304,42 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         }
 
         int i = iri.indexOf('#', 8);
-        String prefix;
-        String postfix;
         if (i == -1) {
             i = iri.lastIndexOf('/');
-            if (i != -1) {
-                prefix = iri.substring(0, i + 1);
-                postfix = iri.substring(i + 1);
-            } else {
-                prefix = "";
-                postfix = iri;
-            }
+        }
+        // The prefix is iri[0, i + 1) and the name is the rest. i == -1 means there is no prefix,
+        // which falls out of the same arithmetic: an empty prefix and the whole IRI as the name.
+        final int prefixLen = i + 1;
+
+        final int prefixId;
+        final String lastPrefix = prefixLookup.names[lastPrefixId];
+        if (lastPrefix != null && lastPrefix.length() == prefixLen && iri.startsWith(lastPrefix)) {
+            // Same namespace as the previous IRI, so its id can be reused as it is. Only the LRU
+            // order has to be updated.
+            prefixId = lastPrefixId;
+            prefixLookup.onAccess(prefixId);
         } else {
-            prefix = iri.substring(0, i + 1);
-            postfix = iri.substring(i + 1);
+            final String prefix = iri.substring(0, prefixLen);
+            final var prefixEntry = prefixLookup.getOrAddEntry(prefix);
+            if (prefixEntry.newEntry) {
+                bufferAppender.appendPrefixEntry(
+                    RdfPrefixEntry.newInstance().setId(prefixEntry.setId).setValue(prefix)
+                );
+            }
+            prefixId = prefixEntry.getId;
+            this.lastPrefixId = prefixId;
         }
 
-        final var prefixEntry = Objects.requireNonNull(prefixLookup).getOrAddEntry(prefix);
+        final String postfix = i == -1 ? iri : iri.substring(prefixLen);
         final var nameEntry = nameLookup.getOrAddEntry(postfix);
-        if (prefixEntry.newEntry) {
-            bufferAppender.appendPrefixEntry(RdfPrefixEntry.newInstance().setId(prefixEntry.setId).setValue(prefix));
-        }
         if (nameEntry.newEntry) {
             bufferAppender.appendNameEntry(RdfNameEntry.newInstance().setId(nameEntry.setId).setValue(postfix));
         }
         int nameId = nameEntry.getId;
-        int prefixId = prefixEntry.getId;
         cachedNode.lookupPointer1 = nameId;
-        cachedNode.lookupSerial1 = Objects.requireNonNull(nameLookup.serials)[nameId];
+        cachedNode.lookupSerial1 = nameSerials[nameId];
         cachedNode.lookupPointer2 = prefixId;
-        cachedNode.lookupSerial2 = Objects.requireNonNull(prefixLookup.serials)[prefixId];
+        cachedNode.lookupSerial2 = prefixSerials[prefixId];
         cachedNode.encoded = RdfIri.newInstance().setPrefixId(prefixId).setNameId(nameId);
         return cachedNode;
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -14,7 +14,7 @@ import java.util.Objects;
  * @param <TNode> The type of RDF nodes used by the RDF library.
  */
 @InternalApi
-final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
+public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     /**
      * A cached node that depends on other lookups (RdfIri and RdfLiteral in the datatype variant).

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -22,9 +22,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     static final class DependentNode<V> {
 
         // The key this entry stands for, and its spread hash. Both live here rather than in a
-        // parallel array in the cache so that a probe touches the array and this object and
-        // nothing else: the hash decides whether the slot can match at all, and it sits in the
-        // same object as the answer.
+        // parallel array for better cache locality.
         public Object key;
         public int keyHash;
         // The actual cached node
@@ -94,19 +92,8 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * most-recent-first, so a miss evicts the older of the two. Adjacent slots share a cache line, so
      * the second probe costs almost nothing.
      *
-     * Worth it because a miss here is expensive: it splits the IRI into two substrings, hashes both
-     * in full and probes two lookup tables. On the SPARQL benchmark presets the IRI cache missed
-     * 22-32% of the time when direct-mapped, and most of that was keys evicting each other rather
-     * than the table being full.
+     * Worth it because a miss here is expensive (IRI re-encoding).
      *
-     * The DependentNode in a slot is recycled, so taking a slot over MUST clear `encoded` – otherwise
-     * the stale lookupPointer/lookupSerial pair could still validate and we would emit the previous
-     * key's IRI or datatype.
-     *
-     * The key and its hash live in the DependentNode rather than in a second array, so a probe reads
-     * the slot array and then one object, instead of a key array, a node array and then the object.
-     * The stored hash also means a slot that cannot match is rejected without dereferencing its key,
-     * which for the datatype literal cache saves a node comparison, not just a string one.
      * @param <V> Type of the encoded node
      */
     private static final class DependentNodeCache<V> {
@@ -155,14 +142,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     private final int maxPrefixTableSize;
     private int lastIriNameId;
     private int lastIriPrefixId = -1000;
-
-    // Lookup id of the prefix we split off the previous IRI. Consecutive IRIs almost always come
-    // from the same namespace, so checking whether this IRI starts with that prefix lets us skip
-    // allocating the prefix substring, hashing it, and probing the prefix map. The prefix string
-    // itself is read back from the lookup's names array, which by definition holds whatever the id
-    // means right now – so an entry that has been evicted and reassigned in the meantime cannot
-    // give a stale answer. Id 0 is never assigned and its name is always null, which is what makes
-    // the initial value safe.
+    // Lookup id of the prefix of the previous IRI.
     private int lastPrefixId;
 
     private final EncoderLookup datatypeLookup;
@@ -181,19 +161,10 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     static final RdfIri zeroIri = RdfIri.newInstance();
 
     /**
-     * Stand-in for a cache entry whose lookup ids are filled in but whose RdfIri was never built.
-     * Jelly-SPARQL only ever wants the two ids (see {@link #makeIriIds}), and building a message
-     * just to read them straight back out is the most expensive thing on that path. It is only
-     * ever a marker: a caller that does want the message materializes it, and this instance is
-     * never handed out.
+     * Marker for a cache entry whose lookup ids are filled in but whose RdfIri was never built.
+     * For example, Jelly-SPARQL only ever wants the two ids (see {@link #makeIriIds}).
      */
     private static final RdfIri IDS_ONLY = RdfIri.newInstance();
-    // One IRI with prefixId=0 per name lookup id, created the first time that id is emitted.
-    // Filling this eagerly used to dominate the cost of building an encoder – a name table entry
-    // is 8 bytes of array, but an RdfIri per entry is a separate object each. Most streams touch
-    // only a fraction of the table, and a stream that uses the prefix table (which is what
-    // Jelly-SPARQL always does) never reads this array at all, because it goes through
-    // makeIriRaw. Slot 0 is never used: lookup ids start at 1.
     private final RdfIri[] nameOnlyIris;
 
     /**
@@ -258,10 +229,6 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             maxNameTableSize,
             maxDatatypeTableSize,
             Math.clamp(maxNameTableSize, 256, 1024),
-            // Two IRI cache slots per name table entry. Distinct IRIs outnumber distinct names – one
-            // name can be the tail of several IRIs – so one slot per name entry leaves the cache
-            // short: on the SPARQL benchmark presets it missed 20-28% of the time at that size and
-            // 4-13% at twice that. The extra cost is one more slot pair per name entry.
             maxNameTableSize * 2,
             Math.clamp(maxNameTableSize, 256, 1024),
             bufferAppender
@@ -269,10 +236,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     }
 
     /**
-     * The prefix-0 IRI for a name id, created on first use. The returned object is handed on to the
-     * frame buffer and must therefore stay valid until the frame is serialized, which is why one is
-     * kept per id instead of a single mutable one. An id that gets evicted and reassigned keeps its
-     * IRI: only the id is encoded, not the name behind it.
+     * The prefix-0 IRI for a name id, created on first use.
      * @param nameId The id of the entry in the name lookup
      */
     private RdfIri nameOnlyIri(int nameId) {
@@ -337,8 +301,6 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         final var nameSerials = Objects.requireNonNull(nameLookup.serials);
         // Slow path, with splitting out the prefix
         final var cachedNode = Objects.requireNonNull(iriNodeCache).get(iri);
-        // Check if the value is still valid. A recycled slot has its `encoded` cleared, and an
-        // entry whose ids are filled in carries at least the IDS_ONLY marker, so this covers both.
         if (
             cachedNode.encoded != null &&
             cachedNode.lookupSerial1 == nameSerials[cachedNode.lookupPointer1] &&
@@ -353,10 +315,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         if (i == -1) {
             i = iri.lastIndexOf('/');
         }
-        // The prefix is iri[0, i + 1) and the name is the rest. i == -1 means there is no prefix,
-        // which falls out of the same arithmetic: an empty prefix and the whole IRI as the name.
         final int prefixLen = i + 1;
-
         final int prefixId;
         final String prefix;
         final String lastPrefix = prefixLookup.names[lastPrefixId];
@@ -378,12 +337,8 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             this.lastPrefixId = prefixId;
         }
 
-        // The name is the tail of the IRI, so the lookup can match it in place. Most of the time
-        // the name is already known and no substring has to be cut out at all.
-        //
-        // Its hash comes out of the IRI's and the prefix's, so the name never has to be scanned.
-        // Both of those are cached in their String: the IRI's was just computed by the node cache
-        // probe above, and the prefix is the one the lookup itself is holding on to.
+        // Name's (suffix's) hashcode is calculated without looking at the string itself,
+        // based on the prefix hashcode. See EncoderLookup.hashOfSuffix
         final var nameEntry = nameLookup.getOrAddEntry(
             iri,
             prefixLen,
@@ -396,12 +351,9 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         }
         int nameId = nameEntry.getId;
         cachedNode.lookupPointer1 = nameId;
-        // The serial arrays are read from the lookups again here: adding an entry can grow a
-        // lookup, and then the arrays fetched at the top of this method are the old, shorter ones.
         cachedNode.lookupSerial1 = Objects.requireNonNull(nameLookup.serials)[nameId];
         cachedNode.lookupPointer2 = prefixId;
         cachedNode.lookupSerial2 = Objects.requireNonNull(prefixLookup.serials)[prefixId];
-        // Left unbuilt until someone asks for the message itself – see IDS_ONLY.
         cachedNode.encoded = IDS_ONLY;
         return cachedNode;
     }
@@ -421,11 +373,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     /**
      * The name and prefix ids of an IRI, packed as {@code (nameId << 32) | prefixId}, without
-     * building an RdfIri for them.
-     * <p>
-     * This is what Jelly-SPARQL encodes from: it writes the two ids into its own column buffers
-     * and never needs the message, so going through {@link #makeIriRaw} would allocate one on
-     * every cache miss purely to have two ints read back out of it.
+     * building an RdfIri. Used in Jelly-SPARQL.
      *
      * @param iri The IRI to encode
      */

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -77,9 +77,20 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
     }
 
     /**
-     * The same, for nodes that depend on lookup entries. The DependentNode in a slot is recycled, so
-     * taking a slot over MUST clear `encoded` – otherwise the stale lookupPointer/lookupSerial pair
-     * could still validate and we would emit the previous key's IRI or datatype.
+     * The same, for nodes that depend on lookup entries, but 2-way set associative: the hash picks a
+     * pair of adjacent slots and the key may be in either of them. Two keys that hash to the same set
+     * can then both stay cached, which a direct-mapped table cannot do. The pair is kept
+     * most-recent-first, so a miss evicts the older of the two. Adjacent slots share a cache line, so
+     * the second probe costs almost nothing.
+     *
+     * Worth it because a miss here is expensive: it splits the IRI into two substrings, hashes both
+     * in full and probes two lookup tables. On the SPARQL benchmark presets the IRI cache missed
+     * 22-32% of the time when direct-mapped, and most of that was keys evicting each other rather
+     * than the table being full.
+     *
+     * The DependentNode in a slot is recycled, so taking a slot over MUST clear `encoded` – otherwise
+     * the stale lookupPointer/lookupSerial pair could still validate and we would emit the previous
+     * key's IRI or datatype.
      * @param <V> Type of the encoded node
      */
     private static final class DependentNodeCache<V> {
@@ -93,21 +104,31 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             final int size = tableSizeFor(minSize);
             this.keys = new Object[size];
             this.nodes = new DependentNode[size];
-            this.mask = size - 1;
+            // A set is two adjacent slots, so there are half as many sets as slots.
+            this.mask = (size >> 1) - 1;
         }
 
         DependentNode<V> get(Object key) {
-            final int slot = slotFor(key, mask);
-            final var node = nodes[slot];
-            if (node == null) {
-                keys[slot] = key;
-                return (nodes[slot] = new DependentNode<>());
+            final int slot = slotFor(key, mask) << 1;
+            if (key.equals(keys[slot])) {
+                return nodes[slot];
             }
-            if (!key.equals(keys[slot])) {
-                keys[slot] = key;
+            // Not in the first way. Whatever is in the first way moves to the second, and the key we
+            // are looking for takes the first – either promoted from the second way, or reusing the
+            // node that the second way held. A key is never in both ways, and a slot only ever has a
+            // node once it has a key, so a null node here means the pair is not full yet.
+            final var other = nodes[slot + 1];
+            final DependentNode<V> node;
+            if (key.equals(keys[slot + 1])) {
+                node = other;
+            } else {
+                node = other == null ? new DependentNode<>() : other;
                 node.encoded = null;
             }
-            return node;
+            keys[slot + 1] = keys[slot];
+            nodes[slot + 1] = nodes[slot];
+            keys[slot] = key;
+            return (nodes[slot] = node);
         }
     }
 
@@ -197,7 +218,12 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             maxNameTableSize,
             maxDatatypeTableSize,
             Math.clamp(maxNameTableSize, 256, 1024),
-            maxNameTableSize,
+            // Two IRI cache slots per name table entry. Distinct IRIs outnumber distinct names – one
+            // name can be the tail of several IRIs – so one slot per name entry leaves the cache
+            // short: on the SPARQL benchmark presets it missed 20-28% of the time at that size and
+            // 4-13% at twice that. The extra cost is one more slot pair per name entry, which is on
+            // the order of the RdfIri per name entry that the encoder already keeps in nameOnlyIris.
+            maxNameTableSize * 2,
             Math.clamp(maxNameTableSize, 256, 1024),
             bufferAppender
         );

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -356,9 +356,11 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         }
         int nameId = nameEntry.getId;
         cachedNode.lookupPointer1 = nameId;
-        cachedNode.lookupSerial1 = nameSerials[nameId];
+        // The serial arrays are read from the lookups again here: adding an entry can grow a
+        // lookup, and then the arrays fetched at the top of this method are the old, shorter ones.
+        cachedNode.lookupSerial1 = Objects.requireNonNull(nameLookup.serials)[nameId];
         cachedNode.lookupPointer2 = prefixId;
-        cachedNode.lookupSerial2 = prefixSerials[prefixId];
+        cachedNode.lookupSerial2 = Objects.requireNonNull(prefixLookup.serials)[prefixId];
         cachedNode.encoded = RdfIri.newInstance().setPrefixId(prefixId).setNameId(nameId);
         return cachedNode;
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -91,8 +91,9 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * can then both stay cached, which a direct-mapped table cannot do. The pair is kept
      * most-recent-first, so a miss evicts the older of the two. Adjacent slots share a cache line, so
      * the second probe costs almost nothing.
-     *
-     * Worth it because a miss here is expensive (IRI re-encoding).
+     * <p>
+     * This is worth it because a cache miss here is expensive (requires re-encoding the IRI
+     * and a few more lookups).
      *
      * @param <V> Type of the encoded node
      */
@@ -120,9 +121,10 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             if (holds(first, key, hash)) {
                 return first;
             }
-            // Not in the first way. Whatever is in the first way moves to the second, and the key we
-            // are looking for takes the first – either promoted from the second way, or reusing the
-            // node that the second way held. A key is never in both ways, and the second way is only
+            // The item is not in the first cache line.
+            // Whatever is in the first line is moved to the second line, and the key we
+            // are looking for takes the first – either promoted from the second line, or reusing the
+            // node that the second line held. A key is never in both lines, and the second line is only
             // ever filled after the first, so a null there means the pair is not full yet.
             final var other = nodes[slot + 1];
             final DependentNode<V> node;

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -159,6 +159,15 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
     // Pre-allocated IRI that has prefixId=0 and nameId=0
     static final RdfIri zeroIri = RdfIri.newInstance();
+
+    /**
+     * Stand-in for a cache entry whose lookup ids are filled in but whose RdfIri was never built.
+     * Jelly-SPARQL only ever wants the two ids (see {@link #makeIriIds}), and building a message
+     * just to read them straight back out is the most expensive thing on that path. It is only
+     * ever a marker: a caller that does want the message materializes it, and this instance is
+     * never handed out.
+     */
+    private static final RdfIri IDS_ONLY = RdfIri.newInstance();
     // One IRI with prefixId=0 per name lookup id, created the first time that id is emitted.
     // Filling this eagerly used to dominate the cost of building an encoder – a name table entry
     // is 8 bytes of array, but an RdfIri per entry is a separate object each. Most streams touch
@@ -218,7 +227,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * @param maxDatatypeTableSize The maximum size of the datatype table
      * @return A new NodeEncoder
      */
-    public static <TNode> NodeEncoder<TNode> create(
+    public static <TNode> NodeEncoderImpl<TNode> create(
         RdfBufferAppender<TNode> bufferAppender,
         int maxPrefixTableSize,
         int maxNameTableSize,
@@ -280,7 +289,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             // Fast path for no prefixes
             return nameOnlyIri(encodeIriNameOnly(iri));
         }
-        return encodeIriWithPrefix(iri).encoded;
+        return materializedIri(encodeIriWithPrefix(iri));
     }
 
     /**
@@ -361,8 +370,41 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         cachedNode.lookupSerial1 = Objects.requireNonNull(nameLookup.serials)[nameId];
         cachedNode.lookupPointer2 = prefixId;
         cachedNode.lookupSerial2 = Objects.requireNonNull(prefixLookup.serials)[prefixId];
-        cachedNode.encoded = RdfIri.newInstance().setPrefixId(prefixId).setNameId(nameId);
+        // Left unbuilt until someone asks for the message itself – see IDS_ONLY.
+        cachedNode.encoded = IDS_ONLY;
         return cachedNode;
+    }
+
+    /**
+     * The RdfIri of a cached node, built now if it was only ever asked for as a pair of ids.
+     */
+    private static RdfIri materializedIri(DependentNode<RdfIri> cachedNode) {
+        final RdfIri encoded = cachedNode.encoded;
+        if (encoded != IDS_ONLY) {
+            return encoded;
+        }
+        return (cachedNode.encoded = RdfIri.newInstance()
+                .setPrefixId(cachedNode.lookupPointer2)
+                .setNameId(cachedNode.lookupPointer1));
+    }
+
+    /**
+     * The name and prefix ids of an IRI, packed as {@code (nameId << 32) | prefixId}, without
+     * building an RdfIri for them.
+     * <p>
+     * This is what Jelly-SPARQL encodes from: it writes the two ids into its own column buffers
+     * and never needs the message, so going through {@link #makeIriRaw} would allocate one on
+     * every cache miss purely to have two ints read back out of it.
+     *
+     * @param iri The IRI to encode
+     */
+    public long makeIriIds(String iri) {
+        if (maxPrefixTableSize == 0) {
+            // Fast path for no prefixes – the prefix id is always 0
+            return (long) encodeIriNameOnly(iri) << 32;
+        }
+        final var cachedNode = encodeIriWithPrefix(iri);
+        return ((long) cachedNode.lookupPointer1 << 32) | (cachedNode.lookupPointer2 & 0xffffffffL);
     }
 
     @Override
@@ -462,7 +504,7 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
                 return RdfIri.newInstance().setPrefixId(prefixId);
             } else {
                 lastIriNameId = nameId;
-                return cachedNode.encoded;
+                return materializedIri(cachedNode);
             }
         }
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -21,6 +21,12 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      */
     static final class DependentNode<V> {
 
+        // The key this entry stands for, and its spread hash. Both live here rather than in a
+        // parallel array in the cache so that a probe touches the array and this object and
+        // nothing else: the hash decides whether the slot can match at all, and it sits in the
+        // same object as the answer.
+        public Object key;
+        public int keyHash;
         // The actual cached node
         public V encoded;
         // 1: datatypes and IRI names
@@ -38,10 +44,15 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         return Integer.highestOneBit(Math.max(minSize - 1, 1)) << 1;
     }
 
+    /** Xor-folds a hash, so that hashCodes differing only high up still spread over the slots. */
+    private static int spread(Object key) {
+        final int h = key.hashCode() * 0x9E3779B1;
+        return h ^ (h >>> 16);
+    }
+
     /** Picks the slot for a key, xor-folding so that hashCodes differing only high up still spread. */
     private static int slotFor(Object key, int mask) {
-        final int h = key.hashCode() * 0x9E3779B1;
-        return (h ^ (h >>> 16)) & mask;
+        return spread(key) & mask;
     }
 
     /**
@@ -91,43 +102,52 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
      * The DependentNode in a slot is recycled, so taking a slot over MUST clear `encoded` – otherwise
      * the stale lookupPointer/lookupSerial pair could still validate and we would emit the previous
      * key's IRI or datatype.
+     *
+     * The key and its hash live in the DependentNode rather than in a second array, so a probe reads
+     * the slot array and then one object, instead of a key array, a node array and then the object.
+     * The stored hash also means a slot that cannot match is rejected without dereferencing its key,
+     * which for the datatype literal cache saves a node comparison, not just a string one.
      * @param <V> Type of the encoded node
      */
     private static final class DependentNodeCache<V> {
 
-        private final Object[] keys;
         private final DependentNode<V>[] nodes;
         private final int mask;
 
         @SuppressWarnings("unchecked")
         DependentNodeCache(int minSize) {
             final int size = tableSizeFor(minSize);
-            this.keys = new Object[size];
             this.nodes = new DependentNode[size];
             // A set is two adjacent slots, so there are half as many sets as slots.
             this.mask = (size >> 1) - 1;
         }
 
+        private static boolean holds(DependentNode<?> node, Object key, int hash) {
+            return node != null && node.keyHash == hash && key.equals(node.key);
+        }
+
         DependentNode<V> get(Object key) {
-            final int slot = slotFor(key, mask) << 1;
-            if (key.equals(keys[slot])) {
-                return nodes[slot];
+            final int hash = spread(key);
+            final int slot = (hash & mask) << 1;
+            final var first = nodes[slot];
+            if (holds(first, key, hash)) {
+                return first;
             }
             // Not in the first way. Whatever is in the first way moves to the second, and the key we
             // are looking for takes the first – either promoted from the second way, or reusing the
-            // node that the second way held. A key is never in both ways, and a slot only ever has a
-            // node once it has a key, so a null node here means the pair is not full yet.
+            // node that the second way held. A key is never in both ways, and the second way is only
+            // ever filled after the first, so a null there means the pair is not full yet.
             final var other = nodes[slot + 1];
             final DependentNode<V> node;
-            if (key.equals(keys[slot + 1])) {
+            if (holds(other, key, hash)) {
                 node = other;
             } else {
                 node = other == null ? new DependentNode<>() : other;
                 node.encoded = null;
+                node.key = key;
+                node.keyHash = hash;
             }
-            keys[slot + 1] = keys[slot];
-            nodes[slot + 1] = nodes[slot];
-            keys[slot] = key;
+            nodes[slot + 1] = first;
             return (nodes[slot] = node);
         }
     }

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -330,10 +330,13 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
             this.lastPrefixId = prefixId;
         }
 
-        final String postfix = i == -1 ? iri : iri.substring(prefixLen);
-        final var nameEntry = nameLookup.getOrAddEntry(postfix);
+        // The name is the tail of the IRI, so the lookup can match it in place. Most of the time
+        // the name is already known and no substring has to be cut out at all.
+        final var nameEntry = nameLookup.getOrAddEntry(iri, prefixLen);
         if (nameEntry.newEntry) {
-            bufferAppender.appendNameEntry(RdfNameEntry.newInstance().setId(nameEntry.setId).setValue(postfix));
+            bufferAppender.appendNameEntry(
+                RdfNameEntry.newInstance().setId(nameEntry.setId).setValue(nameLookup.names[nameEntry.getId])
+            );
         }
         int nameId = nameEntry.getId;
         cachedNode.lookupPointer1 = nameId;

--- a/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
+++ b/core/src/main/java/eu/neverblink/jelly/core/internal/NodeEncoderImpl.java
@@ -328,14 +328,16 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
         final int prefixLen = i + 1;
 
         final int prefixId;
+        final String prefix;
         final String lastPrefix = prefixLookup.names[lastPrefixId];
         if (lastPrefix != null && lastPrefix.length() == prefixLen && iri.startsWith(lastPrefix)) {
             // Same namespace as the previous IRI, so its id can be reused as it is. Only the LRU
             // order has to be updated.
+            prefix = lastPrefix;
             prefixId = lastPrefixId;
             prefixLookup.onAccess(prefixId);
         } else {
-            final String prefix = iri.substring(0, prefixLen);
+            prefix = iri.substring(0, prefixLen);
             final var prefixEntry = prefixLookup.getOrAddEntry(prefix);
             if (prefixEntry.newEntry) {
                 bufferAppender.appendPrefixEntry(
@@ -348,7 +350,15 @@ public final class NodeEncoderImpl<TNode> implements NodeEncoder<TNode> {
 
         // The name is the tail of the IRI, so the lookup can match it in place. Most of the time
         // the name is already known and no substring has to be cut out at all.
-        final var nameEntry = nameLookup.getOrAddEntry(iri, prefixLen);
+        //
+        // Its hash comes out of the IRI's and the prefix's, so the name never has to be scanned.
+        // Both of those are cached in their String: the IRI's was just computed by the node cache
+        // probe above, and the prefix is the one the lookup itself is holding on to.
+        final var nameEntry = nameLookup.getOrAddEntry(
+            iri,
+            prefixLen,
+            EncoderLookup.hashOfSuffix(iri.hashCode(), prefix.hashCode(), iri.length() - prefixLen)
+        );
         if (nameEntry.newEntry) {
             bufferAppender.appendNameEntry(
                 RdfNameEntry.newInstance().setId(nameEntry.setId).setValue(nameLookup.names[nameEntry.getId])

--- a/core/src/test/scala/eu/neverblink/jelly/core/Rdf2ProtoSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/Rdf2ProtoSpec.scala
@@ -33,33 +33,25 @@ class Rdf2ProtoSpec extends AnyWordSpec, Matchers:
     msg.getSerializedSize shouldBe bytes.length
 
   "the packed lookup entries" should {
-    "round-trip a run of names" in {
+    "round-trip a run with an explicit id" in {
       checkMessage(
-        RdfNameEntryPacked.newInstance().setId(3).addValues("a").addValues("b"),
-        () => RdfNameEntryPacked.newInstance(),
-        RdfNameEntryPacked.parseFrom,
+        RdfLookupEntryPacked.newInstance().setId(3).addValues("a").addValues("b"),
+        () => RdfLookupEntryPacked.newInstance(),
+        RdfLookupEntryPacked.parseFrom,
       )
     }
 
-    "round-trip a run of prefixes" in {
+    "round-trip a run continuing from the previous entry" in {
       checkMessage(
-        RdfPrefixEntryPacked.newInstance().addValues("https://test.org/"),
-        () => RdfPrefixEntryPacked.newInstance(),
-        RdfPrefixEntryPacked.parseFrom,
-      )
-    }
-
-    "round-trip a run of datatypes" in {
-      checkMessage(
-        RdfDatatypeEntryPacked.newInstance().setId(1).addValues("https://test.org/dt"),
-        () => RdfDatatypeEntryPacked.newInstance(),
-        RdfDatatypeEntryPacked.parseFrom,
+        RdfLookupEntryPacked.newInstance().addValues("https://test.org/"),
+        () => RdfLookupEntryPacked.newInstance(),
+        RdfLookupEntryPacked.parseFrom,
       )
     }
 
     "cost less than the same entries stated one by one" in {
       val values = (1 to 10).map(i => s"name$i")
-      val packed = RdfNameEntryPacked.newInstance()
+      val packed = RdfLookupEntryPacked.newInstance()
       values.foreach(packed.addValues)
       val unpacked = values.map(v => RdfNameEntry.newInstance().setValue(v))
       // Each unpacked entry pays for its own message framing when put in a repeated field
@@ -70,15 +62,7 @@ class Rdf2ProtoSpec extends AnyWordSpec, Matchers:
 
   "the rdf2 descriptors" should {
     "be available for every message" in {
-      Rdf2.getDescriptor.getMessageTypes.size shouldBe 3
-      Seq(
-        RdfNameEntryPacked.getDescriptor,
-        RdfPrefixEntryPacked.getDescriptor,
-        RdfDatatypeEntryPacked.getDescriptor,
-      ).map(_.getName) shouldBe Seq(
-        "RdfNameEntryPacked",
-        "RdfPrefixEntryPacked",
-        "RdfDatatypeEntryPacked",
-      )
+      Rdf2.getDescriptor.getMessageTypes.size shouldBe 1
+      RdfLookupEntryPacked.getDescriptor.getName shouldBe "RdfLookupEntryPacked"
     }
   }

--- a/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
@@ -118,6 +118,52 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
         v.getId should be > 0
     }
 
+    "look up keys given as a suffix of a longer string" in {
+      val lookup = EncoderLookup(8, true)
+      // Same key, once as a whole string and once as a suffix – both must land on the same entry.
+      val whole = lookup.getOrAddEntry("name0")
+      whole.newEntry should be(true)
+      val suffix = lookup.getOrAddEntry("https://example.org/name0", 20)
+      suffix.newEntry should be(false)
+      suffix.getId should be(whole.getId)
+      // A suffix that is not there yet is added, and the stored name is just the suffix.
+      val fresh = lookup.getOrAddEntry("https://example.org/name1", 20)
+      fresh.newEntry should be(true)
+      lookup.names(fresh.getId) should be("name1")
+      lookup.getOrAddEntry("name1").getId should be(fresh.getId)
+      // from == 0 is the whole string
+      lookup.getOrAddEntry("name0", 0).getId should be(whole.getId)
+    }
+
+    // Eviction reassigns an id, which means the old key has to come out of the hash index. With
+    // linear probing that leaves a hole which the keys behind it may be reachable only through, so
+    // this exercises a deliberately tiny index filled with keys that all collide.
+    "keep colliding keys reachable across many evictions" in {
+      val lookup = EncoderLookup(8, true)
+      // 64 keys cycling through 8 entries, so the 16-slot index is permanently half full and
+      // every miss both evicts and re-inserts.
+      val keys = (0 until 64).map(i => s"k${('a' + i % 26).toChar}${('a' + i / 26).toChar}")
+      val seen = scala.collection.mutable.LinkedHashMap.empty[String, Int]
+      for round <- 0 until 200 do
+        val key = keys(Random.nextInt(keys.size))
+        val v = lookup.getOrAddEntry(key)
+        v.getId should be > 0
+        v.getId should be <= 8
+        // The lookup's own name table is the ground truth for what an id currently means.
+        lookup.names(v.getId) should be(key)
+        if v.newEntry then seen(key) = v.getId
+        else seen(key) should be(v.getId)
+        // Everything the LRU still holds must be findable, and nothing else may be.
+        for (k, id) <- seen.toSeq do
+          if lookup.names(id) == k then lookup.getOrAddEntry(k).newEntry should be(false)
+          else seen -= k
+      // The name table and the index must agree in both directions at the end.
+      for id <- 1 to 8 do
+        val name = lookup.names(id)
+        name should not be null
+        lookup.getOrAddEntry(name).getId should be(id)
+    }
+
     "not use the serials table if not needed" in {
       val lookup = EncoderLookup(16, false)
       for _ <- 1 to 2000 do

--- a/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
@@ -120,19 +120,34 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
 
     "look up keys given as a suffix of a longer string" in {
       val lookup = EncoderLookup(8, true)
+      // The caller supplies the hash, and it has to be the one the suffix itself would have.
+      def suffixEntry(source: String, from: Int) =
+        lookup.getOrAddEntry(source, from, source.substring(from).hashCode)
+
       // Same key, once as a whole string and once as a suffix – both must land on the same entry.
       val whole = lookup.getOrAddEntry("name0")
       whole.newEntry should be(true)
-      val suffix = lookup.getOrAddEntry("https://example.org/name0", 20)
+      val suffix = suffixEntry("https://example.org/name0", 20)
       suffix.newEntry should be(false)
       suffix.getId should be(whole.getId)
       // A suffix that is not there yet is added, and the stored name is just the suffix.
-      val fresh = lookup.getOrAddEntry("https://example.org/name1", 20)
+      val fresh = suffixEntry("https://example.org/name1", 20)
       fresh.newEntry should be(true)
       lookup.names(fresh.getId) should be("name1")
       lookup.getOrAddEntry("name1").getId should be(fresh.getId)
       // from == 0 is the whole string
-      lookup.getOrAddEntry("name0", 0).getId should be(whole.getId)
+      suffixEntry("name0", 0).getId should be(whole.getId)
+    }
+
+    "reject a table larger than the id field can address" in {
+      val error = intercept[IllegalArgumentException] {
+        EncoderLookup(EncoderLookup.MAX_TABLE_SIZE + 1, true)
+      }
+      error.getMessage should include("above the maximum")
+      // The boundary itself is fine – allocating it is wasteful but legal
+      EncoderLookup(EncoderLookup.MAX_TABLE_SIZE, false).size should be(
+        EncoderLookup.MAX_TABLE_SIZE,
+      )
     }
 
     // Eviction reassigns an id, which means the old key has to come out of the hash index. With

--- a/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
+++ b/core/src/test/scala/eu/neverblink/jelly/core/internal/EncoderLookupSpec.scala
@@ -164,6 +164,30 @@ class EncoderLookupSpec extends AnyWordSpec, Matchers:
         lookup.getOrAddEntry(name).getId should be(id)
     }
 
+    // The encoder never scans an IRI's local name to hash it – it subtracts the prefix's hash out
+    // of the whole IRI's. If that arithmetic is off by anything at all, the same name gets filed
+    // under two different slots and the lookup silently stops finding entries that are there.
+    "derive a suffix's hash from the whole string's and the prefix's" in {
+      val strings = Seq(
+        "",
+        "a",
+        "https://example.org/ns0#term1",
+        "https://example.org/a/b/c",
+        // Longer than the tabulated powers of 31, so this goes through the computed path
+        "https://example.org/" + "x" * 400,
+        // Non-ASCII, where a char is not a byte
+        "https://example.org/é中😀",
+      )
+      for s <- strings; i <- 0 to s.length do
+        val prefix = s.substring(0, i)
+        val suffix = s.substring(i)
+        withClue(s"'$s' split at $i: ") {
+          EncoderLookup.hashOfSuffix(s.hashCode, prefix.hashCode, suffix.length) should be(
+            suffix.hashCode,
+          )
+        }
+    }
+
     "not use the serials table if not needed" in {
       val lookup = EncoderLookup(16, false)
       for _ <- 1 to 2000 do

--- a/jena-sparql/src/main/java/eu/neverblink/jelly/convert/jena/sparql/RowSetWriterJelly.java
+++ b/jena-sparql/src/main/java/eu/neverblink/jelly/convert/jena/sparql/RowSetWriterJelly.java
@@ -64,7 +64,10 @@ public final class RowSetWriterJelly implements RowSetWriter {
         final List<Var> vars = rowSet.getResultVars();
         final SparqlEncoder<Node> encoder = converterFactory.encoder(SparqlEncoder.Params.of(options.options()));
         encoder.setVariables(vars.stream().map(Var::getVarName).toList());
-        final Node[] row = new Node[vars.size()];
+        // Copied out of the list once: the row loop below reads this per cell, and going through
+        // List.get for that costs an interface call and a bounds check every time.
+        final Var[] varArray = vars.toArray(new Var[0]);
+        final Node[] row = new Node[varArray.length];
         // Frames are budgeted in values, so the row limit depends on how wide the result set is.
         // A zero-variable result set carries no values at all, hence the lower bound of one row.
         final int rowsPerFrame = Math.max(1, options.maxValuesPerFrame() / Math.max(1, row.length));
@@ -74,8 +77,8 @@ public final class RowSetWriterJelly implements RowSetWriter {
             int rowsInFrame = 0;
             while (rowSet.hasNext()) {
                 final Binding binding = rowSet.next();
-                for (int i = 0; i < row.length; i++) {
-                    row[i] = binding.get(vars.get(i));
+                for (int i = 0; i < varArray.length; i++) {
+                    row[i] = binding.get(varArray[i]);
                 }
                 if (!encoder.appendRow(row)) {
                     // The frame filled up its lookup tables before reaching the row limit

--- a/jena-sparql/src/main/java/eu/neverblink/jelly/convert/jena/sparql/RowSetWriterJelly.java
+++ b/jena-sparql/src/main/java/eu/neverblink/jelly/convert/jena/sparql/RowSetWriterJelly.java
@@ -64,8 +64,7 @@ public final class RowSetWriterJelly implements RowSetWriter {
         final List<Var> vars = rowSet.getResultVars();
         final SparqlEncoder<Node> encoder = converterFactory.encoder(SparqlEncoder.Params.of(options.options()));
         encoder.setVariables(vars.stream().map(Var::getVarName).toList());
-        // Copied out of the list once: the row loop below reads this per cell, and going through
-        // List.get for that costs an interface call and a bounds check every time.
+        // Repeatedly iterating over an array copy is faster than over a List.
         final Var[] varArray = vars.toArray(new Var[0]);
         final Node[] row = new Node[varArray.length];
         // Frames are budgeted in values, so the row limit depends on how wide the result set is.

--- a/jmh/README.md
+++ b/jmh/README.md
@@ -17,13 +17,13 @@ sbt "jmh/Jmh/run -wi 10 -i 10 .*RdfIriParseBench.*"
 To run with the perfasm profiler, use:
 
 ```bash
-sbt "jmh/Jmh/run -f1 -prof "perfasm:intelSyntax=true;tooBigThreshold=1500;top=3" .*RdfIriParseBench.*"
+sbt "jmh/Jmh/run -f1 -prof \"perfasm:intelSyntax=true;tooBigThreshold=1500;top=3\" .*RdfIriParseBench.*"
 ```
 
 Run this to get all options for perfasm:
 
 ```bash
-sbt "jmh/Jmh/run -f1 -prof perfasm:help"
+sbt "jmh/Jmh/run -f1 -prof \"perfasm:help\""
 ```
 
 To see allocation rates:

--- a/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/ArrayNodeCache.java
+++ b/jmh/src/main/java/eu/neverblink/jelly/jmh/caches/ArrayNodeCache.java
@@ -5,6 +5,10 @@ import java.util.function.Function;
 /**
  * Direct-mapped cache: a power-of-two table indexed by the mixed hash, where a colliding key
  * overwrites the slot.
+ *
+ * <p>The same table can also be read 2-way set associative, see {@link #getOrCompute2Way}. Both
+ * geometries use the same capacity, so a benchmark comparing them compares hit rate and probe cost,
+ * not memory.
  */
 public final class ArrayNodeCache<K, V> {
 
@@ -31,6 +35,25 @@ public final class ArrayNodeCache<K, V> {
             return (V) values[pos];
         }
         final var value = mappingFunction.apply(key);
+        keys[pos] = key;
+        values[pos] = value;
+        return value;
+    }
+
+    /**
+     * Reads the table as 2-way set associative: the hash picks a pair of adjacent slots and either
+     * of them can hold the key. The pair is kept most-recent-first, so a miss evicts the older entry.
+     */
+    @SuppressWarnings("unchecked")
+    public V getOrCompute2Way(K key, Function<K, V> mappingFunction) {
+        // Half as many sets as slots, hence the shifted mask.
+        final int pos = (mix(key.hashCode()) & (mask >> 1)) << 1;
+        if (key.equals(keys[pos])) {
+            return (V) values[pos];
+        }
+        final var value = key.equals(keys[pos + 1]) ? (V) values[pos + 1] : mappingFunction.apply(key);
+        keys[pos + 1] = keys[pos];
+        values[pos + 1] = values[pos];
         keys[pos] = key;
         values[pos] = value;
         return value;

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
@@ -14,19 +14,10 @@ import scala.collection.mutable
 import scala.compiletime.uninitialized
 
 /** Number of triples the benchmark encodes per invocation.
-  *
-  * Has to be an `inline val` – `@OperationsPerInvocation` takes a compile-time constant.
   */
 inline val encoderTriples = 100_000
 
 /** Throughput of the RDF encoder (Jena nodes in, RdfStreamRows out), in triples per second.
-  *
-  * Protobuf serialization is deliberately left out – this measures `ProtoEncoder` and everything
-  * under it (the node caches and `EncoderLookup`), which is what changes there actually move.
-  *
-  * The `preset` parameter matters a lot for `EncoderLookup`: with `big` the lookup tables never
-  * fill up on this dataset and nothing is ever evicted, while with `small` the prefix table
-  * thrashes and roughly half the lookups end in an eviction.
   */
 object EncoderBench:
   @State(Scope.Benchmark)
@@ -85,7 +76,7 @@ class EncoderBench extends CommonParams:
   @Benchmark
   @OperationsPerInvocation(encoderTriples)
   def encodeTriples(blackhole: Blackhole, input: BenchInput): Unit =
-    // Mirrors JellyStreamWriter: a reusable buffer and an arena allocator, flushed every frame.
+    // Same as JellyStreamWriter: a reusable buffer and an arena allocator, flushed every frame.
     val buffer = RowBuffer.newReusableForEncoder(frameSize + 8)
     val allocator = EncoderAllocator.newArenaAllocator(frameSize + 8)
     val encoder = JenaConverterFactory

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
@@ -9,7 +9,6 @@ import org.apache.jena.graph.{Node, Triple}
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 
-import java.util.concurrent.TimeUnit
 import scala.collection.mutable
 import scala.compiletime.uninitialized
 

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderBench.scala
@@ -1,0 +1,104 @@
+package eu.neverblink.jelly.jmh
+
+import eu.neverblink.jelly.convert.jena.JenaConverterFactory
+import eu.neverblink.jelly.core.{JellyOptions, ProtoEncoder}
+import eu.neverblink.jelly.core.RdfHandler.AnyStatementHandler
+import eu.neverblink.jelly.core.memory.{EncoderAllocator, RowBuffer}
+import eu.neverblink.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
+import org.apache.jena.graph.{Node, Triple}
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable
+import scala.compiletime.uninitialized
+
+/** Number of triples the benchmark encodes per invocation.
+  *
+  * Has to be an `inline val` – `@OperationsPerInvocation` takes a compile-time constant.
+  */
+inline val encoderTriples = 100_000
+
+/** Throughput of the RDF encoder (Jena nodes in, RdfStreamRows out), in triples per second.
+  *
+  * Protobuf serialization is deliberately left out – this measures `ProtoEncoder` and everything
+  * under it (the node caches and `EncoderLookup`), which is what changes there actually move.
+  *
+  * The `preset` parameter matters a lot for `EncoderLookup`: with `big` the lookup tables never
+  * fill up on this dataset and nothing is ever evicted, while with `small` the prefix table
+  * thrashes and roughly half the lookups end in an eviction.
+  */
+object EncoderBench:
+  @State(Scope.Benchmark)
+  class BenchInput:
+    @Param(Array("big", "big-full", "small"))
+    var preset: String = uninitialized
+
+    var triples: Array[Triple] = uninitialized
+    var options: RdfStreamOptions = uninitialized
+
+    @Setup(Level.Trial)
+    def setup(): Unit =
+      options = preset match
+        case "big" => JellyOptions.BIG_STRICT
+        // This dataset has ~1000 distinct IRI names, so the "big" name table (4000) never fills up
+        // on it and nothing is ever evicted. This variant shrinks just the name table so that it
+        // does fill up, which is what a larger dataset would do to the "big" preset.
+        case "big-full" => JellyOptions.BIG_STRICT.clone().setMaxNameTableSize(512)
+        case "small" => JellyOptions.SMALL_STRICT
+        case other =>
+          throw IllegalArgumentException(
+            s"Unknown preset '$other'. Available: big, big-full, small",
+          )
+
+      val builder = mutable.ArrayBuilder.make[Triple]
+      val handler = new AnyStatementHandler[Node]:
+        override def handleTriple(subject: Node, predicate: Node, `object`: Node): Unit =
+          builder += Triple.create(subject, predicate, `object`)
+
+        override def handleQuad(subject: Node, predicate: Node, `object`: Node, graph: Node): Unit =
+          handleTriple(subject, predicate, `object`)
+
+      val decoder = JenaConverterFactory
+        .getInstance()
+        .anyStatementDecoder(handler, JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+      val is = getClass.getResourceAsStream("/assist-iot-weather_100kt.jelly.gz")
+      val gzis = new java.util.zip.GZIPInputStream(is)
+      Iterator
+        .continually(RdfStreamFrame.parseDelimitedFrom(gzis))
+        .takeWhile(_ != null)
+        .foreach(_.getRows.forEach(decoder.ingestRow))
+
+      triples = builder.result()
+      require(
+        triples.length == encoderTriples,
+        s"Expected $encoderTriples triples, got ${triples.length}. Throughput is reported per " +
+          "triple, so a dataset of a different size would be misreported.",
+      )
+
+  /** Frame size used by the Jena stream writer by default. */
+  private inline val frameSize = 256
+
+class EncoderBench extends CommonParams:
+  import EncoderBench.*
+
+  @Benchmark
+  @OperationsPerInvocation(encoderTriples)
+  def encodeTriples(blackhole: Blackhole, input: BenchInput): Unit =
+    // Mirrors JellyStreamWriter: a reusable buffer and an arena allocator, flushed every frame.
+    val buffer = RowBuffer.newReusableForEncoder(frameSize + 8)
+    val allocator = EncoderAllocator.newArenaAllocator(frameSize + 8)
+    val encoder = JenaConverterFactory
+      .getInstance()
+      .encoder(ProtoEncoder.Params.of(input.options, false, buffer, allocator))
+    val triples = input.triples
+    var i = 0
+    while i < triples.length do
+      val t = triples(i)
+      encoder.handleTriple(t.getSubject, t.getPredicate, t.getObject)
+      if buffer.size >= frameSize then
+        blackhole.consume(buffer.size)
+        buffer.clear()
+        allocator.releaseAll()
+      i += 1
+    blackhole.consume(buffer.size)

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderDigest.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/EncoderDigest.scala
@@ -1,0 +1,70 @@
+package eu.neverblink.jelly.jmh
+
+import eu.neverblink.jelly.convert.jena.JenaConverterFactory
+import eu.neverblink.jelly.core.{JellyOptions, ProtoEncoder}
+import eu.neverblink.jelly.core.RdfHandler.AnyStatementHandler
+import eu.neverblink.jelly.core.memory.RowBuffer
+import eu.neverblink.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamOptions}
+import org.apache.jena.graph.{Node, Triple}
+
+import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
+import scala.collection.mutable
+
+/** Prints a digest of the encoder's output, so that a change to the encoder can be checked for
+  * being byte-for-byte output-preserving.
+  *
+  * Run with: `sbt "jmh/runMain eu.neverblink.jelly.jmh.EncoderDigest"`
+  */
+object EncoderDigest:
+
+  private def load(): Array[Triple] =
+    val builder = mutable.ArrayBuilder.make[Triple]
+    val handler = new AnyStatementHandler[Node]:
+      override def handleTriple(subject: Node, predicate: Node, `object`: Node): Unit =
+        builder += Triple.create(subject, predicate, `object`)
+      override def handleQuad(subject: Node, predicate: Node, `object`: Node, graph: Node): Unit =
+        handleTriple(subject, predicate, `object`)
+    val decoder = JenaConverterFactory
+      .getInstance()
+      .anyStatementDecoder(handler, JellyOptions.DEFAULT_SUPPORTED_OPTIONS)
+    val gzis =
+      new java.util.zip.GZIPInputStream(
+        getClass.getResourceAsStream("/assist-iot-weather_100kt.jelly.gz"),
+      )
+    Iterator
+      .continually(RdfStreamFrame.parseDelimitedFrom(gzis))
+      .takeWhile(_ != null)
+      .foreach(_.getRows.forEach(decoder.ingestRow))
+    builder.result()
+
+  private def encode(triples: Array[Triple], options: RdfStreamOptions): (String, Int) =
+    val out = ByteArrayOutputStream()
+    val buffer = RowBuffer.newLazyImmutable(264)
+    val encoder = JenaConverterFactory
+      .getInstance()
+      .encoder(ProtoEncoder.Params.of(options, false, buffer))
+    def flush(): Unit =
+      if !buffer.isEmpty then
+        val frame = RdfStreamFrame.newInstance()
+        frame.setRows(buffer)
+        frame.writeDelimitedTo(out)
+        buffer.clear()
+    for t <- triples do
+      encoder.handleTriple(t.getSubject, t.getPredicate, t.getObject)
+      if buffer.size >= 256 then flush()
+    flush()
+    val bytes = out.toByteArray
+    val digest = MessageDigest.getInstance("SHA-256").digest(bytes)
+    (digest.map("%02x".format(_)).mkString.take(16), bytes.length)
+
+  def main(args: Array[String]): Unit =
+    val triples = load()
+    val presets = Seq(
+      "big" -> JellyOptions.BIG_STRICT,
+      "big-full" -> JellyOptions.BIG_STRICT.clone().setMaxNameTableSize(512),
+      "small" -> JellyOptions.SMALL_STRICT,
+    )
+    for (name, options) <- presets do
+      val (digest, size) = encode(triples, options)
+      System.err.printf("%-10s sha256=%s bytes=%,d%n", name, digest, size)

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/NodeCacheBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/NodeCacheBench.scala
@@ -113,9 +113,11 @@ object NodeCacheBench:
     val fifo = new LinkedHashMapNodeCache[AnyRef, DependentNode](cacheSize)
     val lru = new LinkedHashMapLruNodeCache[AnyRef, DependentNode](cacheSize)
     val array = new ArrayNodeCache[AnyRef, DependentNode](cacheSize)
+    val array2Way = new ArrayNodeCache[AnyRef, DependentNode](cacheSize)
     var fifoHits = 0
     var lruHits = 0
     var arrayHits = 0
+    var array2WayHits = 0
     for key <- keys do
       var missed = false
       fifo.getOrCompute(key, _ => { missed = true; new DependentNode })
@@ -126,10 +128,14 @@ object NodeCacheBench:
       missed = false
       array.getOrCompute(key, _ => { missed = true; new DependentNode })
       if !missed then arrayHits += 1
+      missed = false
+      array2Way.getOrCompute2Way(key, _ => { missed = true; new DependentNode })
+      if !missed then array2WayHits += 1
     Seq(
       "FIFO" -> fifoHits.toDouble / keys.length,
       "LRU" -> lruHits.toDouble / keys.length,
       "direct-mapped" -> arrayHits.toDouble / keys.length,
+      "2-way" -> array2WayHits.toDouble / keys.length,
     )
 
   private def report(rates: Seq[(String, Double)]): String =
@@ -160,6 +166,19 @@ class NodeCacheBench extends CommonParams:
     var i = 0
     while i < keys.length do
       blackhole.consume(cache.getOrCompute(keys(i), make))
+      i += 1
+
+  /** Same table size as `iriArray`, read 2-way set associative. */
+  @Benchmark
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  def iriArray2Way(blackhole: Blackhole, input: BenchInput): Unit =
+    val cache = new ArrayNodeCache[String, DependentNode](input.iriCacheSize)
+    val make: java.util.function.Function[String, DependentNode] = _ => new DependentNode
+    val keys = input.iriKeys
+    var i = 0
+    while i < keys.length do
+      blackhole.consume(cache.getOrCompute2Way(keys(i), make))
       i += 1
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlDecodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlDecodeBench.scala
@@ -3,6 +3,7 @@ package eu.neverblink.jelly.jmh.sparql
 import eu.neverblink.jelly.convert.jena.sparql.{JenaSparqlConverterFactory, RowSetReaderJelly}
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlResultsFrame
 import eu.neverblink.jelly.core.sparql.{JellySparqlOptions, SparqlResultsHandler}
+import eu.neverblink.jelly.jmh.CommonParams
 import org.apache.jena.graph.Node
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
@@ -62,7 +63,7 @@ object SparqlDecodeBench:
         .takeWhile(_ != null)
         .toArray
 
-class SparqlDecodeBench:
+class SparqlDecodeBench extends CommonParams:
   import SparqlDecodeBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlDecodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlDecodeBench.scala
@@ -4,6 +4,7 @@ import eu.neverblink.jelly.convert.jena.sparql.{JenaSparqlConverterFactory, RowS
 import eu.neverblink.jelly.core.proto.v1.sparql.SparqlResultsFrame
 import eu.neverblink.jelly.core.sparql.{JellySparqlOptions, SparqlResultsHandler}
 import org.apache.jena.graph.Node
+import eu.neverblink.jelly.jmh.CommonParams
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 
@@ -62,7 +63,7 @@ object SparqlDecodeBench:
         .takeWhile(_ != null)
         .toArray
 
-class SparqlDecodeBench:
+class SparqlDecodeBench extends CommonParams:
   import SparqlDecodeBench.*
 
   @Benchmark

--- a/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlEncodeBench.scala
+++ b/jmh/src/main/scala/eu/neverblink/jelly/jmh/sparql/SparqlEncodeBench.scala
@@ -2,6 +2,7 @@ package eu.neverblink.jelly.jmh.sparql
 
 import eu.neverblink.jelly.convert.jena.sparql.JenaSparqlConverterFactory
 import eu.neverblink.jelly.core.sparql.SparqlEncoder
+import eu.neverblink.jelly.jmh.CommonParams
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
 
@@ -47,7 +48,7 @@ object SparqlEncodeBench:
     def setup(): Unit =
       data = SparqlBenchData.load(preset)
 
-class SparqlEncodeBench:
+class SparqlEncodeBench extends CommonParams:
   import SparqlEncodeBench.*
 
   /** The encoder alone: builds the frames, but does not serialize them. */


### PR DESCRIPTION
In RDF encode there is very little throughput difference, because a lot of this only matters if you actually serialize the values. But still, I'd look at allocation rates...

Anyway, this mainly optimizes the cases where Jelly usually is slower, such as literal-heavy or high-entropy data.

Measured on DGX Spark:

Before:

```
Benchmark                                                 (dataset)  (format)   Mode  Cnt         Score        Error   Units
SparqlThroughputBench.serialize                             weather     jelly  thrpt   15   9216049.257 ± 120076.318   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm          weather     jelly  thrpt   15        51.486 ±      0.001    B/op
SparqlThroughputBench.serialize                     realistic-mixed     jelly  thrpt   15   2845959.868 ±  47087.582   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm  realistic-mixed     jelly  thrpt   15       304.027 ±      0.001    B/op
SparqlThroughputBench.serialize                              wide-5     jelly  thrpt   15   3746575.120 ±  55226.768   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm           wide-5     jelly  thrpt   15       273.810 ±      0.001    B/op
SparqlThroughputBench.serialize                            lit-lang     jelly  thrpt   15  15779910.641 ± 219342.491   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm         lit-lang     jelly  thrpt   15        59.440 ±      0.001    B/op

Benchmark                                      (preset)   Mode  Cnt         Score        Error   Units
EncoderBench.encodeTriples                          big  thrpt   15  21154063.047 ± 407094.244   ops/s
EncoderBench.encodeTriples:gc.alloc.rate.norm       big  thrpt   15        41.142 ±      0.001    B/op
EncoderBench.encodeTriples                        small  thrpt   15  16077949.622 ± 102914.799   ops/s
EncoderBench.encodeTriples:gc.alloc.rate.norm     small  thrpt   15        95.291 ±      0.001    B/op
```

After:

```
Benchmark                                                 (dataset)  (format)   Mode  Cnt         Score        Error   Units
SparqlThroughputBench.serialize                             weather     jelly  thrpt   15   9709256.606 ± 343476.383   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm          weather     jelly  thrpt   15        31.916 ±      0.001    B/op
SparqlThroughputBench.serialize                     realistic-mixed     jelly  thrpt   15   4224621.947 ±  81914.387   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm  realistic-mixed     jelly  thrpt   15        87.212 ±      0.001    B/op
SparqlThroughputBench.serialize                              wide-5     jelly  thrpt   15   5343053.434 ±  84990.543   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm           wide-5     jelly  thrpt   15         7.261 ±      0.001    B/op
SparqlThroughputBench.serialize                            lit-lang     jelly  thrpt   15  19929862.393 ± 160738.030   ops/s
SparqlThroughputBench.serialize:gc.alloc.rate.norm         lit-lang     jelly  thrpt   15        46.408 ±      0.001    B/op

Benchmark                                      (preset)   Mode  Cnt         Score        Error   Units
EncoderBench.encodeTriples                          big  thrpt   15  21416331.823 ± 381353.207   ops/s
EncoderBench.encodeTriples:gc.alloc.rate.norm       big  thrpt   15        30.194 ±      0.001    B/op
EncoderBench.encodeTriples                        small  thrpt   15  16310906.144 ± 395299.416   ops/s
EncoderBench.encodeTriples:gc.alloc.rate.norm     small  thrpt   15        47.467 ±      0.001    B/op
```